### PR TITLE
fix(eslint-config): Ignore external modules with import/no-cycle

### DIFF
--- a/.changeset/brave-countries-mate.md
+++ b/.changeset/brave-countries-mate.md
@@ -1,0 +1,5 @@
+---
+'@guardian/eslint-config': patch
+---
+
+Configures `import/no-cycle` to ignore external modules, decreasing the time it takes to lint a project.

--- a/libs/@guardian/eslint-config/.eslintrc.js
+++ b/libs/@guardian/eslint-config/.eslintrc.js
@@ -75,6 +75,6 @@ module.exports = {
 		],
 
 		// prevent circular dependencies
-		'import/no-cycle': 2,
+		'import/no-cycle': ['error', { ignoreExternal: true }],
 	},
 };


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Configures the `import/no-cycle` rule to ignore external modules to decrease the duration of the lint check.

In `@guardian/cdk` we're seeing `import/no-cycle` take a significant amount of time:

```console
➜ TIMING=1 npm run lint

> @guardian/cdk@47.1.0 lint
> eslint src --ext .ts

Rule                                    | Time (ms) | Relative
:---------------------------------------|----------:|--------:
import/no-cycle                         | 24660.951 |    81.0%
import/namespace                        |  3185.143 |    10.5%
prettier/prettier                       |  1226.525 |     4.0%
@typescript-eslint/no-misused-promises  |   283.835 |     0.9%
@typescript-eslint/no-floating-promises |   228.278 |     0.7%
@typescript-eslint/no-unsafe-assignment |   134.758 |     0.4%
@typescript-eslint/no-unsafe-argument   |   114.937 |     0.4%
@typescript-eslint/naming-convention    |   102.000 |     0.3%
import/no-unresolved                    |    76.968 |     0.3%
import/order                            |    69.877 |     0.2%
```

With `import/no-cycle` configured to ignore external modules, this is dramatically changed:

```console
➜ TIMING=1 npm run lint

> @guardian/cdk@47.1.0 lint
> eslint src --ext .ts

Rule                                    | Time (ms) | Relative
:---------------------------------------|----------:|--------:
import/namespace                        |  8576.203 |    54.0%
import/no-cycle                         |  4863.588 |    30.6%
prettier/prettier                       |  1130.410 |     7.1%
@typescript-eslint/no-misused-promises  |   278.362 |     1.8%
@typescript-eslint/no-floating-promises |   230.481 |     1.5%
@typescript-eslint/no-unsafe-assignment |   127.062 |     0.8%
@typescript-eslint/no-unsafe-argument   |   115.256 |     0.7%
@typescript-eslint/naming-convention    |    99.910 |     0.6%
import/order                            |    60.633 |     0.4%
import/no-unresolved                    |    45.641 |     0.3%
```

See: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md#ignoreexternal

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Improved eslint performance.