### PR TITLE
Enforce `no-explicit-any` in `@guardian/eslint-config-typescript`

### DIFF
--- a/.changeset/clean-glasses-dress.md
+++ b/.changeset/clean-glasses-dress.md
@@ -1,0 +1,5 @@
+---
+'@guardian/eslint-config-typescript': major
+---
+
+Explicit uses of `any` are now errors, not just warnings.

--- a/libs/@guardian/eslint-config-typescript/index.js
+++ b/libs/@guardian/eslint-config-typescript/index.js
@@ -119,6 +119,10 @@ module.exports = {
 		// use `a?.b` instead of `a && a.b`
 		'@typescript-eslint/prefer-optional-chain': 2,
 
+		// by default this a `warn`, but we want to enforce it
+		// https://typescript-eslint.io/rules/no-explicit-any
+		'@typescript-eslint/no-explicit-any': 2,
+
 		// requires any function or method that returns a Promise to be marked async
 		// '@typescript-eslint/promise-function-async': 2,
 	},


### PR DESCRIPTION
## What are you changing?

- disallow explicit use of `any`

## Why?

- `any` is basically no type-checking at all, and we if we're going to use types, we should make sure we do (currently it's a warning)
