### PR TITLE
Enforce sequencing of builds

### DIFF
--- a/libs/@guardian/source-react-components-development-kitchen/package.json
+++ b/libs/@guardian/source-react-components-development-kitchen/package.json
@@ -5,6 +5,7 @@
 	"devDependencies": {
 		"@babel/core": "7.20.5",
 		"@emotion/react": "11.0.0",
+		"@guardian/ab-react": "workspace:*",
 		"@guardian/libs": "9.0.0",
 		"@guardian/source-foundations": "7.0.0",
 		"@guardian/source-react-components": "9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,6 +388,7 @@ importers:
     specifiers:
       '@babel/core': 7.20.5
       '@emotion/react': 11.0.0
+      '@guardian/ab-react': workspace:*
       '@guardian/libs': 9.0.0
       '@guardian/source-foundations': 7.0.0
       '@guardian/source-react-components': 9.0.0
@@ -399,6 +400,7 @@ importers:
     devDependencies:
       '@babel/core': 7.20.5
       '@emotion/react': 11.0.0_6j7527pt6xlln2hks56p7acusi
+      '@guardian/ab-react': link:../ab-react
       '@guardian/libs': 9.0.0
       '@guardian/source-foundations': 7.0.0
       '@guardian/source-react-components': 9.0.0_okhws3igzik5hxyexclavuvnwa


### PR DESCRIPTION
## What are you changing?

- add a dependency to `@guardian/ab-react` in `@guardian/source-react-components-development-kitchen`

## Why?

- `@guardian/ab-react` has to be built before `@guardian/source-react-components-development-kitchen`, as the existence of the latter’s build output in the `dist/` folder generates the following error when building the former.
- https://github.com/guardian/csnx/pull/371#issuecomment-1396223148