### PR TITLE
Feat: extend article design types to include Profile and Timeline

### DIFF
--- a/.changeset/violet-shirts-serve.md
+++ b/.changeset/violet-shirts-serve.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Extends format's articleDesign type to include `Profile` and `Timeline`

--- a/libs/@guardian/libs/src/format/ArticleDesign.ts
+++ b/libs/@guardian/libs/src/format/ArticleDesign.ts
@@ -23,4 +23,6 @@ export enum ArticleDesign {
 	Correction,
 	FullPageInteractive,
 	NewsletterSignup,
+	Timeline,
+	Profile,
 }


### PR DESCRIPTION
## What are you changing?
This PR extends the `ArticleDesign` type to include `Profile` and `Timeline`

## Why?
This change is due to an editorial desire to separate profile and timeline articles from the standard design, allow for specific styling of these articles
