### PR TITLE
remove eslint-config-prettier from eslint-config

### DIFF
--- a/libs/@guardian/eslint-config/index.js
+++ b/libs/@guardian/eslint-config/index.js
@@ -8,7 +8,6 @@ module.exports = {
 		'eslint:recommended',
 		'plugin:import/errors',
 		'plugin:import/warnings',
-		'prettier',
 	],
 	plugins: ['eslint-comments'],
 	rules: {

--- a/libs/@guardian/eslint-config/package.json
+++ b/libs/@guardian/eslint-config/package.json
@@ -4,7 +4,6 @@
 	"description": "ESLint config for Guardian JavaScript projects",
 	"main": "index.js",
 	"dependencies": {
-		"eslint-config-prettier": "8.5.0",
 		"eslint-plugin-eslint-comments": "3.2.0",
 		"eslint-plugin-import": "2.26.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,11 +154,9 @@ importers:
   libs/@guardian/eslint-config:
     specifiers:
       eslint: 8.0.0
-      eslint-config-prettier: 8.5.0
       eslint-plugin-eslint-comments: 3.2.0
       eslint-plugin-import: 2.26.0
     dependencies:
-      eslint-config-prettier: 8.5.0_eslint@8.0.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.0.0
       eslint-plugin-import: 2.26.0_eslint@8.0.0
     devDependencies:


### PR DESCRIPTION
## What are you changing?

- Removes `eslint-config-prettier` from `eslint-config`

## Why?

- I wanted to open a discussion around whether `eslint-config` should assume that the project will also be using `prettier`. `eslint-config-prettier` turns off some core `eslint` rules which some projects using `eslint-config` might want to keep.
