### PR TITLE
Dont warn about missing peerdeps for these packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,14 @@
 		"typescript": "^4.7.4",
 		"update-section": "^0.3.3"
 	},
-	"packageManager": "pnpm@7.9.0"
+	"packageManager": "pnpm@7.9.0",
+	"pnpm": {
+		"peerDependencyRules": {
+			"ignoreMissing": [
+				"typescript",
+				"eslint",
+				"prettier"
+			]
+		}
+	}
 }


### PR DESCRIPTION
they’re installed in the root, no one else needs to worry

