### PR TITLE
Flatten nested Source stories

### DIFF
--- a/apps/source-storybook/src/eslint-plugin-source-foundations/README.stories.mdx
+++ b/apps/source-storybook/src/eslint-plugin-source-foundations/README.stories.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/addon-docs';
 import ReadMe from '@guardian/eslint-plugin-source-foundations/README.md';
 
 <Meta
-	title="packages/eslint-plugin-source-foundations/README"
+	title="README"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/apps/source-storybook/src/eslint-plugin-source-react-components/README.stories.mdx
+++ b/apps/source-storybook/src/eslint-plugin-source-react-components/README.stories.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/addon-docs';
 import ReadMe from '@guardian/eslint-plugin-source-react-components/README.md';
 
 <Meta
-	title="packages/eslint-plugin-source-react-components/README"
+	title="README"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/accessibility/description-id.stories.mdx
+++ b/libs/@guardian/source-foundations/src/accessibility/description-id.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="source-foundations/descriptionId"
+	title="descriptionId"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/accessibility/description-id.stories.mdx
+++ b/libs/@guardian/source-foundations/src/accessibility/description-id.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="Packages/source-foundations/descriptionId"
+	title="source-foundations/descriptionId"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/accessibility/focus-halo.stories.mdx
+++ b/libs/@guardian/source-foundations/src/accessibility/focus-halo.stories.mdx
@@ -3,7 +3,7 @@ import { Meta } from '@storybook/addon-docs';
 import { focusHalo } from './focus-halo';
 
 <Meta
-	title="Packages/source-foundations/focusHalo"
+	title="source-foundations/focusHalo"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/accessibility/focus-halo.stories.mdx
+++ b/libs/@guardian/source-foundations/src/accessibility/focus-halo.stories.mdx
@@ -3,7 +3,7 @@ import { Meta } from '@storybook/addon-docs';
 import { focusHalo } from './focus-halo';
 
 <Meta
-	title="source-foundations/focusHalo"
+	title="focusHalo"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/accessibility/focus-style-manager.stories.mdx
+++ b/libs/@guardian/source-foundations/src/accessibility/focus-style-manager.stories.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/addon-docs';
 import { FocusStyleManager } from './focus-style-manager';
 
 <Meta
-	title="source-foundations/FocusStyleManager"
+	title="FocusStyleManager"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/accessibility/focus-style-manager.stories.mdx
+++ b/libs/@guardian/source-foundations/src/accessibility/focus-style-manager.stories.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/addon-docs';
 import { FocusStyleManager } from './focus-style-manager';
 
 <Meta
-	title="Packages/source-foundations/FocusStyleManager"
+	title="source-foundations/FocusStyleManager"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/accessibility/generate-source-id.stories.mdx
+++ b/libs/@guardian/source-foundations/src/accessibility/generate-source-id.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="Packages/source-foundations/generateSourceId"
+	title="source-foundations/generateSourceId"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/accessibility/generate-source-id.stories.mdx
+++ b/libs/@guardian/source-foundations/src/accessibility/generate-source-id.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="source-foundations/generateSourceId"
+	title="generateSourceId"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/accessibility/visually-hidden.stories.mdx
+++ b/libs/@guardian/source-foundations/src/accessibility/visually-hidden.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="source-foundations/visuallyHidden"
+	title="visuallyHidden"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/accessibility/visually-hidden.stories.mdx
+++ b/libs/@guardian/source-foundations/src/accessibility/visually-hidden.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="Packages/source-foundations/visuallyHidden"
+	title="source-foundations/visuallyHidden"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/colour/palette.stories.mdx
+++ b/libs/@guardian/source-foundations/src/colour/palette.stories.mdx
@@ -3,7 +3,7 @@ import { palette as colours } from './palette';
 import { ColorPalette, ColorItem } from './storybookColorPalette';
 
 <Meta
-	title="source-foundations/palette"
+	title="palette"
 	parameters={{ previewTabs: { canvas: { hidden: true } }, viewMode: 'docs' }}
 />
 

--- a/libs/@guardian/source-foundations/src/colour/palette.stories.mdx
+++ b/libs/@guardian/source-foundations/src/colour/palette.stories.mdx
@@ -3,7 +3,7 @@ import { palette as colours } from './palette';
 import { ColorPalette, ColorItem } from './storybookColorPalette';
 
 <Meta
-	title="Packages/source-foundations/palette"
+	title="source-foundations/palette"
 	parameters={{ previewTabs: { canvas: { hidden: true } }, viewMode: 'docs' }}
 />
 

--- a/libs/@guardian/source-foundations/src/mq/mq.stories.mdx
+++ b/libs/@guardian/source-foundations/src/mq/mq.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="Packages/source-foundations/Media queries"
+	title="source-foundations/Media queries"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/mq/mq.stories.mdx
+++ b/libs/@guardian/source-foundations/src/mq/mq.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="source-foundations/Media queries"
+	title="Media queries"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/size/size.stories.mdx
+++ b/libs/@guardian/source-foundations/src/size/size.stories.mdx
@@ -1,9 +1,6 @@
 import { Meta } from '@storybook/addon-docs';
 
-<Meta
-	title="source-foundations/Size"
-	parameters={{ previewTabs: { canvas: { hidden: true } } }}
-/>
+<Meta title="Size" parameters={{ previewTabs: { canvas: { hidden: true } } }} />
 
 # Size
 

--- a/libs/@guardian/source-foundations/src/size/size.stories.mdx
+++ b/libs/@guardian/source-foundations/src/size/size.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="Packages/source-foundations/Size"
+	title="source-foundations/Size"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/space/space.stories.mdx
+++ b/libs/@guardian/source-foundations/src/space/space.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="Packages/source-foundations/Space"
+	title="source-foundations/Space"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/space/space.stories.mdx
+++ b/libs/@guardian/source-foundations/src/space/space.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="source-foundations/Space"
+	title="Space"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/typography/typography.stories.mdx
+++ b/libs/@guardian/source-foundations/src/typography/typography.stories.mdx
@@ -17,7 +17,7 @@ import {
 	https://github.com/storybookjs/storybook/issues/9209 -->
 
 <Meta
-	title="Packages/source-foundations/Typography"
+	title="source-foundations/Typography"
 	parameters={{ previewTabs: { canvas: { hidden: true } }, viewMode: 'docs' }}
 />
 

--- a/libs/@guardian/source-foundations/src/typography/typography.stories.mdx
+++ b/libs/@guardian/source-foundations/src/typography/typography.stories.mdx
@@ -17,7 +17,7 @@ import {
 	https://github.com/storybookjs/storybook/issues/9209 -->
 
 <Meta
-	title="source-foundations/Typography"
+	title="Typography"
 	parameters={{ previewTabs: { canvas: { hidden: true } }, viewMode: 'docs' }}
 />
 

--- a/libs/@guardian/source-foundations/src/utils/resets.stories.mdx
+++ b/libs/@guardian/source-foundations/src/utils/resets.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="source-foundations/CSS reset"
+	title="CSS reset"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-foundations/src/utils/resets.stories.mdx
+++ b/libs/@guardian/source-foundations/src/utils/resets.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="Packages/source-foundations/CSS reset"
+	title="source-foundations/CSS reset"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 

--- a/libs/@guardian/source-react-components-development-kitchen/src/divider/Divider.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/divider/Divider.stories.tsx
@@ -3,7 +3,7 @@ import type { DividerProps } from './Divider';
 import { Divider } from './Divider';
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/Divider',
+	title: 'source-react-components-development-kitchen/Divider',
 	component: Divider,
 };
 

--- a/libs/@guardian/source-react-components-development-kitchen/src/divider/Divider.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/divider/Divider.stories.tsx
@@ -3,7 +3,7 @@ import type { DividerProps } from './Divider';
 import { Divider } from './Divider';
 
 export default {
-	title: 'source-react-components-development-kitchen/Divider',
+	title: 'Divider',
 	component: Divider,
 };
 

--- a/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialButton.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialButton.stories.tsx
@@ -16,7 +16,7 @@ const defaultFormat = {
 };
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/EditorialButton',
+	title: 'source-react-components-development-kitchen/EditorialButton',
 	component: EditorialButton,
 	argTypes: {
 		format: {

--- a/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialButton.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialButton.stories.tsx
@@ -16,7 +16,7 @@ const defaultFormat = {
 };
 
 export default {
-	title: 'source-react-components-development-kitchen/EditorialButton',
+	title: 'EditorialButton',
 	component: EditorialButton,
 	argTypes: {
 		format: {

--- a/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialLinkButton.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialLinkButton.stories.tsx
@@ -16,7 +16,7 @@ const defaultFormat = {
 };
 
 export default {
-	title: 'source-react-components-development-kitchen/EditorialLinkButton',
+	title: 'EditorialLinkButton',
 	component: EditorialLinkButton,
 	argTypes: {
 		format: {

--- a/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialLinkButton.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialLinkButton.stories.tsx
@@ -16,8 +16,7 @@ const defaultFormat = {
 };
 
 export default {
-	title:
-		'Packages/source-react-components-development-kitchen/EditorialLinkButton',
+	title: 'source-react-components-development-kitchen/EditorialLinkButton',
 	component: EditorialLinkButton,
 	argTypes: {
 		format: {

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.stories.tsx
@@ -3,7 +3,7 @@ import type { FooterLinksProps } from './FooterLinks';
 import { defaultGuardianLinks, FooterLinks } from './FooterLinks';
 
 export default {
-	title: 'source-react-components-development-kitchen/FooterLinks',
+	title: 'FooterLinks',
 	component: FooterLinks,
 	parameters: {
 		layout: 'fullscreen',

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.stories.tsx
@@ -3,7 +3,7 @@ import type { FooterLinksProps } from './FooterLinks';
 import { defaultGuardianLinks, FooterLinks } from './FooterLinks';
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/FooterLinks',
+	title: 'source-react-components-development-kitchen/FooterLinks',
 	component: FooterLinks,
 	parameters: {
 		layout: 'fullscreen',

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.stories.tsx
@@ -7,8 +7,7 @@ import type { FooterWithContentsProps } from './FooterWithContents';
 import { FooterWithContents } from './FooterWithContents';
 
 export default {
-	title:
-		'Packages/source-react-components-development-kitchen/FooterWithContents',
+	title: 'source-react-components-development-kitchen/FooterWithContents',
 	component: FooterWithContents,
 	parameters: {
 		layout: 'fullscreen',

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.stories.tsx
@@ -7,7 +7,7 @@ import type { FooterWithContentsProps } from './FooterWithContents';
 import { FooterWithContents } from './FooterWithContents';
 
 export default {
-	title: 'source-react-components-development-kitchen/FooterWithContents',
+	title: 'FooterWithContents',
 	component: FooterWithContents,
 	parameters: {
 		layout: 'fullscreen',

--- a/libs/@guardian/source-react-components-development-kitchen/src/lines/Lines.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/lines/Lines.stories.tsx
@@ -6,7 +6,7 @@ import { SquigglyLines as SquigglyLinesComponent } from './SquigglyLines';
 import { StraightLines as StraightLinesComponent } from './StraightLines';
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/Lines',
+	title: 'source-react-components-development-kitchen/Lines',
 	component: StraightLinesComponent,
 	args: {
 		count: '4',

--- a/libs/@guardian/source-react-components-development-kitchen/src/lines/Lines.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/lines/Lines.stories.tsx
@@ -6,7 +6,7 @@ import { SquigglyLines as SquigglyLinesComponent } from './SquigglyLines';
 import { StraightLines as StraightLinesComponent } from './StraightLines';
 
 export default {
-	title: 'source-react-components-development-kitchen/Lines',
+	title: 'Lines',
 	component: StraightLinesComponent,
 	args: {
 		count: '4',

--- a/libs/@guardian/source-react-components-development-kitchen/src/logo/Logo.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/logo/Logo.stories.tsx
@@ -3,7 +3,7 @@ import type { Story } from '@storybook/react';
 import { Logo } from './Logo';
 
 export default {
-	title: 'source-react-components-development-kitchen/Logo',
+	title: 'Logo',
 	component: Logo,
 	args: {
 		logoType: 'standard',

--- a/libs/@guardian/source-react-components-development-kitchen/src/logo/Logo.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/logo/Logo.stories.tsx
@@ -3,7 +3,7 @@ import type { Story } from '@storybook/react';
 import { Logo } from './Logo';
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/Logo',
+	title: 'source-react-components-development-kitchen/Logo',
 	component: Logo,
 	args: {
 		logoType: 'standard',

--- a/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/NumericInput.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/NumericInput.stories.tsx
@@ -4,7 +4,7 @@ import type { NumericInputProps } from './NumericInput';
 import { NumericInput } from './NumericInput';
 
 export default {
-	title: 'source-react-components-development-kitchen/NumericInput',
+	title: 'NumericInput',
 	component: NumericInput,
 	args: {
 		label: 'Account number',

--- a/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/NumericInput.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/NumericInput.stories.tsx
@@ -4,7 +4,7 @@ import type { NumericInputProps } from './NumericInput';
 import { NumericInput } from './NumericInput';
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/NumericInput',
+	title: 'source-react-components-development-kitchen/NumericInput',
 	component: NumericInput,
 	args: {
 		label: 'Account number',

--- a/libs/@guardian/source-react-components-development-kitchen/src/quote-icon/QuoteIcon.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/quote-icon/QuoteIcon.stories.tsx
@@ -14,7 +14,7 @@ const defaultFormat = {
 };
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/QuoteIcon',
+	title: 'source-react-components-development-kitchen/QuoteIcon',
 	component: QuoteIcon,
 	argTypes: {
 		format: {

--- a/libs/@guardian/source-react-components-development-kitchen/src/quote-icon/QuoteIcon.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/quote-icon/QuoteIcon.stories.tsx
@@ -14,7 +14,7 @@ const defaultFormat = {
 };
 
 export default {
-	title: 'source-react-components-development-kitchen/QuoteIcon',
+	title: 'QuoteIcon',
 	component: QuoteIcon,
 	argTypes: {
 		format: {

--- a/libs/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.stories.tsx
@@ -3,7 +3,7 @@ import type { StarRatingProps } from './StarRating';
 import { StarRating } from './StarRating';
 
 export default {
-	title: 'source-react-components-development-kitchen/Star Rating',
+	title: 'Star Rating',
 	component: StarRating,
 	args: {
 		size: 'medium',

--- a/libs/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.stories.tsx
@@ -3,7 +3,7 @@ import type { StarRatingProps } from './StarRating';
 import { StarRating } from './StarRating';
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/Star Rating',
+	title: 'source-react-components-development-kitchen/Star Rating',
 	component: StarRating,
 	args: {
 		size: 'medium',

--- a/libs/@guardian/source-react-components-development-kitchen/src/summary/ErrorSummary.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/summary/ErrorSummary.stories.tsx
@@ -3,7 +3,7 @@ import type { ErrorSummaryProps } from './ErrorSummary';
 import { ErrorSummary } from './ErrorSummary';
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/Error Summary',
+	title: 'source-react-components-development-kitchen/Error Summary',
 	component: ErrorSummary,
 	args: {
 		message: 'There has been a problem',

--- a/libs/@guardian/source-react-components-development-kitchen/src/summary/ErrorSummary.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/summary/ErrorSummary.stories.tsx
@@ -3,7 +3,7 @@ import type { ErrorSummaryProps } from './ErrorSummary';
 import { ErrorSummary } from './ErrorSummary';
 
 export default {
-	title: 'source-react-components-development-kitchen/Error Summary',
+	title: 'Error Summary',
 	component: ErrorSummary,
 	args: {
 		message: 'There has been a problem',

--- a/libs/@guardian/source-react-components-development-kitchen/src/summary/InfoSummary.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/summary/InfoSummary.stories.tsx
@@ -3,7 +3,7 @@ import type { InfoSummaryProps } from './InfoSummary';
 import { InfoSummary } from './InfoSummary';
 
 export default {
-	title: 'source-react-components-development-kitchen/Info Summary',
+	title: 'Info Summary',
 	component: InfoSummary,
 	args: {
 		message: 'Here is some information',

--- a/libs/@guardian/source-react-components-development-kitchen/src/summary/InfoSummary.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/summary/InfoSummary.stories.tsx
@@ -3,7 +3,7 @@ import type { InfoSummaryProps } from './InfoSummary';
 import { InfoSummary } from './InfoSummary';
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/Info Summary',
+	title: 'source-react-components-development-kitchen/Info Summary',
 	component: InfoSummary,
 	args: {
 		message: 'Here is some information',

--- a/libs/@guardian/source-react-components-development-kitchen/src/summary/SuccessSummary.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/summary/SuccessSummary.stories.tsx
@@ -3,7 +3,7 @@ import type { SuccessSummaryProps } from './SuccessSummary';
 import { SuccessSummary } from './SuccessSummary';
 
 export default {
-	title: 'source-react-components-development-kitchen/Success Summary',
+	title: 'Success Summary',
 	component: SuccessSummary,
 	args: {
 		message: 'Your request was successful',

--- a/libs/@guardian/source-react-components-development-kitchen/src/summary/SuccessSummary.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/summary/SuccessSummary.stories.tsx
@@ -3,7 +3,7 @@ import type { SuccessSummaryProps } from './SuccessSummary';
 import { SuccessSummary } from './SuccessSummary';
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/Success Summary',
+	title: 'source-react-components-development-kitchen/Success Summary',
 	component: SuccessSummary,
 	args: {
 		message: 'Your request was successful',

--- a/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/ToggleSwitchApps.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/ToggleSwitchApps.stories.tsx
@@ -4,8 +4,7 @@ import { ToggleSwitchApps } from './ToggleSwitchApps';
 import type { ToggleSwitchAppsProps } from './ToggleSwitchApps';
 
 export default {
-	title:
-		'Packages/source-react-components-development-kitchen/ToggleSwitchApps',
+	title: 'source-react-components-development-kitchen/ToggleSwitchApps',
 	component: ToggleSwitchApps,
 	args: {},
 };

--- a/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/ToggleSwitchApps.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/ToggleSwitchApps.stories.tsx
@@ -4,7 +4,7 @@ import { ToggleSwitchApps } from './ToggleSwitchApps';
 import type { ToggleSwitchAppsProps } from './ToggleSwitchApps';
 
 export default {
-	title: 'source-react-components-development-kitchen/ToggleSwitchApps',
+	title: 'ToggleSwitchApps',
 	component: ToggleSwitchApps,
 	args: {},
 };

--- a/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.stories.tsx
@@ -60,7 +60,7 @@ const pillars = [
 ];
 
 export default {
-	title: 'source-react-components-development-kitchen/ToggleSwitch',
+	title: 'ToggleSwitch',
 	component: ToggleSwitch,
 };
 

--- a/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.stories.tsx
@@ -60,7 +60,7 @@ const pillars = [
 ];
 
 export default {
-	title: 'Packages/source-react-components-development-kitchen/ToggleSwitch',
+	title: 'source-react-components-development-kitchen/ToggleSwitch',
 	component: ToggleSwitch,
 };
 

--- a/libs/@guardian/source-react-components/README.md
+++ b/libs/@guardian/source-react-components/README.md
@@ -66,7 +66,7 @@ Standard themes available from `@guardian/source-react-components`:
 - **brand – exported as `[componentName]ThemeBrand`**
 - **brandAlt – exported as `[componentName]ThemeBrandAlt`**
 
-To find out which themes a component supports, check its stories under `Packages/source-react-components/<ComponentName>`
+To find out which themes a component supports, check its stories under `source-react-components/<ComponentName>`
 
 Note that some components have their own unique themes in addition to the standard set of themes. For instance, the button component defines [two themes for use in Reader Revenue flows](https://theguardian.design/2a1e5182b/p/435225-button/t/41a3ce).
 

--- a/libs/@guardian/source-react-components/src/accordion/Accordion.stories.tsx
+++ b/libs/@guardian/source-react-components/src/accordion/Accordion.stories.tsx
@@ -4,7 +4,7 @@ import { Accordion } from './Accordion';
 import { AccordionRow } from './AccordionRow';
 
 export default {
-	title: 'source-react-components/Accordion',
+	title: 'Accordion',
 	component: Accordion,
 	subcomponents: { AccordionRow },
 	args: {

--- a/libs/@guardian/source-react-components/src/accordion/Accordion.stories.tsx
+++ b/libs/@guardian/source-react-components/src/accordion/Accordion.stories.tsx
@@ -4,7 +4,7 @@ import { Accordion } from './Accordion';
 import { AccordionRow } from './AccordionRow';
 
 export default {
-	title: 'Packages/source-react-components/Accordion',
+	title: 'source-react-components/Accordion',
 	component: Accordion,
 	subcomponents: { AccordionRow },
 	args: {

--- a/libs/@guardian/source-react-components/src/brand/SvgGuardianBestWebsiteLogo.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgGuardianBestWebsiteLogo.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgGuardianBestWebsiteLogoProps } from './SvgGuardianBestWebsiteLo
 import { SvgGuardianBestWebsiteLogo } from './SvgGuardianBestWebsiteLogo';
 
 export default {
-	title: 'source-react-components/SvgGuardianBestWebsiteLogo',
+	title: 'SvgGuardianBestWebsiteLogo',
 	component: SvgGuardianBestWebsiteLogo,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgGuardianBestWebsiteLogo.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgGuardianBestWebsiteLogo.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgGuardianBestWebsiteLogoProps } from './SvgGuardianBestWebsiteLo
 import { SvgGuardianBestWebsiteLogo } from './SvgGuardianBestWebsiteLogo';
 
 export default {
-	title: 'Packages/source-react-components/SvgGuardianBestWebsiteLogo',
+	title: 'source-react-components/SvgGuardianBestWebsiteLogo',
 	component: SvgGuardianBestWebsiteLogo,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgGuardianLiveLogo.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgGuardianLiveLogo.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgGuardianLiveLogoProps } from './SvgGuardianLiveLogo';
 import { SvgGuardianLiveLogo } from './SvgGuardianLiveLogo';
 
 export default {
-	title: 'source-react-components/SvgGuardianLiveLogo',
+	title: 'SvgGuardianLiveLogo',
 	component: SvgGuardianLiveLogo,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgGuardianLiveLogo.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgGuardianLiveLogo.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgGuardianLiveLogoProps } from './SvgGuardianLiveLogo';
 import { SvgGuardianLiveLogo } from './SvgGuardianLiveLogo';
 
 export default {
-	title: 'Packages/source-react-components/SvgGuardianLiveLogo',
+	title: 'source-react-components/SvgGuardianLiveLogo',
 	component: SvgGuardianLiveLogo,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgGuardianLogo.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgGuardianLogo.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgGuardianLogoProps } from './SvgGuardianLogo';
 import { SvgGuardianLogo } from './SvgGuardianLogo';
 
 export default {
-	title: 'source-react-components/SvgGuardianLogo',
+	title: 'SvgGuardianLogo',
 	component: SvgGuardianLogo,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgGuardianLogo.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgGuardianLogo.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgGuardianLogoProps } from './SvgGuardianLogo';
 import { SvgGuardianLogo } from './SvgGuardianLogo';
 
 export default {
-	title: 'Packages/source-react-components/SvgGuardianLogo',
+	title: 'source-react-components/SvgGuardianLogo',
 	component: SvgGuardianLogo,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelBrand.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelBrand.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgRoundelBrandProps } from './SvgRoundelBrand';
 import { SvgRoundelBrand } from './SvgRoundelBrand';
 
 export default {
-	title: 'source-react-components/SvgRoundelBrand',
+	title: 'SvgRoundelBrand',
 	component: SvgRoundelBrand,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelBrand.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelBrand.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgRoundelBrandProps } from './SvgRoundelBrand';
 import { SvgRoundelBrand } from './SvgRoundelBrand';
 
 export default {
-	title: 'Packages/source-react-components/SvgRoundelBrand',
+	title: 'source-react-components/SvgRoundelBrand',
 	component: SvgRoundelBrand,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelBrandInverse.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelBrandInverse.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgRoundelBrandInverseProps } from './SvgRoundelBrandInverse';
 import { SvgRoundelBrandInverse } from './SvgRoundelBrandInverse';
 
 export default {
-	title: 'source-react-components/SvgRoundelBrandInverse',
+	title: 'SvgRoundelBrandInverse',
 	component: SvgRoundelBrandInverse,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelBrandInverse.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelBrandInverse.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgRoundelBrandInverseProps } from './SvgRoundelBrandInverse';
 import { SvgRoundelBrandInverse } from './SvgRoundelBrandInverse';
 
 export default {
-	title: 'Packages/source-react-components/SvgRoundelBrandInverse',
+	title: 'source-react-components/SvgRoundelBrandInverse',
 	component: SvgRoundelBrandInverse,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelDefault.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelDefault.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgRoundelDefaultProps } from './SvgRoundelDefault';
 import { SvgRoundelDefault } from './SvgRoundelDefault';
 
 export default {
-	title: 'Packages/source-react-components/SvgRoundelDefault',
+	title: 'source-react-components/SvgRoundelDefault',
 	component: SvgRoundelDefault,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelDefault.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelDefault.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgRoundelDefaultProps } from './SvgRoundelDefault';
 import { SvgRoundelDefault } from './SvgRoundelDefault';
 
 export default {
-	title: 'source-react-components/SvgRoundelDefault',
+	title: 'SvgRoundelDefault',
 	component: SvgRoundelDefault,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelInverse.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelInverse.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgRoundelInverseProps } from './SvgRoundelInverse';
 import { SvgRoundelInverse } from './SvgRoundelInverse';
 
 export default {
-	title: 'Packages/source-react-components/SvgRoundelInverse',
+	title: 'source-react-components/SvgRoundelInverse',
 	component: SvgRoundelInverse,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelInverse.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelInverse.stories.tsx
@@ -3,7 +3,7 @@ import type { SvgRoundelInverseProps } from './SvgRoundelInverse';
 import { SvgRoundelInverse } from './SvgRoundelInverse';
 
 export default {
-	title: 'source-react-components/SvgRoundelInverse',
+	title: 'SvgRoundelInverse',
 	component: SvgRoundelInverse,
 	argTypes: {
 		width: {

--- a/libs/@guardian/source-react-components/src/button/Button.stories.tsx
+++ b/libs/@guardian/source-react-components/src/button/Button.stories.tsx
@@ -59,7 +59,7 @@ const createStory = (args: Partial<ButtonProps>, parameters: Parameters) => {
 };
 
 export default {
-	title: 'source-react-components/Button',
+	title: 'Button',
 	component: Button,
 	argTypes: {
 		icon: {

--- a/libs/@guardian/source-react-components/src/button/Button.stories.tsx
+++ b/libs/@guardian/source-react-components/src/button/Button.stories.tsx
@@ -59,7 +59,7 @@ const createStory = (args: Partial<ButtonProps>, parameters: Parameters) => {
 };
 
 export default {
-	title: 'Packages/source-react-components/Button',
+	title: 'source-react-components/Button',
 	component: Button,
 	argTypes: {
 		icon: {

--- a/libs/@guardian/source-react-components/src/button/LinkButton.stories.tsx
+++ b/libs/@guardian/source-react-components/src/button/LinkButton.stories.tsx
@@ -14,7 +14,7 @@ const priorityArgs: ButtonPriority[] = [
 ];
 
 export default {
-	title: 'source-react-components/LinkButton',
+	title: 'LinkButton',
 	component: LinkButton,
 	argTypes: {
 		icon: {

--- a/libs/@guardian/source-react-components/src/button/LinkButton.stories.tsx
+++ b/libs/@guardian/source-react-components/src/button/LinkButton.stories.tsx
@@ -14,7 +14,7 @@ const priorityArgs: ButtonPriority[] = [
 ];
 
 export default {
-	title: 'Packages/source-react-components/LinkButton',
+	title: 'source-react-components/LinkButton',
 	component: LinkButton,
 	argTypes: {
 		icon: {

--- a/libs/@guardian/source-react-components/src/checkbox/Checkbox.stories.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/Checkbox.stories.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from './Checkbox';
 import { checkboxThemeBrand } from './theme';
 
 export default {
-	title: 'source-react-components/Checkbox',
+	title: 'Checkbox',
 	component: Checkbox,
 	argTypes: {},
 	args: {

--- a/libs/@guardian/source-react-components/src/checkbox/Checkbox.stories.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/Checkbox.stories.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from './Checkbox';
 import { checkboxThemeBrand } from './theme';
 
 export default {
-	title: 'Packages/source-react-components/Checkbox',
+	title: 'source-react-components/Checkbox',
 	component: Checkbox,
 	argTypes: {},
 	args: {

--- a/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
@@ -7,7 +7,7 @@ import { CheckboxGroup } from './CheckboxGroup';
 import { checkboxThemeBrand } from './theme';
 
 export default {
-	title: 'source-react-components/CheckboxGroup',
+	title: 'CheckboxGroup',
 	component: CheckboxGroup,
 	subcomponents: { Checkbox },
 	argTypes: {},

--- a/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
@@ -7,7 +7,7 @@ import { CheckboxGroup } from './CheckboxGroup';
 import { checkboxThemeBrand } from './theme';
 
 export default {
-	title: 'Packages/source-react-components/CheckboxGroup',
+	title: 'source-react-components/CheckboxGroup',
 	component: CheckboxGroup,
 	subcomponents: { Checkbox },
 	argTypes: {},

--- a/libs/@guardian/source-react-components/src/choice-card/ChoiceCard.stories.tsx
+++ b/libs/@guardian/source-react-components/src/choice-card/ChoiceCard.stories.tsx
@@ -4,7 +4,7 @@ import { ChoiceCard } from './ChoiceCard';
 import type { ChoiceCardProps } from './ChoiceCard';
 
 export default {
-	title: 'Packages/source-react-components/ChoiceCard',
+	title: 'source-react-components/ChoiceCard',
 	component: ChoiceCard,
 	args: {
 		id: 'option-1-id',

--- a/libs/@guardian/source-react-components/src/choice-card/ChoiceCard.stories.tsx
+++ b/libs/@guardian/source-react-components/src/choice-card/ChoiceCard.stories.tsx
@@ -4,7 +4,7 @@ import { ChoiceCard } from './ChoiceCard';
 import type { ChoiceCardProps } from './ChoiceCard';
 
 export default {
-	title: 'source-react-components/ChoiceCard',
+	title: 'ChoiceCard',
 	component: ChoiceCard,
 	args: {
 		id: 'option-1-id',

--- a/libs/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.stories.tsx
@@ -7,7 +7,7 @@ import { ChoiceCardGroup } from './ChoiceCardGroup';
 import type { ChoiceCardGroupProps } from './ChoiceCardGroup';
 
 export default {
-	title: 'source-react-components/ChoiceCardGroup',
+	title: 'ChoiceCardGroup',
 	component: ChoiceCardGroup,
 	subcomponents: { ChoiceCard },
 	args: {

--- a/libs/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.stories.tsx
@@ -7,7 +7,7 @@ import { ChoiceCardGroup } from './ChoiceCardGroup';
 import type { ChoiceCardGroupProps } from './ChoiceCardGroup';
 
 export default {
-	title: 'Packages/source-react-components/ChoiceCardGroup',
+	title: 'source-react-components/ChoiceCardGroup',
 	component: ChoiceCardGroup,
 	subcomponents: { ChoiceCard },
 	args: {

--- a/libs/@guardian/source-react-components/src/columns/Columns.stories.tsx
+++ b/libs/@guardian/source-react-components/src/columns/Columns.stories.tsx
@@ -12,7 +12,7 @@ const Code = (args: HTMLAttributes<HTMLElement>) => (
 );
 
 export default {
-	title: 'Packages/source-react-components/Columns',
+	title: 'source-react-components/Columns',
 	component: Columns,
 	subcomponents: { Column },
 };

--- a/libs/@guardian/source-react-components/src/columns/Columns.stories.tsx
+++ b/libs/@guardian/source-react-components/src/columns/Columns.stories.tsx
@@ -12,7 +12,7 @@ const Code = (args: HTMLAttributes<HTMLElement>) => (
 );
 
 export default {
-	title: 'source-react-components/Columns',
+	title: 'Columns',
 	component: Columns,
 	subcomponents: { Column },
 };

--- a/libs/@guardian/source-react-components/src/container/Container.stories.tsx
+++ b/libs/@guardian/source-react-components/src/container/Container.stories.tsx
@@ -3,7 +3,7 @@ import type { ContainerProps } from './Container';
 import { Container } from './Container';
 
 export default {
-	title: 'source-react-components/Container',
+	title: 'Container',
 	component: Container,
 	argTypes: {
 		border: {

--- a/libs/@guardian/source-react-components/src/container/Container.stories.tsx
+++ b/libs/@guardian/source-react-components/src/container/Container.stories.tsx
@@ -3,7 +3,7 @@ import type { ContainerProps } from './Container';
 import { Container } from './Container';
 
 export default {
-	title: 'Packages/source-react-components/Container',
+	title: 'source-react-components/Container',
 	component: Container,
 	argTypes: {
 		border: {

--- a/libs/@guardian/source-react-components/src/footer/BackToTop.stories.tsx
+++ b/libs/@guardian/source-react-components/src/footer/BackToTop.stories.tsx
@@ -3,7 +3,7 @@ import { BackToTop } from './BackToTop';
 
 export default {
 	component: BackToTop,
-	title: 'Packages/source-react-components/BackToTop',
+	title: 'source-react-components/BackToTop',
 };
 
 const Template: Story = () => BackToTop;

--- a/libs/@guardian/source-react-components/src/footer/BackToTop.stories.tsx
+++ b/libs/@guardian/source-react-components/src/footer/BackToTop.stories.tsx
@@ -3,7 +3,7 @@ import { BackToTop } from './BackToTop';
 
 export default {
 	component: BackToTop,
-	title: 'source-react-components/BackToTop',
+	title: 'BackToTop',
 };
 
 const Template: Story = () => BackToTop;

--- a/libs/@guardian/source-react-components/src/footer/Footer.stories.tsx
+++ b/libs/@guardian/source-react-components/src/footer/Footer.stories.tsx
@@ -5,7 +5,7 @@ import { Footer } from './Footer';
 
 export default {
 	component: Footer,
-	title: 'source-react-components/Footer',
+	title: 'Footer',
 	argTypes: {
 		children: {
 			options: ['with', 'without'],

--- a/libs/@guardian/source-react-components/src/footer/Footer.stories.tsx
+++ b/libs/@guardian/source-react-components/src/footer/Footer.stories.tsx
@@ -5,7 +5,7 @@ import { Footer } from './Footer';
 
 export default {
 	component: Footer,
-	title: 'Packages/source-react-components/Footer',
+	title: 'source-react-components/Footer',
 	argTypes: {
 		children: {
 			options: ['with', 'without'],

--- a/libs/@guardian/source-react-components/src/hide/Hide.stories.tsx
+++ b/libs/@guardian/source-react-components/src/hide/Hide.stories.tsx
@@ -4,7 +4,7 @@ import type { HideProps } from './Hide';
 import { Hide } from './Hide';
 
 export default {
-	title: 'source-react-components/Hide',
+	title: 'Hide',
 	component: Hide,
 	argTypes: {
 		above: {

--- a/libs/@guardian/source-react-components/src/hide/Hide.stories.tsx
+++ b/libs/@guardian/source-react-components/src/hide/Hide.stories.tsx
@@ -4,7 +4,7 @@ import type { HideProps } from './Hide';
 import { Hide } from './Hide';
 
 export default {
-	title: 'Packages/source-react-components/Hide',
+	title: 'source-react-components/Hide',
 	component: Hide,
 	argTypes: {
 		above: {

--- a/libs/@guardian/source-react-components/src/icons/Icons.stories.tsx
+++ b/libs/@guardian/source-react-components/src/icons/Icons.stories.tsx
@@ -240,7 +240,7 @@ const widePaymentIcons = {
 };
 
 export default {
-	title: 'source-react-components/Icons',
+	title: 'Icons',
 };
 
 // *****************************************************************************

--- a/libs/@guardian/source-react-components/src/icons/Icons.stories.tsx
+++ b/libs/@guardian/source-react-components/src/icons/Icons.stories.tsx
@@ -240,7 +240,7 @@ const widePaymentIcons = {
 };
 
 export default {
-	title: 'Packages/source-react-components/Icons',
+	title: 'source-react-components/Icons',
 };
 
 // *****************************************************************************

--- a/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
+++ b/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
@@ -3,7 +3,7 @@ import type { InlineProps } from './Inline';
 import { Inline } from './Inline';
 
 export default {
-	title: 'Packages/source-react-components/Inline',
+	title: 'source-react-components/Inline',
 	component: Inline,
 };
 

--- a/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
+++ b/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
@@ -3,7 +3,7 @@ import type { InlineProps } from './Inline';
 import { Inline } from './Inline';
 
 export default {
-	title: 'source-react-components/Inline',
+	title: 'Inline',
 	component: Inline,
 };
 

--- a/libs/@guardian/source-react-components/src/label/Label.stories.tsx
+++ b/libs/@guardian/source-react-components/src/label/Label.stories.tsx
@@ -6,7 +6,7 @@ import { labelThemeBrand } from './theme';
 import type { LabelProps } from './types';
 
 export default {
-	title: 'source-react-components/Label',
+	title: 'Label',
 	args: {
 		text: 'Email',
 		optional: false,

--- a/libs/@guardian/source-react-components/src/label/Label.stories.tsx
+++ b/libs/@guardian/source-react-components/src/label/Label.stories.tsx
@@ -6,7 +6,7 @@ import { labelThemeBrand } from './theme';
 import type { LabelProps } from './types';
 
 export default {
-	title: 'Packages/source-react-components/Label',
+	title: 'source-react-components/Label',
 	args: {
 		text: 'Email',
 		optional: false,

--- a/libs/@guardian/source-react-components/src/label/Legend.stories.tsx
+++ b/libs/@guardian/source-react-components/src/label/Legend.stories.tsx
@@ -6,7 +6,7 @@ import { labelThemeBrand } from './theme';
 import type { LegendProps } from './types';
 
 export default {
-	title: 'source-react-components/Legend',
+	title: 'Legend',
 	args: {
 		text: 'Email',
 		supporting: 'undefined',

--- a/libs/@guardian/source-react-components/src/label/Legend.stories.tsx
+++ b/libs/@guardian/source-react-components/src/label/Legend.stories.tsx
@@ -6,7 +6,7 @@ import { labelThemeBrand } from './theme';
 import type { LegendProps } from './types';
 
 export default {
-	title: 'Packages/source-react-components/Legend',
+	title: 'source-react-components/Legend',
 	args: {
 		text: 'Email',
 		supporting: 'undefined',

--- a/libs/@guardian/source-react-components/src/link/ButtonLink.stories.tsx
+++ b/libs/@guardian/source-react-components/src/link/ButtonLink.stories.tsx
@@ -4,7 +4,7 @@ import type { ButtonLinkProps } from './ButtonLink';
 import { ButtonLink } from './ButtonLink';
 
 export default {
-	title: 'source-react-components/ButtonLink',
+	title: 'ButtonLink',
 	component: ButtonLink,
 	args: {
 		priority: 'primary',

--- a/libs/@guardian/source-react-components/src/link/ButtonLink.stories.tsx
+++ b/libs/@guardian/source-react-components/src/link/ButtonLink.stories.tsx
@@ -4,7 +4,7 @@ import type { ButtonLinkProps } from './ButtonLink';
 import { ButtonLink } from './ButtonLink';
 
 export default {
-	title: 'Packages/source-react-components/ButtonLink',
+	title: 'source-react-components/ButtonLink',
 	component: ButtonLink,
 	args: {
 		priority: 'primary',

--- a/libs/@guardian/source-react-components/src/link/Link.stories.tsx
+++ b/libs/@guardian/source-react-components/src/link/Link.stories.tsx
@@ -7,7 +7,7 @@ import type { LinkProps } from './Link';
 import { linkThemeBrand, linkThemeBrandAlt } from './theme';
 
 export default {
-	title: 'Packages/source-react-components/Link',
+	title: 'source-react-components/Link',
 	component: Link,
 	args: {
 		priority: 'primary',

--- a/libs/@guardian/source-react-components/src/link/Link.stories.tsx
+++ b/libs/@guardian/source-react-components/src/link/Link.stories.tsx
@@ -7,7 +7,7 @@ import type { LinkProps } from './Link';
 import { linkThemeBrand, linkThemeBrandAlt } from './theme';
 
 export default {
-	title: 'source-react-components/Link',
+	title: 'Link',
 	component: Link,
 	args: {
 		priority: 'primary',

--- a/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
@@ -7,7 +7,7 @@ import { radioThemeBrand } from './theme';
 // import type { Args, Story } from '@storybook/react';
 
 export default {
-	title: 'source-react-components/Radio',
+	title: 'Radio',
 	component: Radio,
 	argTypes: {
 		label: {

--- a/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
@@ -7,7 +7,7 @@ import { radioThemeBrand } from './theme';
 // import type { Args, Story } from '@storybook/react';
 
 export default {
-	title: 'Packages/source-react-components/Radio',
+	title: 'source-react-components/Radio',
 	component: Radio,
 	argTypes: {
 		label: {

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
@@ -8,7 +8,7 @@ import { radioThemeBrand } from './theme';
 // import type { Args, Story } from '@storybook/react';
 
 export default {
-	title: 'source-react-components/RadioGroup',
+	title: 'RadioGroup',
 	component: RadioGroup,
 	subcomponents: { Radio },
 	args: {

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
@@ -8,7 +8,7 @@ import { radioThemeBrand } from './theme';
 // import type { Args, Story } from '@storybook/react';
 
 export default {
-	title: 'Packages/source-react-components/RadioGroup',
+	title: 'source-react-components/RadioGroup',
 	component: RadioGroup,
 	subcomponents: { Radio },
 	args: {

--- a/libs/@guardian/source-react-components/src/select/Select.stories.tsx
+++ b/libs/@guardian/source-react-components/src/select/Select.stories.tsx
@@ -4,7 +4,7 @@ import type { SelectProps } from './Select';
 import { Select } from './Select';
 
 export default {
-	title: 'Packages/source-react-components/Select',
+	title: 'source-react-components/Select',
 	component: Select,
 	subcomponents: { Option },
 	argTypes: {

--- a/libs/@guardian/source-react-components/src/select/Select.stories.tsx
+++ b/libs/@guardian/source-react-components/src/select/Select.stories.tsx
@@ -4,7 +4,7 @@ import type { SelectProps } from './Select';
 import { Select } from './Select';
 
 export default {
-	title: 'source-react-components/Select',
+	title: 'Select',
 	component: Select,
 	subcomponents: { Option },
 	argTypes: {

--- a/libs/@guardian/source-react-components/src/stack/Stack.stories.tsx
+++ b/libs/@guardian/source-react-components/src/stack/Stack.stories.tsx
@@ -3,7 +3,7 @@ import type { StackProps } from './Stack';
 import { Stack } from './Stack';
 
 export default {
-	title: 'source-react-components/Stack',
+	title: 'Stack',
 	component: Stack,
 };
 

--- a/libs/@guardian/source-react-components/src/stack/Stack.stories.tsx
+++ b/libs/@guardian/source-react-components/src/stack/Stack.stories.tsx
@@ -3,7 +3,7 @@ import type { StackProps } from './Stack';
 import { Stack } from './Stack';
 
 export default {
-	title: 'Packages/source-react-components/Stack',
+	title: 'source-react-components/Stack',
 	component: Stack,
 };
 

--- a/libs/@guardian/source-react-components/src/text-area/TextArea.stories.tsx
+++ b/libs/@guardian/source-react-components/src/text-area/TextArea.stories.tsx
@@ -4,7 +4,7 @@ import type { TextAreaProps } from './TextArea';
 import { TextArea } from './TextArea';
 
 export default {
-	title: 'source-react-components/TextArea',
+	title: 'TextArea',
 	component: TextArea,
 	argTypes: {
 		error: {

--- a/libs/@guardian/source-react-components/src/text-area/TextArea.stories.tsx
+++ b/libs/@guardian/source-react-components/src/text-area/TextArea.stories.tsx
@@ -4,7 +4,7 @@ import type { TextAreaProps } from './TextArea';
 import { TextArea } from './TextArea';
 
 export default {
-	title: 'Packages/source-react-components/TextArea',
+	title: 'source-react-components/TextArea',
 	component: TextArea,
 	argTypes: {
 		error: {

--- a/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
+++ b/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
@@ -4,7 +4,7 @@ import { TextInput } from './TextInput';
 import type { TextInputProps } from './TextInput';
 
 export default {
-	title: 'Packages/source-react-components/TextInput',
+	title: 'source-react-components/TextInput',
 	component: TextInput,
 	args: {
 		label: 'Email',

--- a/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
+++ b/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
@@ -4,7 +4,7 @@ import { TextInput } from './TextInput';
 import type { TextInputProps } from './TextInput';
 
 export default {
-	title: 'source-react-components/TextInput',
+	title: 'TextInput',
 	component: TextInput,
 	args: {
 		label: 'Email',

--- a/libs/@guardian/source-react-components/src/tiles/Tiles.stories.tsx
+++ b/libs/@guardian/source-react-components/src/tiles/Tiles.stories.tsx
@@ -4,7 +4,7 @@ import type { TilesProps } from './Tiles';
 import { Tiles } from './Tiles';
 
 export default {
-	title: 'source-react-components/Tiles',
+	title: 'Tiles',
 	component: Tiles,
 	args: {
 		columns: '2',

--- a/libs/@guardian/source-react-components/src/tiles/Tiles.stories.tsx
+++ b/libs/@guardian/source-react-components/src/tiles/Tiles.stories.tsx
@@ -4,7 +4,7 @@ import type { TilesProps } from './Tiles';
 import { Tiles } from './Tiles';
 
 export default {
-	title: 'Packages/source-react-components/Tiles',
+	title: 'source-react-components/Tiles',
 	component: Tiles,
 	args: {
 		columns: '2',

--- a/libs/@guardian/source-react-components/src/user-feedback/InlineError.stories.tsx
+++ b/libs/@guardian/source-react-components/src/user-feedback/InlineError.stories.tsx
@@ -5,7 +5,7 @@ import { userFeedbackThemeBrand } from './theme';
 import type { UserFeedbackProps } from './types';
 
 export default {
-	title: 'Packages/source-react-components/InlineError',
+	title: 'source-react-components/InlineError',
 	component: InlineError,
 };
 

--- a/libs/@guardian/source-react-components/src/user-feedback/InlineError.stories.tsx
+++ b/libs/@guardian/source-react-components/src/user-feedback/InlineError.stories.tsx
@@ -5,7 +5,7 @@ import { userFeedbackThemeBrand } from './theme';
 import type { UserFeedbackProps } from './types';
 
 export default {
-	title: 'source-react-components/InlineError',
+	title: 'InlineError',
 	component: InlineError,
 };
 

--- a/libs/@guardian/source-react-components/src/user-feedback/InlineSuccess.stories.tsx
+++ b/libs/@guardian/source-react-components/src/user-feedback/InlineSuccess.stories.tsx
@@ -4,7 +4,7 @@ import { userFeedbackThemeBrand } from './theme';
 import type { UserFeedbackProps } from './types';
 
 export default {
-	title: 'Packages/source-react-components/InlineSuccess',
+	title: 'source-react-components/InlineSuccess',
 	component: InlineSuccess,
 };
 

--- a/libs/@guardian/source-react-components/src/user-feedback/InlineSuccess.stories.tsx
+++ b/libs/@guardian/source-react-components/src/user-feedback/InlineSuccess.stories.tsx
@@ -4,7 +4,7 @@ import { userFeedbackThemeBrand } from './theme';
 import type { UserFeedbackProps } from './types';
 
 export default {
-	title: 'source-react-components/InlineSuccess',
+	title: 'InlineSuccess',
 	component: InlineSuccess,
 };
 


### PR DESCRIPTION
## What are you changing?

- We previously nested stories for Source under `Packages/[package name]/*` when they were part of a combined Storybook in the original repository. This changes that scheme so we don't nest and the available packages are shown by default in the composed csnx Storybook.

## Why?

- This will make it easier for users to see which components are available to them at a glance. (thanks @joecowton1 for the suggestion)

<img width="318" alt="Screenshot 2022-12-01 at 11 00 36" src="https://user-images.githubusercontent.com/1771189/205023963-b4903b20-e2c5-44b4-84fa-bc7656f66b62.png">

