### PR TITLE
Remove references to the old `say-hello` app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,6 @@
 # standardise on a shell
 export SHELL := /usr/bin/env bash
 
-###################################### DEV #####################################
-
-# start the `say-hello` test app
-.PHONY: say-hello
-say-hello: env
-	$(call log,"Running tests")
-	@corepack pnpm nx run say-hello:serve
-
 ################################# CODE QUALITY #################################
 
 # runs the tests for all projects

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Tasks are defined in the [`Makefile`](./Makefile).
 - `make clean` _removes all build artifacts_
 - `make fix` _attemps to fix lint errors across all projects_
 - `make lint` _checks all projects for lint errors_
-- `make say-hello` _start the `say-hello` test app_
 - `make test` _runs the tests for all projects_
 - `make validate` _makes sure absolutely everything is working_
 


### PR DESCRIPTION
## What does this change?
This updates the `makefile` and README to remove any references to `say-hello`, which was removed earlier in [this commit](https://github.com/guardian/csnx/commit/e30107a1ced7b53d2c6c0194e7897bbf69430a68)

## Why?
<img width="406" alt="Screenshot 2022-09-01 at 15 23 16" src="https://user-images.githubusercontent.com/1336821/187944113-e398de62-7df1-4c11-9995-888efb578363.png">
