### PR TITLE
add `@guardian/tsconfig`

### DIFF
--- a/.changeset/chilly-waves-search.md
+++ b/.changeset/chilly-waves-search.md
@@ -1,0 +1,5 @@
+---
+'@guardian/tsconfig': minor
+---
+
+Create `@guardian/tsconfig`

--- a/apps/test-app/index.ts
+++ b/apps/test-app/index.ts
@@ -1,3 +1,1 @@
-import { publicLib } from '@guardian/public-lib';
-
-console.log(publicLib());
+console.log('Hello world!');

--- a/libs/tsconfig/README.md
+++ b/libs/tsconfig/README.md
@@ -1,0 +1,24 @@
+# `@guardian/tsconfig`
+
+> TSConfig base for Guardian TypeScript projects.
+
+## Installation
+
+```shell
+yarn add -D @guardian/tsconfig
+```
+
+or
+
+```shell
+npm install --save-dev @guardian/tsconfig
+```
+
+## Usage
+
+```jsonc
+// tsconfig.json
+{
+	"extends": "@guardian/tsconfig/tsconfig.json"
+}
+```

--- a/libs/tsconfig/package.json
+++ b/libs/tsconfig/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "@guardian/tsconfig",
+	"version": "0.1.0",
+	"main": "./tsconfig.json"
+}

--- a/libs/tsconfig/package.json
+++ b/libs/tsconfig/package.json
@@ -1,5 +1,17 @@
 {
 	"name": "@guardian/tsconfig",
-	"version": "0.1.0",
-	"main": "./tsconfig.json"
+	"version": "0.0.0",
+	"description": "TSConfig base for Guardian TypeScript projects",
+	"homepage": "https://github.com/guardian/csnx/libs/tsconfig#readme",
+	"bugs": {
+		"url": "https://github.com/guardian/csnx/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/guardian/csnx.git"
+	},
+	"license": "MIT",
+	"files": [
+		"tsconfig.json"
+	]
 }

--- a/libs/tsconfig/project.json
+++ b/libs/tsconfig/project.json
@@ -1,0 +1,3 @@
+{
+	"$schema": "../../node_modules/nx/schemas/project-schema.json"
+}

--- a/libs/tsconfig/tsconfig.json
+++ b/libs/tsconfig/tsconfig.json
@@ -1,0 +1,15 @@
+// Guardian base config intended to improve code quality
+// It should not have any opinions about project shape
+{
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "node",
+		"noImplicitReturns": true,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedLocals": true,
+		"strict": true,
+		"target": "esnext"
+	}
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,28 +1,18 @@
 {
+	"extends": "./libs/tsconfig/tsconfig.json",
 	"compilerOptions": {
-		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"declaration": true,
 		"declarationMap": true,
-		"emitDecoratorMetadata": true,
-		"esModuleInterop": true,
-		"experimentalDecorators": true,
 		"forceConsistentCasingInFileNames": true,
 		"importHelpers": true,
 		"lib": ["es2017", "dom"],
-		"module": "esnext",
-		"moduleResolution": "node",
-		"noImplicitAny": true,
-		"noImplicitReturns": true,
-		"noImplicitThis": true,
-		"noUnusedLocals": true,
-		"paths": {},
+		"paths": {
+			"@guardian/tsconfig": ["libs/tsconfig"]
+		},
 		"resolveJsonModule": true,
 		"rootDir": ".",
-		"sourceMap": true,
-		"strict": true,
-		"strictNullChecks": true,
-		"target": "esnext"
+		"sourceMap": true
 	},
 	"exclude": ["node_modules", "tmp"]
 }

--- a/workspace.json
+++ b/workspace.json
@@ -1,5 +1,7 @@
 {
 	"$schema": "./node_modules/nx/schemas/workspace-schema.json",
 	"version": 2,
-	"projects": {}
+	"projects": {
+		"tsconfig": "libs/tsconfig"
+	}
 }


### PR DESCRIPTION
Add `@guardian/tsconfig`.

It has no build step so currently changesets/nx does not need any special config (due to changesets not expecting Nx's default behaviour of building everything to a root-level `dist`) 