### PR TITLE
Remove stories for Source eslint plugins

### DIFF
--- a/libs/@guardian/eslint-plugin-source-foundations/README.stories.mdx
+++ b/libs/@guardian/eslint-plugin-source-foundations/README.stories.mdx
@@ -1,9 +1,0 @@
-import { Meta } from '@storybook/addon-docs';
-import ReadMe from './README.md';
-
-<Meta
-	title="packages/eslint-plugin-source-foundations/README"
-	parameters={{ previewTabs: { canvas: { hidden: true } } }}
-/>
-
-<ReadMe />

--- a/libs/@guardian/eslint-plugin-source-react-components/README.stories.mdx
+++ b/libs/@guardian/eslint-plugin-source-react-components/README.stories.mdx
@@ -1,9 +1,0 @@
-import { Meta } from '@storybook/addon-docs';
-import ReadMe from './README.md';
-
-<Meta
-	title="packages/eslint-plugin-source-react-components/README"
-	parameters={{ previewTabs: { canvas: { hidden: true } } }}
-/>
-
-<ReadMe />


### PR DESCRIPTION
## What are you changing?

- We're removing both Source eslint plugin README stories in favour of using their markdown equivalent.

## Why?

- We felt it was unnecessary to document this information as a story, especially because we don't render any components.
- This change would have required adding a new instance of AWS Amplify for each plugin.
