### PR TITLE
Add back `test` and `e2e` jobs to source foundations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,25 +15,25 @@ storybooks: env
 .PHONY: test
 test: env
 	$(call log,"Running unit tests")
-	@corepack pnpm nx run-many --target=test --all=true
+	@corepack pnpm nx run-many --target=test --all=true --skip-nx-cache
 
 # runs the e2e tests for all projects
 .PHONY: e2e
 e2e: env
 	$(call log,"Running e2e tests")
-	@corepack pnpm nx run-many --target=e2e --all=true
+	@corepack pnpm nx run-many --target=e2e --all=true --skip-nx-cache
 
 # checks all projects for lint errors
 .PHONY: lint
 lint: install
 	$(call log,"Linting projects")
-	@corepack pnpm nx run-many --target=lint --all=true
+	@corepack pnpm nx run-many --target=lint --all=true --skip-nx-cache
 
 # attemps to fix lint errors across all projects
 .PHONY: fix
 fix: install
 	$(call log,"Attempting to fix lint error in projects")
-	@corepack pnpm nx run-many --target=fix --all=true
+	@corepack pnpm nx run-many --target=fix --all=true --skip-nx-cache
 
 # makes sure absolutely everything is working
 .PHONY: validate
@@ -51,13 +51,13 @@ clean: env
 .PHONY: build
 build: env clean
 	$(call log,"Building projects")
-	@corepack pnpm nx run-many --target=build --all=true
+	@corepack pnpm nx run-many --target=build --all=true --skip-nx-cache
 
 # builds all storybooks
 .PHONY: build-storybooks
 build-storybooks: env
 	$(call log,"Building storybooks")
-	@corepack pnpm nx run-many --target=build-storybook --all=true
+	@corepack pnpm nx run-many --target=build-storybook --all=true --skip-nx-cache
 
 ############################### MANAGING PACKAGES ##############################
 

--- a/libs/@guardian/source-foundations/jest.e2e.setup.ts
+++ b/libs/@guardian/source-foundations/jest.e2e.setup.ts
@@ -6,4 +6,7 @@
 // @ts-ignore
 import * as dist from '../../../dist/libs/@guardian/source-foundations';
 
+// Register our custom Jest matcher.
+import './lib/jest-matchers/toBeValidCSS.ts';
+
 jest.mock('./src/index', () => dist);

--- a/libs/@guardian/source-foundations/project.json
+++ b/libs/@guardian/source-foundations/project.json
@@ -28,6 +28,23 @@
 				"lintFilePatterns": ["libs/@guardian/source-foundations/**/*.ts"]
 			}
 		},
+		"test": {
+			"executor": "@nrwl/jest:jest",
+			"outputs": ["coverage/libs/@guardian/source-foundations"],
+			"options": {
+				"jestConfig": "libs/@guardian/source-foundations/jest.config.ts",
+				"passWithNoTests": true
+			}
+		},
+		"e2e": {
+			"executor": "@nrwl/jest:jest",
+			"outputs": ["coverage/libs/@guardian/source-foundations"],
+			"options": {
+				"jestConfig": "libs/@guardian/source-foundations/jest.config.ts",
+				"passWithNoTests": true,
+				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
+			}
+		},
 		"storybook": {
 			"executor": "nx:run-commands",
 			"options": {


### PR DESCRIPTION
## What are you changing?

- Registering the `toBeValidCSS` Jest matcher in the source foundations e2e jest setup file.
- Adding the `test` and `e2e` rules back into the source foundations project.json

## Why?

- So we can run our tests against source foundations.
- Reinstate these rules as they were removed during the initial step of the migration.


closes https://github.com/guardian/csnx/issues/223
