### PR TITLE
Use AWS Amplify to host storybooks

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,4 +1,13 @@
-name: Deploy Storybook to GitHub Pages
+# This workflow deploys the root-level to GitHub Pages.
+#
+# The root-level storybook composes the individual project storybooks, which
+# are built and deployed by AWS Amplify projects on commits to main branch.
+#
+# To add another project storybook, you need to add a new AWS Amplify project.
+# See the existing projects (prefixed with "csnx/storybooks-") for examples of
+# how to do this.
+
+name: Deploy Storybooks
 on:
   push:
     branches:
@@ -15,8 +24,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm nx run csnx:build-storybook
-      - name: deploy
+
+      - name: Build root storybook
+        run: pnpm nx run csnx:build-storybook
+
+      - name: Deploy root storybook to github pages
         run: pnpm storybook-to-ghpages --ci --existing-output-dir dist/storybook/apps/csnx
         env:
           GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,11 +1,12 @@
 # This workflow deploys the root-level to GitHub Pages.
 #
-# The root-level storybook composes the individual project storybooks, which
-# are built and deployed by AWS Amplify projects on commits to main branch.
+# The root-level storybook composes the individual project storybooks, which are
+# built and deployed by AWS Amplify projects on commits to main branch.
 #
 # To add another project storybook, you need to add a new AWS Amplify project.
-# See the existing projects (prefixed with "csnx/storybooks-") for examples of
-# how to do this.
+# See the existing projects (prefixed with "csnx/storybooks-") at
+# https://eu-west-1.console.aws.amazon.com/amplify/home?region=eu-west-1 for
+# examples of how to do this.
 
 name: Deploy Storybooks
 on:

--- a/apps/csnx/.storybook/main.js
+++ b/apps/csnx/.storybook/main.js
@@ -37,15 +37,15 @@ module.exports = {
 		return {
 			'source-foundations': {
 				title: 'source-foundations',
-				url: 'https://main--635a6aa8070dfdbfdac36f65.chromatic.com',
+				url: 'https://main.diy95zty49kdd.amplifyapp.com',
 			},
 			'source-react-components': {
 				title: 'source-react-components',
-				url: 'https://main--635a6fffacd30d393597c1ff.chromatic.com',
+				url: 'https://main.d2zt1j33ncruvj.amplifyapp.com',
 			},
 			'source-react-components-development-kitchen': {
 				title: 'source-react-components-development-kitchen',
-				url: 'https://main--635a7057acd30d393597c208.chromatic.com',
+				url: 'https://main.d25xfnd702qjsd.amplifyapp.com',
 			},
 		};
 	},


### PR DESCRIPTION
## What are you changing?

- hosts project storybooks on AWS amplify

## Why?

- chromatic CDN is unusably slow
- we want people to be able to use our storybooks

Co-authored-by: Joe Cowton <joe.cowton@guardian.co.uk>
