### PR TITLE
Fix eslint parsing "maximum call stack size exceeded" issue in source-foundations

### DIFF
--- a/libs/@guardian/eslint-config-typescript/package.json
+++ b/libs/@guardian/eslint-config-typescript/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"eslint": "8.0.0",
-		"typescript": "4.1.2"
+		"typescript": "4.2.2"
 	},
 	"peerDependencies": {
 		"eslint": "workspace:^",

--- a/libs/@guardian/source-foundations/project.json
+++ b/libs/@guardian/source-foundations/project.json
@@ -14,6 +14,13 @@
 				"assets": ["libs/@guardian/source-foundations/*.md"]
 			}
 		},
+		"lint": {
+			"executor": "@csnx/eslint:check",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": ["libs/@guardian/source-foundations/**/*.ts"]
+			}
+		},
 		"fix": {
 			"executor": "@csnx/eslint:fix",
 			"outputs": ["{options.outputFile}"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,16 +154,16 @@ importers:
       eslint: 8.0.0
       eslint-import-resolver-typescript: 3.5.0
       eslint-plugin-import: 2.26.0
-      typescript: 4.1.2
+      typescript: 4.2.2
     dependencies:
       '@guardian/eslint-config': link:../eslint-config
-      '@typescript-eslint/eslint-plugin': 5.36.1_iq5gmiqet7rqbsxn252aqj4fby
-      '@typescript-eslint/parser': 5.36.1_bj2xhvhw4kzrbf7d45h2myrriy
+      '@typescript-eslint/eslint-plugin': 5.36.1_ai2qwq6ftvvac3e2nax7nm3a5q
+      '@typescript-eslint/parser': 5.36.1_vizttnskhxwupgy3pyipyx545a
       eslint-import-resolver-typescript: 3.5.0_vrppu4wnfrn2cbiuko2grd2pga
       eslint-plugin-import: 2.26.0_vqjbtdhhrgxydnvupboyyqn3y4
     devDependencies:
       eslint: 8.0.0
-      typescript: 4.1.2
+      typescript: 4.2.2
 
   libs/@guardian/eslint-plugin-source-foundations:
     specifiers:
@@ -7151,7 +7151,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/eslint-plugin/5.36.1_iq5gmiqet7rqbsxn252aqj4fby:
+  /@typescript-eslint/eslint-plugin/5.36.1_ai2qwq6ftvvac3e2nax7nm3a5q:
     resolution: {integrity: sha512-iC40UK8q1tMepSDwiLbTbMXKDxzNy+4TfPWgIL661Ym0sD42vRcQU93IsZIrmi+x292DBr60UI/gSwfdVYexCA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7164,18 +7164,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.1_bj2xhvhw4kzrbf7d45h2myrriy
+      '@typescript-eslint/parser': 5.36.1_vizttnskhxwupgy3pyipyx545a
       '@typescript-eslint/scope-manager': 5.36.1
-      '@typescript-eslint/type-utils': 5.36.1_bj2xhvhw4kzrbf7d45h2myrriy
-      '@typescript-eslint/utils': 5.36.1_bj2xhvhw4kzrbf7d45h2myrriy
+      '@typescript-eslint/type-utils': 5.36.1_vizttnskhxwupgy3pyipyx545a
+      '@typescript-eslint/utils': 5.36.1_vizttnskhxwupgy3pyipyx545a
       debug: 4.3.4
       eslint: 8.0.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.1.2
-      typescript: 4.1.2
+      tsutils: 3.21.0_typescript@4.2.2
+      typescript: 4.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7201,7 +7201,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/5.36.1_bj2xhvhw4kzrbf7d45h2myrriy:
+  /@typescript-eslint/parser/5.36.1_vizttnskhxwupgy3pyipyx545a:
     resolution: {integrity: sha512-/IsgNGOkBi7CuDfUbwt1eOqUXF9WGVBW9dwEe1pi+L32XrTsZIgmDFIi2RxjzsvB/8i+MIf5JIoTEH8LOZ368A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7215,10 +7215,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.36.1
       '@typescript-eslint/types': 5.36.1
-      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.1.2
+      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.2.2
       debug: 4.3.4
       eslint: 8.0.0
-      typescript: 4.1.2
+      typescript: 4.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7288,7 +7288,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/type-utils/5.36.1_bj2xhvhw4kzrbf7d45h2myrriy:
+  /@typescript-eslint/type-utils/5.36.1_vizttnskhxwupgy3pyipyx545a:
     resolution: {integrity: sha512-xfZhfmoQT6m3lmlqDvDzv9TiCYdw22cdj06xY0obSznBsT///GK5IEZQdGliXpAOaRL34o8phEvXzEo/VJx13Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7300,12 +7300,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.1.2
-      '@typescript-eslint/utils': 5.36.1_bj2xhvhw4kzrbf7d45h2myrriy
+      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.2.2
+      '@typescript-eslint/utils': 5.36.1_vizttnskhxwupgy3pyipyx545a
       debug: 4.3.4
       eslint: 8.0.0
-      tsutils: 3.21.0_typescript@4.1.2
-      typescript: 4.1.2
+      tsutils: 3.21.0_typescript@4.2.2
+      typescript: 4.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7344,7 +7344,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.36.1_typescript@4.1.2:
+  /@typescript-eslint/typescript-estree/5.36.1_typescript@4.2.2:
     resolution: {integrity: sha512-ih7V52zvHdiX6WcPjsOdmADhYMDN15SylWRZrT2OMy80wzKbc79n8wFW0xpWpU0x3VpBz/oDgTm2xwDAnFTl+g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7359,8 +7359,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.1.2
-      typescript: 4.1.2
+      tsutils: 3.21.0_typescript@4.2.2
+      typescript: 4.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7428,7 +7428,7 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/utils/5.36.1_bj2xhvhw4kzrbf7d45h2myrriy:
+  /@typescript-eslint/utils/5.36.1_vizttnskhxwupgy3pyipyx545a:
     resolution: {integrity: sha512-lNj4FtTiXm5c+u0pUehozaUWhh7UYKnwryku0nxJlYUEWetyG92uw2pr+2Iy4M/u0ONMKzfrx7AsGBTCzORmIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7440,7 +7440,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.36.1
       '@typescript-eslint/types': 5.36.1
-      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.1.2
+      '@typescript-eslint/typescript-estree': 5.36.1_typescript@4.2.2
       eslint: 8.0.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.0.0
@@ -10359,7 +10359,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.1_bj2xhvhw4kzrbf7d45h2myrriy
+      '@typescript-eslint/parser': 5.36.1_vizttnskhxwupgy3pyipyx545a
       debug: 3.2.7
       eslint: 8.0.0
       eslint-import-resolver-node: 0.3.6
@@ -10487,7 +10487,7 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.1_bj2xhvhw4kzrbf7d45h2myrriy
+      '@typescript-eslint/parser': 5.36.1_vizttnskhxwupgy3pyipyx545a
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -17451,7 +17451,7 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /tsutils/3.21.0_typescript@4.1.2:
+  /tsutils/3.21.0_typescript@4.2.2:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -17461,7 +17461,7 @@ packages:
         optional: true
     dependencies:
       tslib: 1.14.1
-      typescript: 4.1.2
+      typescript: 4.2.2
     dev: false
 
   /tsutils/3.21.0_typescript@4.8.4:
@@ -17561,8 +17561,8 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript/4.1.2:
-    resolution: {integrity: sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==}
+  /typescript/4.2.2:
+    resolution: {integrity: sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
 


### PR DESCRIPTION
## What are you changing?

Sets the version of typescript used in eslint-config-typescript to the earliest version that fixes a 'maximum call stack size exceeded' error. 

It was caused by how string literal types were parsed by versions of Typescript before 4.2.2 when eslint was parsing a conditional including a template literal type `font-styles.ts` file in source-foundations.

The github issue that describes the problem and its resolution that was subsequently included in the stable release (`typescript@4.2.2`) is here: https://github.com/microsoft/TypeScript/issues/41651

Because this fixes the linting of source-foundations, this PR also reinstates the `lint` task in the source-foundations `project.json`.

## Why?

Without the fix included in `typescript@4.2.2` we are unable to lint the `font-styles.ts` file in source-foundations without the call stack size exceeded error. Typescript 4.2.2 was chosen because it's the earliest version that includes the patch for the issue.
