### PR TITLE
add age warning component to kitchen

### DIFF
--- a/.changeset/nervous-flies-sip.md
+++ b/.changeset/nervous-flies-sip.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': minor
+---
+
+Adding AgeWarning component in kitchen which inserts a yellow warning banner on the page showing how old the content is

--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.stories.tsx
@@ -31,3 +31,6 @@ emptyWarningPrefix.args = { age: '5 years', warningPrefix: '' };
 
 export const customWarningPrefix = Template.bind({});
 customWarningPrefix.args = { age: '5 years', warningPrefix: 'This book is ' };
+
+export const supportsDarkMode = Template.bind({});
+supportsDarkMode.args = { age: '10 years old', supportsDarkMode: true };

--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.stories.tsx
@@ -1,0 +1,33 @@
+import type { Story } from '@storybook/react';
+import type { AgeWarningProps } from './AgeWarning';
+import { AgeWarning } from './AgeWarning';
+
+export default {
+	component: AgeWarning,
+	title: 'AgeWarning',
+};
+
+const Template: Story<AgeWarningProps> = (args: AgeWarningProps) => (
+	<AgeWarning {...args} />
+);
+
+export const ageWarning = Template.bind({});
+ageWarning.args = { age: '10 years old' };
+
+export const smallWarning = Template.bind({});
+smallWarning.args = { age: '5 months old', size: 'small' };
+
+export const screenReaderVersion = Template.bind({});
+screenReaderVersion.args = {
+	age: '20 million years old',
+	isScreenReader: true,
+};
+
+export const missingOldText = Template.bind({});
+missingOldText.args = { age: '5 years' };
+
+export const emptyWarningPrefix = Template.bind({});
+emptyWarningPrefix.args = { age: '5 years', warningPrefix: '' };
+
+export const customWarningPrefix = Template.bind({});
+customWarningPrefix.args = { age: '5 years', warningPrefix: 'This book is ' };

--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
@@ -1,0 +1,77 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import {
+	from,
+	palette,
+	textSans,
+	visuallyHidden,
+} from '@guardian/source-foundations';
+import { darkModeCss } from './styles';
+
+export interface AgeWarningProps {
+	age: string;
+	isScreenReader?: boolean;
+	size?: 'small' | 'medium';
+	warningPrefix?: string;
+}
+
+const ageWarningStyles = (isSmall: boolean): SerializedStyles => css`
+	${isSmall ? textSans.xxsmall() : textSans.medium()};
+	color: ${palette.neutral[7]};
+	background-color: ${palette.brandAlt[400]};
+	display: inline-block;
+
+	> strong {
+		font-weight: bold;
+	}
+
+	padding: ${isSmall ? '3px 5px' : '6px 10px'};
+
+	${from.mobileLandscape} {
+		padding-left: ${isSmall ? '6px' : '12px'};
+	}
+
+	${from.leftCol} {
+		padding-left: ${isSmall ? '5px' : '10px'};
+	}
+
+	${darkModeCss`
+		background-color: ${palette.brandAlt[200]};
+    `}
+`;
+
+const ageWarningScreenReader = css`
+	${visuallyHidden};
+`;
+
+const prefixStyle = css`
+	padding-left: 2px;
+`;
+
+const ensureOldText = (age: string): string =>
+	age.endsWith('old') ? age : `${age} old`;
+
+export const AgeWarning = ({
+	age,
+	isScreenReader,
+	size = 'medium',
+	warningPrefix = 'This article is more than ',
+}: AgeWarningProps): EmotionJSX.Element => {
+	const isSmall = size === 'small';
+	const ageOld = ensureOldText(age);
+
+	if (isScreenReader) {
+		return <div css={ageWarningScreenReader}>{warningPrefix + age}</div>;
+	}
+
+	return (
+		<div css={ageWarningStyles(isSmall)} aria-hidden="true">
+			<svg width="11" height="11" viewBox="0 0 11 11">
+				<path d="M5.4 0C2.4 0 0 2.4 0 5.4s2.4 5.4 5.4 5.4 5.4-2.4 5.4-5.4S8.4 0 5.4 0zm3 6.8H4.7V1.7h.7L6 5.4l2.4.6v.8z"></path>
+			</svg>
+			<span css={prefixStyle}>{warningPrefix}</span>
+			<strong>{ageOld}</strong>
+		</div>
+	);
+};

--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
@@ -10,13 +10,32 @@ import {
 import { darkModeCss } from './styles';
 
 export interface AgeWarningProps {
+	/**
+	 * the age to be shown in the warning. e.g. 5 years
+	 */
 	age: string;
+	/**
+	 * hiding the warning from sight while still being available to screen readers.
+	 */
 	isScreenReader?: boolean;
+	/**
+	 * size of the yellow warning banner
+	 */
 	size?: 'small' | 'medium';
+	/**
+	 * the message to be shown before the age. default is 'This article is more than '
+	 */
 	warningPrefix?: string;
+	/**
+	 * use this if platform support dark mode
+	 */
+	supportsDarkMode: boolean;
 }
 
-const ageWarningStyles = (isSmall: boolean): SerializedStyles => css`
+const ageWarningStyles = (
+	isSmall: boolean,
+	supportsDarkMode: boolean,
+): SerializedStyles => css`
 	${isSmall ? textSans.xxsmall() : textSans.medium()};
 	color: ${palette.neutral[7]};
 	background-color: ${palette.brandAlt[400]};
@@ -36,7 +55,7 @@ const ageWarningStyles = (isSmall: boolean): SerializedStyles => css`
 		padding-left: ${isSmall ? '5px' : '10px'};
 	}
 
-	${darkModeCss`
+	${darkModeCss(supportsDarkMode)`
 		background-color: ${palette.brandAlt[200]};
     `}
 `;
@@ -57,6 +76,7 @@ export const AgeWarning = ({
 	isScreenReader,
 	size = 'medium',
 	warningPrefix = 'This article is more than ',
+	supportsDarkMode = false,
 }: AgeWarningProps): EmotionJSX.Element => {
 	const isSmall = size === 'small';
 	const ageOld = ensureOldText(age);
@@ -66,7 +86,7 @@ export const AgeWarning = ({
 	}
 
 	return (
-		<div css={ageWarningStyles(isSmall)} aria-hidden="true">
+		<div css={ageWarningStyles(isSmall, supportsDarkMode)} aria-hidden="true">
 			<svg width="11" height="11" viewBox="0 0 11 11">
 				<path d="M5.4 0C2.4 0 0 2.4 0 5.4s2.4 5.4 5.4 5.4 5.4-2.4 5.4-5.4S8.4 0 5.4 0zm3 6.8H4.7V1.7h.7L6 5.4l2.4.6v.8z"></path>
 			</svg>

--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
@@ -27,7 +27,7 @@ export interface AgeWarningProps {
 	 */
 	warningPrefix?: string;
 	/**
-	 * use this if platform support dark mode
+	 * use this if platform supports dark mode
 	 */
 	supportsDarkMode: boolean;
 }

--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/README.md
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/README.md
@@ -1,0 +1,25 @@
+# `AgeWarning`
+
+Inserts a yellow warning banner on the page showing how old the content is
+
+## Install
+
+```sh
+$ yarn add @guardian/source-react-components-development-kitchen
+```
+
+or
+
+```sh
+$ npm i @guardian/source-react-components-development-kitchen
+```
+
+## Use
+
+### API
+
+See [storybook](https://guardian.github.io/csnx/?path=/docs/source-react-components-development-kitchen_agewarning--age-warning)
+
+### How to use
+
+For context and visual guides relating to usage see the [Source Design System website](https://theguardian.design).

--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/styles.ts
@@ -1,0 +1,16 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+
+export const darkModeCss = (
+	styles: TemplateStringsArray,
+	...placeholders: string[]
+): SerializedStyles => {
+	const darkStyles = styles
+		.map((style, i) => `${style}${placeholders[i] ? placeholders[i] : ''}`)
+		.join('');
+	return css`
+		@media (prefers-color-scheme: dark) {
+			${darkStyles}
+		}
+	`;
+};

--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/styles.ts
@@ -1,16 +1,21 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 
-export const darkModeCss = (
-	styles: TemplateStringsArray,
-	...placeholders: string[]
-): SerializedStyles => {
-	const darkStyles = styles
-		.map((style, i) => `${style}${placeholders[i] ? placeholders[i] : ''}`)
-		.join('');
-	return css`
-		@media (prefers-color-scheme: dark) {
-			${darkStyles}
-		}
-	`;
-};
+export const darkModeCss =
+	(supportsDarkMode: boolean) =>
+	(styles: TemplateStringsArray, ...placeholders: string[]): SerializedStyles =>
+		supportsDarkMode
+			? css`
+					@media (prefers-color-scheme: dark) {
+						${styles
+							.map((style, i) => {
+								const placeholder = placeholders[i];
+								if (placeholder) {
+									return `${style}${placeholder ? placeholder : ''}`;
+								}
+								return style;
+							})
+							.join('')}
+					}
+			  `
+			: css``;


### PR DESCRIPTION
## What are you changing?
- This PR is adding the `AgeWarning` component which inserts a yellow warning banner on the page showing how old the content is. 
![image](https://user-images.githubusercontent.com/15894063/206146299-a84ee664-8ab1-4c8c-b6ee-1fdd022bf348.png)

supporting dark mode:
![image](https://user-images.githubusercontent.com/15894063/206146861-d61436bc-adec-42c5-b8e0-7f774f684d62.png)

Note: Although for the time being there's no  dark mode support in `csnx`, the `darkModeCss` function was added in the styles.ts for AgeWarning component to make it usable for the apps. Whenever we come up with a solid solution for dark mode, this component can also be updated accordingly. 



## Why?
- This component is used in DCR already. But because there's also a usecase for it in AR, we can probably benefit from adding it to kitchen
