### PR TITLE
reverse the logic of the npm-package:build TS check

### DIFF
--- a/.changeset/quiet-eels-fix.md
+++ b/.changeset/quiet-eels-fix.md
@@ -1,0 +1,10 @@
+---
+'@guardian/browserslist-config': patch
+'@guardian/eslint-config': patch
+'@guardian/eslint-config-typescript': patch
+'@guardian/libs': patch
+'@guardian/prettier': patch
+'@guardian/tsconfig': patch
+---
+
+CommonJS exports in NPM packages target `ES2018`

--- a/tools/nx-plugins/npm-package/build/get-compiler-options.ts
+++ b/tools/nx-plugins/npm-package/build/get-compiler-options.ts
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/unbound-method -- this is what the TS methods do */
+import path from 'node:path';
+import type { ExecutorContext } from '@nrwl/devkit';
+import {
+	findConfigFile,
+	parseJsonConfigFileContent,
+	readConfigFile,
+	sys,
+} from 'typescript';
+import type { BuildExecutorOptions } from './schema';
+
+export const getCompilerOptions = (
+	options: BuildExecutorOptions,
+	context: ExecutorContext,
+) => {
+	const tsconfigPath = findConfigFile(
+		context.root,
+		sys.fileExists,
+		options.tsConfig,
+	);
+
+	if (tsconfigPath) {
+		// Read tsconfig.json file
+		const tsconfigFile = readConfigFile(tsconfigPath, sys.readFile);
+
+		// Resolve extends
+		const parsedTsconfig = parseJsonConfigFileContent(
+			tsconfigFile.config,
+			sys,
+			path.dirname(tsconfigPath),
+		);
+
+		return parsedTsconfig.options;
+	}
+
+	return {};
+};

--- a/tools/nx-plugins/npm-package/build/index.ts
+++ b/tools/nx-plugins/npm-package/build/index.ts
@@ -78,10 +78,10 @@ export default async function buildExecutor(
 
 		let entries: Entries | undefined;
 
-		if (options.entry) {
-			if (!options.tsConfig) {
+		if (options.tsConfig) {
+			if (!options.entry) {
 				logger.error(
-					"You must include a 'tsConfig' option when using the 'entry' option",
+					"You must include a 'entry' option when using the 'tsConfig' option",
 				);
 				return { success: false };
 			}


### PR DESCRIPTION
## What are you changing?

- target ES2018 in cjs exports in NPM packages

## Why?

- fixes #140 