### PR TITLE
Add a section for NVM when helping people troubleshoot Husky issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,12 @@ Or for [`asdf`](https://asdf-vm.com/):
 . /opt/homebrew/opt/asdf/asdf.sh
 ```
 
+Or for [`nvm`](https://github.com/nvm-sh/nvm):
+
+```sh
+# ~/.huskyrc
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && nvm use
+```
+
 See https://typicode.github.io/husky/#/?id=command-not-found for more info.


### PR DESCRIPTION
## What does this change?
This PR updates the README to include instructions for NVM when troubleshooting [Husky issues](https://typicode.github.io/husky/#/?id=command-not-found)