### PR TITLE
Enable skipping of Nx cache in `make` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,25 +15,25 @@ storybooks: env
 .PHONY: test
 test: env
 	$(call log,"Running unit tests")
-	@corepack pnpm nx run-many --target=test --all=true --skip-nx-cache
+	@corepack pnpm nx run-many --target=test --all=true --skip-nx-cache=$(SKIP_NX_CACHE)
 
 # runs the e2e tests for all projects
 .PHONY: e2e
 e2e: env
 	$(call log,"Running e2e tests")
-	@corepack pnpm nx run-many --target=e2e --all=true --skip-nx-cache
+	@corepack pnpm nx run-many --target=e2e --all=true --skip-nx-cache=$(SKIP_NX_CACHE)
 
 # checks all projects for lint errors
 .PHONY: lint
 lint: install
 	$(call log,"Linting projects")
-	@corepack pnpm nx run-many --target=lint --all=true --skip-nx-cache
+	@corepack pnpm nx run-many --target=lint --all=true --skip-nx-cache=$(SKIP_NX_CACHE)
 
 # attemps to fix lint errors across all projects
 .PHONY: fix
 fix: install
 	$(call log,"Attempting to fix lint error in projects")
-	@corepack pnpm nx run-many --target=fix --all=true --skip-nx-cache
+	@corepack pnpm nx run-many --target=fix --all=true --skip-nx-cache=$(SKIP_NX_CACHE)
 
 # makes sure absolutely everything is working
 .PHONY: validate
@@ -51,13 +51,13 @@ clean: env
 .PHONY: build
 build: env clean
 	$(call log,"Building projects")
-	@corepack pnpm nx run-many --target=build --all=true --skip-nx-cache
+	@corepack pnpm nx run-many --target=build --all=true --skip-nx-cache=$(SKIP_NX_CACHE)
 
 # builds all storybooks
 .PHONY: build-storybooks
 build-storybooks: env
 	$(call log,"Building storybooks")
-	@corepack pnpm nx run-many --target=build-storybook --all=true --skip-nx-cache
+	@corepack pnpm nx run-many --target=build-storybook --all=true --skip-nx-cache=$(SKIP_NX_CACHE)
 
 ############################### MANAGING PACKAGES ##############################
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ This happens _per project_. So if you change `project-a` but not `project-b`, Nx
 
 This includes between development and CI, between machines, pulls etc.
 
+### Skipping the cache
+
+To force the tasks in the [`Makefile`](./Makefile) to skip the Nx cache, set `SKIP_NX_CACHE=true`, e.g.
+
+```sh
+SKIP_NX_CACHE=true make test
+```
+
 ## Troubleshooting
 
 ### Unable to commit


### PR DESCRIPTION
## What are you changing?

allow make targets to skip the Nx cache from the command line, e.g. 
```sh
$ SKIP_NX_CACHE=true make test
```

## Why?

- #230 added universal skipping of the Nx cache for all Nx processes triggered from the makefile, which means we don't get any of the benefits of Nx's computation caching
- this was probably inadvertent, but it highlights the need to be able to do this
