### PR TITLE
Docs: Fix markdown for StarRating change

### DIFF
--- a/libs/@guardian/source-react-components-development-kitchen/CHANGELOG.md
+++ b/libs/@guardian/source-react-components-development-kitchen/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Major Changes
 
-- f83640ca: Visually hide StarRating's <figcaption> element
+- f83640ca: Visually hide StarRating's `<figcaption>` element
 
 ### Minor Changes
 


### PR DESCRIPTION
>**Note**
>I know that the changelog file is typically generated dynamically, but it looks to me as though it should be fine to commit manual edits as well? If not, any advice on how to edit this properly would be appreciated!

## What are you changing?

Adds backtick quotes around the `<figure>` tag in recent StarRating major change, so that it's recognised as text that should be included in a code block.


## Why?
There was an unquoted HTML tag in the changelog which Github was removing when it rendered HTML from markdown.

## Changeset

No changeset required for this change.
