### PR TITLE
Add data-ignore attribute to KnowledgeQuiz atoms <ol> to avoid duplicate list numbers 

### DIFF
--- a/.changeset/shaggy-ways-love.md
+++ b/.changeset/shaggy-ways-love.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Adding data-ignore attribute to KnowledgeQuiz atom ordered lists to remove duplicate list numbers

--- a/.changeset/spotty-wasps-leave.md
+++ b/.changeset/spotty-wasps-leave.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': minor
+---
+
+Added css override to KnowledgeQuiz atom to avoid duplicate list numbers

--- a/.changeset/spotty-wasps-leave.md
+++ b/.changeset/spotty-wasps-leave.md
@@ -1,5 +1,0 @@
----
-'@guardian/atoms-rendering': minor
----
-
-Added css override to KnowledgeQuiz atom to avoid duplicate list numbers

--- a/libs/@guardian/atoms-rendering/src/KnowledgeQuiz.tsx
+++ b/libs/@guardian/atoms-rendering/src/KnowledgeQuiz.tsx
@@ -82,7 +82,7 @@ export const KnowledgeQuizAtom = ({
 					/>
 				</div>
 			)}
-			<ol>
+			<ol data-ignore="global-ol-styling">
 				{questions.map((question, idx) => (
 					<Question
 						key={question.id}
@@ -149,9 +149,6 @@ export const Question = ({
 		<li
 			css={css`
 				${theme === ArticleSpecial.Labs ? textSans.medium() : body.medium()};
-				::before {
-					content: none !important;
-				}
 			`}
 		>
 			<fieldset css={fieldsetStyle}>

--- a/libs/@guardian/atoms-rendering/src/KnowledgeQuiz.tsx
+++ b/libs/@guardian/atoms-rendering/src/KnowledgeQuiz.tsx
@@ -149,6 +149,9 @@ export const Question = ({
 		<li
 			css={css`
 				${theme === ArticleSpecial.Labs ? textSans.medium() : body.medium()};
+				::before {
+					content: none !important;
+				}
 			`}
 		>
 			<fieldset css={fieldsetStyle}>


### PR DESCRIPTION
## What are you changing?

Knowledge quizzes are currently showing a duplicated number before the question:

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/102960844/212055099-89394b5c-42a6-49fc-b04c-5be3f06d0faa.png">

This css change removes it in when the atom gets rendered by DCR (the change should only affect atoms in the context of DCR; if there are any other consumers of the package then they shouldn't see any difference in behaviour from this update.

<img width="1328" alt="image" src="https://user-images.githubusercontent.com/102960844/212140911-ec9e980d-3b77-4d8f-9efc-cb0c68691e54.png">

Paired with @bryophyta and @ioannakok on this - the issue is caused by css defined in DCR, which raised the question of whether this issue could be solved through changes in that repo, e.g. telling DCR to not apply its global css stylings to atoms imported from atoms-rendering. However, this requires a larger conversation with the Web Experience team; hence this simple change to solve the problem now, until we can have that discussion. 