### PR TITLE
Update any links to old Source GH pages

### DIFF
--- a/.changeset/selfish-news-leave.md
+++ b/.changeset/selfish-news-leave.md
@@ -1,0 +1,6 @@
+---
+'@guardian/eslint-plugin-source-foundations': patch
+'@guardian/eslint-plugin-source-react-components': patch
+---
+
+Links in `eslint-plugin-source-foundations` and `eslint-plugin-source-react-components` eslint documentation updated to point at the relevant readme instead of the archived Source repo.

--- a/libs/@guardian/eslint-plugin-source-foundations/src/rules/no-star-imports-or-exports.ts
+++ b/libs/@guardian/eslint-plugin-source-foundations/src/rules/no-star-imports-or-exports.ts
@@ -20,7 +20,7 @@ export const noStarImportsOrExports: Rule.RuleModule = {
 		docs: {
 			description: 'Disallow * imports and exports',
 			category: 'Possible Problems',
-			url: 'https://github.com/guardian/source',
+			url: 'https://github.com/guardian/csnx/tree/main/libs/@guardian/eslint-plugin-source-foundations/README.md',
 		},
 	},
 

--- a/libs/@guardian/eslint-plugin-source-foundations/src/rules/valid-import-path.ts
+++ b/libs/@guardian/eslint-plugin-source-foundations/src/rules/valid-import-path.ts
@@ -320,7 +320,7 @@ export const validFoundationsImportPath: Rule.RuleModule = {
 		docs: {
 			description: 'Get Source imports from v4 packages',
 			category: 'Deprecated',
-			url: 'https://github.com/guardian/source',
+			url: 'https://github.com/guardian/csnx/tree/main/libs/@guardian/eslint-plugin-source-foundations/README.md',
 		},
 		fixable: 'code',
 		schema: [],

--- a/libs/@guardian/eslint-plugin-source-react-components/src/rules/valid-import-path.ts
+++ b/libs/@guardian/eslint-plugin-source-react-components/src/rules/valid-import-path.ts
@@ -320,7 +320,7 @@ export const validImportPath: Rule.RuleModule = {
 		docs: {
 			description: 'Get Source imports from v4 packages',
 			category: 'Deprecated',
-			url: 'https://github.com/guardian/source',
+			url: 'https://github.com/guardian/csnx/tree/main/libs/@guardian/eslint-plugin-source-react-components/README.md',
 		},
 		fixable: 'code',
 		schema: [],


### PR DESCRIPTION
## What are you changing?

- Updates the eslint documentation for the `eslint-plugin-source-foundations` and `eslint-plugin-source-react-components` packages to point to their respective README.md files instead of the archived Source repository.

## Why?

- We'd like to move away from referencing the archived Source repo where possible

closes https://github.com/guardian/csnx/issues/298
