### PR TITLE
restrict `@guardian/core-web-vitals` peerdep on libs to `10.x`

### DIFF
--- a/.changeset/thin-books-tap.md
+++ b/.changeset/thin-books-tap.md
@@ -1,0 +1,5 @@
+---
+'@guardian/core-web-vitals': patch
+---
+
+peer dependency on `@guardian/libs` is now restricted to current major version (`^10.0.0`, rather than `<=10.0.0`)

--- a/libs/@guardian/core-web-vitals/package.json
+++ b/libs/@guardian/core-web-vitals/package.json
@@ -10,7 +10,7 @@
 		"web-vitals": "2.0.0"
 	},
 	"peerDependencies": {
-		"@guardian/libs": "<=10.0.0",
+		"@guardian/libs": "workspace:^",
 		"tslib": "workspace:^",
 		"web-vitals": "workspace:^"
 	},


### PR DESCRIPTION
## What are you changing?

- restrict `@guardian/core-web-vitals` peerdep on libs to `10.x`

## Why?

- it's too broad, it will allow potentially breaking versions of libs to be used without authors knowing
