### PR TITLE
Use rollup's output to set the entry fields in `package.json`

### DIFF
--- a/libs/@guardian/libs/README.md
+++ b/libs/@guardian/libs/README.md
@@ -97,7 +97,7 @@ import { loadScript, storage, ...etc } from '@guardian/libs';
 
 ### TypeScript
 
-If you are using this library with TypeScript, make sure you are using at least TypeScript v<!-- TS_VERSION -->^4.7.4<!-- /TS_VERSION -->.
+If you are using this library with TypeScript, make sure you are using at least TypeScript v<!-- TS_VERSION -->4.8.2<!-- /TS_VERSION -->.
 
 ### Bundling
 

--- a/libs/@guardian/libs/project.json
+++ b/libs/@guardian/libs/project.json
@@ -7,7 +7,7 @@
 			"executor": "@csnx/npm-package:build",
 			"outputs": ["{options.outputPath}"],
 			"options": {
-				"main": "libs/@guardian/libs/src/index.ts",
+				"entry": "libs/@guardian/libs/src/index.ts",
 				"tsConfig": "libs/@guardian/libs/tsconfig.json",
 				"packageJson": "libs/@guardian/libs/package.json",
 				"outputPath": "dist/libs/@guardian/libs",

--- a/tools/nx-plugins/npm-package/build/get-declared-deps.ts
+++ b/tools/nx-plugins/npm-package/build/get-declared-deps.ts
@@ -1,6 +1,6 @@
 import { isObject } from '@guardian/libs';
 
-export const getDeps = async (pkgPath: string) => {
+export const getDeclaredDeps = async (pkgPath: string) => {
 	/* eslint-disable @typescript-eslint/no-unsafe-assignment --
 		json is an any
 	*/

--- a/tools/nx-plugins/npm-package/build/schema.d.ts
+++ b/tools/nx-plugins/npm-package/build/schema.d.ts
@@ -1,5 +1,5 @@
 export interface BuildExecutorOptions {
-	main?: string;
+	entry?: string;
 	outputPath: string;
 	tsConfig?: string;
 	packageJson: string;

--- a/tools/nx-plugins/npm-package/build/schema.json
+++ b/tools/nx-plugins/npm-package/build/schema.json
@@ -3,7 +3,7 @@
 	"type": "object",
 	"cli": "nx",
 	"properties": {
-		"main": {
+		"entry": {
 			"type": "string",
 			"description": "The name of the main entry-point file."
 		},


### PR DESCRIPTION
## What are you changing?

- use rollup's output info the set the paths for the `main`, `module` and `exports` fields

## Why?

- the `main`, `module` and `exports` field paths were hardcoded to the module format path, but this path is not always correct (e.g. if the code in `src` imports from somewhere outside of there)

### before 

```json
  "exports": "./esm/index.js",
  "main": "cjs/index.js",
  "module": "esm/index.js",
```

### after
```json
  "exports": "./esm/index.js",
  "main": "cjs/index.js",
  "module": "esm/index.js",
```
or
```json
  "exports": "./esm/src/index.js",
  "main": "cjs/src/index.js",
  "module": "esm/src/index.js",
```
or whatever rollup tells us it's built