### PR TITLE
Setup Jest matcher for source-foundations

### DIFF
--- a/libs/@guardian/source-foundations/jest.config.ts
+++ b/libs/@guardian/source-foundations/jest.config.ts
@@ -13,4 +13,5 @@ export default {
 	},
 	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
 	coverageDirectory: '../../../coverage/libs/@guardian/source-foundations',
+	setupFilesAfterEnv: ['./lib/jest-matchers/toBeValidCSS.ts'],
 };

--- a/libs/@guardian/source-foundations/lib/jest-matchers/index.d.ts
+++ b/libs/@guardian/source-foundations/lib/jest-matchers/index.d.ts
@@ -1,0 +1,12 @@
+declare namespace jest {
+	interface Matchers<R> {
+		toBeValidCSS(options?: ToBeValidCSSOptions): R;
+	}
+}
+
+type ToBeValidCSSOptions = {
+	/**
+	 * Set this to true if the CSS is a fragment (e.g. not wrapped in a selector and valid on its own)
+	 */
+	isFragment?: boolean;
+};

--- a/libs/@guardian/source-foundations/lib/jest-matchers/index.ts
+++ b/libs/@guardian/source-foundations/lib/jest-matchers/index.ts
@@ -1,4 +1,0 @@
-// Registers our custom jest matchers before running tests.
-
-// Register the toBeValidCSS matcher
-require('./toBeValidCSS');

--- a/libs/@guardian/source-foundations/lib/jest-matchers/toBeValidCSS.ts
+++ b/libs/@guardian/source-foundations/lib/jest-matchers/toBeValidCSS.ts
@@ -1,22 +1,6 @@
 import type { Warning } from 'lightningcss';
 import { transform } from 'lightningcss';
 
-type ToBeValidCSSOptions = {
-	/**
-	 * Set this to true if the CSS is a fragment (e.g. not wrapped in a selector and valid on its own)
-	 */
-	isFragment?: boolean;
-};
-
-declare global {
-	// eslint-disable-next-line @typescript-eslint/no-namespace -- we extend the jest matchers interface like this
-	namespace jest {
-		interface Matchers<R> {
-			toBeValidCSS(options?: ToBeValidCSSOptions): R;
-		}
-	}
-}
-
 expect.extend({
 	/**
 	 * Uses the lightningcss library to validate given CSS

--- a/libs/@guardian/source-foundations/package.json
+++ b/libs/@guardian/source-foundations/package.json
@@ -5,5 +5,8 @@
 	"sideEffects": false,
 	"dependencies": {
 		"mini-svg-data-uri": "1.4.4"
+	},
+	"devDependencies": {
+		"lightningcss": "^1.16.1"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,9 +235,12 @@ importers:
 
   libs/@guardian/source-foundations:
     specifiers:
+      lightningcss: ^1.16.1
       mini-svg-data-uri: 1.4.4
     dependencies:
       mini-svg-data-uri: 1.4.4
+    devDependencies:
+      lightningcss: 1.16.1
 
   libs/@guardian/source-react-components:
     specifiers:
@@ -4600,7 +4603,7 @@ packages:
       node-machine-id: 1.1.12
       strip-json-comments: 3.1.1
       tar: 6.1.11
-      yargs-parser: 21.0.1
+      yargs-parser: 21.1.1
     transitivePeerDependencies:
       - debug
     dev: true
@@ -9873,6 +9876,12 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
+  /detect-libc/1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+    dev: true
+
   /detect-newline/3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
@@ -13665,6 +13674,94 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  /lightningcss-darwin-arm64/1.16.1:
+    resolution: {integrity: sha512-/J898YSAiGVqdybHdIF3Ao0Hbh2vyVVj5YNm3NznVzTSvkOi3qQCAtO97sfmNz+bSRHXga7ZPLm+89PpOM5gAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-darwin-x64/1.16.1:
+    resolution: {integrity: sha512-vyKCNPRNRqke+5i078V+N0GLfMVLEaNcqIcv28hA/vUNRGk/90EDkDB9EndGay0MoPIrC2y0qE3Y74b/OyedqQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-linux-arm-gnueabihf/1.16.1:
+    resolution: {integrity: sha512-0AJC52l40VbrzkMJz6qRvlqVVGykkR2MgRS4bLjVC2ab0H0I/n4p6uPZXGvNIt5gw1PedeND/hq+BghNdgfuPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-linux-arm64-gnu/1.16.1:
+    resolution: {integrity: sha512-NqxYXsRvI3/Fb9AQLXKrYsU0Q61LqKz5It+Es9gidsfcw1lamny4lmlUgO3quisivkaLCxEkogaizcU6QeZeWQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-linux-arm64-musl/1.16.1:
+    resolution: {integrity: sha512-VUPQ4dmB9yDQxpJF8/imtwNcbIPzlL6ArLHSUInOGxipDk1lOAklhUjbKUvlL3HVlDwD3WHCxggAY01WpFcjiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-linux-x64-gnu/1.16.1:
+    resolution: {integrity: sha512-A40Jjnbellnvh4YF+kt047GLnUU59iLN2LFRCyWQG+QqQZeXOCzXfTQ6EJB4yvHB1mQvWOVdAzVrtEmRw3Vh8g==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-linux-x64-musl/1.16.1:
+    resolution: {integrity: sha512-VZf76GxW+8mk238tpw0u9R66gBi/m0YB0TvD54oeGiOqvTZ/mabkBkbsuXTSWcKYj8DSrLW+A42qu+6PLRsIgA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss-win32-x64-msvc/1.16.1:
+    resolution: {integrity: sha512-Djy+UzlTtJMayVJU3eFuUW5Gdo+zVTNPJhlYw25tNC9HAoMCkIdSDDrGsWEdEyibEV7xwB8ySTmLuxilfhBtgg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /lightningcss/1.16.1:
+    resolution: {integrity: sha512-zU8OTaps3VAodmI2MopfqqOQQ4A9L/2Eo7xoTH/4fNkecy6ftfiGwbbRMTQqtIqJjRg3f927e+lnyBBPhucY1Q==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      detect-libc: 1.0.3
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.16.1
+      lightningcss-darwin-x64: 1.16.1
+      lightningcss-linux-arm-gnueabihf: 1.16.1
+      lightningcss-linux-arm64-gnu: 1.16.1
+      lightningcss-linux-arm64-musl: 1.16.1
+      lightningcss-linux-x64-gnu: 1.16.1
+      lightningcss-linux-x64-musl: 1.16.1
+      lightningcss-win32-x64-msvc: 1.16.1
+    dev: true
 
   /lilconfig/2.0.5:
     resolution: {integrity: sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==}


### PR DESCRIPTION
## What are you changing?

- Setup the `toBeValidCSS` Jest matcher in the csnx source-foundations Jest config.
- Extended the source foundations Jest `Matchers` interface to include `toBeValidCSS`.
- Ensured that the tests still run and are type checked as expected.