### PR TITLE
create global csnx window type

### DIFF
--- a/@types/window.d.ts
+++ b/@types/window.d.ts
@@ -1,5 +1,5 @@
-import type { TeamSubscription } from '../logger/@types/logger';
-import type { Switches } from '../switches/@types/Switches';
+import type { TeamSubscription } from '../libs/@guardian/libs/src/logger/@types/logger';
+import type { Switches } from '../libs/@guardian/libs/src/switches/@types/Switches';
 
 declare global {
 	interface Window {

--- a/libs/@guardian/libs/tsconfig.json
+++ b/libs/@guardian/libs/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../../tsconfig.base.json",
 	"files": [],
-	"include": ["."],
+	"include": [".", "../../../@types/window.d.ts"],
 	"references": [
 		{
 			"path": "./tsconfig.spec.json"

--- a/libs/@guardian/source-react-components-development-kitchen/tsconfig.json
+++ b/libs/@guardian/source-react-components-development-kitchen/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../../tsconfig.base.json",
 	"files": [],
-	"include": [".", "../libs/src/@types"],
+	"include": [".", "../../../@types/window.d.ts"],
 	"references": [
 		{
 			"path": "./tsconfig.spec.json"


### PR DESCRIPTION
## What are you changing?

- moving the window ambient type declaration from libs to the project root

## Why?

- makes it available for all projects to include and define props on
