### PR TITLE
Code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,21 +2,18 @@
 
 # please add yourself in a PR
 
-<!-- CSNX repo config -->
 * @guardian/csnx
-[!libs/@guardian, !apps] @guardian/csnx
+!libs/@guardian/* @guardian/csnx
+!apps/* @guardian/csnx
 
-<!-- @guardian/atoms-rendering -->
 libs/@guardian/atoms-rendering/* @guardian/dotcom-platform @guardian/commercial-dev @guardian/client-side-infra
 
-<!-- Source packages -->
 libs/@guardian/source-foundations/* @guardian/source
 libs/@guardian/source-react-components/* @guardian/source
 libs/@guardian/source-react-components-development-kitchen/* @guardian/source
 libs/@guardian/eslint-plugin-source-foundations/* @guardian/source
 libs/@guardian/eslint-plugin-source-react-components/* @guardian/source
 
-<!-- CSTI packages -->
 libs/@guardian/tsconfig/* @guardian/client-side-infra
 libs/@guardian/prettier/* @guardian/client-side-infra
 libs/@guardian/libs/* @guardian/client-side-infra @guardian/apps-rendering @guardian/dotcom-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,8 @@
 # please add yourself in a PR
 
 * @guardian/csnx
-![apps, libs/@guardian] @guardian/csnx
 
-libs/@guardian/atoms-rendering/* @guardian/dotcom-platform @guardian/commercial-dev @guardian/client-side-infra
+libs/@guardian/atoms-rendering/* @guardian/commercial-dev @guardian/client-side-infra
 
 libs/@guardian/source-foundations/* @guardian/source
 libs/@guardian/source-react-components/* @guardian/source
@@ -15,9 +14,7 @@ libs/@guardian/eslint-plugin-source-react-components/* @guardian/source
 
 libs/@guardian/tsconfig/* @guardian/client-side-infra
 libs/@guardian/prettier/* @guardian/client-side-infra
-libs/@guardian/libs/* @guardian/client-side-infra @guardian/apps-rendering @guardian/dotcom-platform
 libs/@guardian/eslint-config/* @guardian/client-side-infra
 libs/@guardian/eslint-config-typescript/* @guardian/client-side-infra
 libs/@guardian/browserlist-config/*  @guardian/client-side-infra @guardian/dotcom-platform
-
-
+libs/@guardian/libs/* @guardian/client-side-infra @guardian/apps-rendering @guardian/dotcom-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # please add yourself in a PR
 
 * @guardian/csnx
-![apps/*, libs/@guardian] @guardian/csnx
+![apps, libs/@guardian] @guardian/csnx
 
 libs/@guardian/atoms-rendering/* @guardian/dotcom-platform @guardian/commercial-dev @guardian/client-side-infra
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,7 @@
 # please add yourself in a PR
 
 * @guardian/csnx
-!libs/@guardian/* @guardian/csnx
-!apps/* @guardian/csnx
+![apps/*, libs/@guardian] @guardian/csnx
 
 libs/@guardian/atoms-rendering/* @guardian/dotcom-platform @guardian/commercial-dev @guardian/client-side-infra
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,27 @@
 # if you would like to be notified about changes in particular part of this repo,
+
 # please add yourself in a PR
 
-* @guardian/client-side-infra
+<!-- CSNX repo config -->
+* @guardian/csnx
+[!libs/@guardian, !apps] @guardian/csnx
 
-libs/@guardian/libs/src/coreWebVitals/* @guardian/dotcom-platform @guardian/commercial-dev
+<!-- @guardian/atoms-rendering -->
+libs/@guardian/atoms-rendering/* @guardian/dotcom-platform @guardian/commercial-dev @guardian/client-side-infra
 
-libs/@guardian/libs/src/format/* @guardian/apps-rendering @guardian/dotcom-platform
+<!-- Source packages -->
+libs/@guardian/source-foundations/* @guardian/source
+libs/@guardian/source-react-components/* @guardian/source
+libs/@guardian/source-react-components-development-kitchen/* @guardian/source
+libs/@guardian/eslint-plugin-source-foundations/* @guardian/source
+libs/@guardian/eslint-plugin-source-react-components/* @guardian/source
+
+<!-- CSTI packages -->
+libs/@guardian/tsconfig/* @guardian/client-side-infra
+libs/@guardian/prettier/* @guardian/client-side-infra
+libs/@guardian/libs/* @guardian/client-side-infra @guardian/apps-rendering @guardian/dotcom-platform
+libs/@guardian/eslint-config/* @guardian/client-side-infra
+libs/@guardian/eslint-config-typescript/* @guardian/client-side-infra
+libs/@guardian/browserlist-config/*  @guardian/client-side-infra @guardian/dotcom-platform
+
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 
 * @guardian/csnx
 
-libs/@guardian/atoms-rendering/* @guardian/commercial-dev @guardian/client-side-infra
+libs/@guardian/atoms-rendering/* @guardian/dotcom-platform @guardian/commercial-dev @guardian/client-side-infra
 
 libs/@guardian/source-foundations/* @guardian/source
 libs/@guardian/source-react-components/* @guardian/source


### PR DESCRIPTION
## What are you changing?

- adding specific code owners for project directories.

## Why?

- we're currently both unspecific and low on reviewers.

We've added two new teams `@guardian/source` (to review Source repos) and `@guardian/csnx` (to review CSNX config).
