### PR TITLE
Add types (correctly) to `@guardian/prettier`

### DIFF
--- a/.changeset/brown-wombats-juggle.md
+++ b/.changeset/brown-wombats-juggle.md
@@ -1,0 +1,5 @@
+---
+'@guardian/prettier': patch
+---
+
+Fix types export

--- a/libs/@guardian/prettier/index.d.ts
+++ b/libs/@guardian/prettier/index.d.ts
@@ -1,0 +1,3 @@
+import { Options } from 'prettier';
+declare const prettierConfig: Options;
+export default prettierConfig;

--- a/libs/@guardian/prettier/index.js
+++ b/libs/@guardian/prettier/index.js
@@ -1,6 +1,3 @@
-/**
- * @type {import('prettier').Options}
- */
 module.exports = {
 	arrowParens: 'always',
 	bracketSpacing: true,

--- a/libs/@guardian/prettier/project.json
+++ b/libs/@guardian/prettier/project.json
@@ -11,6 +11,7 @@
 				"outputPath": "dist/libs/@guardian/prettier",
 				"assets": [
 					"libs/@guardian/prettier/index.js",
+					"libs/@guardian/prettier/index.d.ts",
 					"libs/@guardian/prettier/*.md"
 				]
 			}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,8 @@
 			"@csnx/eslint": ["tools/nx-plugins/eslint"],
 			"@csnx/hello-world": ["libs/@csnx/hello-world/src/index.ts"],
 			"@csnx/npm-package": ["tools/nx-plugins/npm-package"],
-			"@guardian/libs": ["libs/@guardian/libs/src/index.ts"]
+			"@guardian/libs": ["libs/@guardian/libs/src/index.ts"],
+			"@guardian/prettier": ["libs/@guardian/prettier/index.d.ts"]
 		},
 		"rootDir": ".",
 		"sourceMap": true


### PR DESCRIPTION
_depends on #98_

## What are you changing?

- add correct types to `@guardian/prettier`

## Why?

- so it can be successfully imported and used programmatically (e.g. in #101)
