### PR TITLE
patch: add age warning component in kitchen

### DIFF
--- a/.changeset/olive-mirrors-arrive.md
+++ b/.changeset/olive-mirrors-arrive.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Export AgeWarning component

--- a/libs/@guardian/source-react-components-development-kitchen/src/index.test.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/index.test.ts
@@ -3,6 +3,7 @@ import * as pkgExports from './index';
 // this makes sure no type exports have been removed
 // it won't catch that new ones have been added, but can anyone?
 export type {
+	AgeWarningProps,
 	EditorialButtonProps,
 	EditorialLinkButtonProps,
 	ExpandingWrapperProps,
@@ -22,6 +23,7 @@ export type {
 
 it('Should have exactly these exports', () => {
 	expect(Object.keys(pkgExports).sort()).toEqual([
+		'AgeWarning',
 		'DashedLines',
 		'Divider',
 		'DottedLines',

--- a/libs/@guardian/source-react-components-development-kitchen/src/index.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/index.ts
@@ -9,6 +9,9 @@ export type { EditorialLinkButtonProps } from './editorial-button/EditorialLinkB
 export { ExpandingWrapper } from './expanding-wrapper/ExpandingWrapper';
 export type { ExpandingWrapperProps } from './expanding-wrapper/ExpandingWrapper';
 
+export { AgeWarning } from './age-warning/AgeWarning';
+export type { AgeWarningProps } from './age-warning/AgeWarning';
+
 export { Lines } from './lines/Lines';
 export { SquigglyLines } from './lines/SquigglyLines';
 export { DashedLines } from './lines/DashedLines';


### PR DESCRIPTION
## What are you changing?
- A new AgeWarning Component was added in https://github.com/guardian/csnx/pull/286, but I missed adding the new component to the list of Exports so it was not available.

## Why?
- Exporting AgeWarning component
