### PR TITLE
Update background of GuideAtoms on Analysis articles

### DIFF
--- a/.changeset/chilled-icons-taste.md
+++ b/.changeset/chilled-icons-taste.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Analysis Guide Atoms should have a different background

--- a/libs/@guardian/atoms-rendering/src/GuideAtom.stories.tsx
+++ b/libs/@guardian/atoms-rendering/src/GuideAtom.stories.tsx
@@ -4,8 +4,10 @@ import {
 	lifestylePillarStoryExpanded,
 	listStoryExpanded,
 	orderedListStoryExpanded,
+	analysisStoryExpanded,
 } from './fixtures/guideAtom';
 import { GuideAtom } from './GuideAtom';
+import { css } from '@emotion/react';
 
 export default {
 	title: 'GuideAtom',
@@ -35,4 +37,19 @@ export const ImageStoryExpanded = (): JSX.Element => {
 export const LifestylePillarStoryExpanded = (): JSX.Element => {
 	//Modelled after: https://www.theguardian.com/money/2020/aug/07/energy-bills-to-be-cut-by-84-pounds-for-11m-uk-households-ofgem
 	return <GuideAtom {...lifestylePillarStoryExpanded} />;
+};
+
+export const AnalysisStoryExpanded = (): JSX.Element => {
+	// Modelled after: https://www.theguardian.com/football/2022/dec/11/gareth-southgate-england-world-cup-qatar
+	return (
+		<div
+			css={css`
+				background-color: #fff4f2;
+			`}
+		>
+			Analysis Articles have a different color background, so quick guide atoms
+			should too.
+			<GuideAtom {...analysisStoryExpanded} />
+		</div>
+	);
 };

--- a/libs/@guardian/atoms-rendering/src/GuideAtom.tsx
+++ b/libs/@guardian/atoms-rendering/src/GuideAtom.tsx
@@ -10,6 +10,7 @@ export const GuideAtom = ({
 	image,
 	html,
 	credit,
+	design,
 	pillar,
 	expandForStorybook,
 	likeHandler,
@@ -20,6 +21,7 @@ export const GuideAtom = ({
 		<Container
 			id={id}
 			title={title}
+			design={design}
 			pillar={pillar}
 			atomType="guide"
 			atomTypeTitle="Quick Guide"

--- a/libs/@guardian/atoms-rendering/src/expandableAtom/Container.tsx
+++ b/libs/@guardian/atoms-rendering/src/expandableAtom/Container.tsx
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
 import type { ArticleTheme } from '@guardian/libs';
+import { ArticleDesign } from '@guardian/libs';
 import { neutral, text } from '@guardian/source-foundations';
 import { Summary } from './Summary';
 
@@ -8,40 +10,46 @@ const containerStyling = css`
 	position: relative;
 `;
 
-const detailStyling = css`
-	margin: 16px 0 36px;
-	background: ${neutral[93]};
-	color: ${text.primary};
-	padding: 0 5px 6px;
-	border-image: repeating-linear-gradient(
-			to bottom,
-			${neutral[86]},
-			${neutral[86]} 1px,
-			transparent 1px,
-			transparent 4px
-		)
-		13;
-	border-top: 13px solid black;
-	position: relative;
-	summary {
-		list-style: none;
-		margin: 0 0 16px;
-	}
+export const detailStyling = (design?: ArticleDesign): SerializedStyles => {
+	// One off background colour for analysis articles
+	const background =
+		design === ArticleDesign.Analysis ? '#F2E8E6' : neutral[93];
+	return css`
+		margin: 16px 0 36px;
+		background: ${background};
+		color: ${text.primary};
+		padding: 0 5px 6px;
+		border-image: repeating-linear-gradient(
+				to bottom,
+				${neutral[86]},
+				${neutral[86]} 1px,
+				transparent 1px,
+				transparent 4px
+			)
+			13;
+		border-top: 13px solid black;
+		position: relative;
+		summary {
+			list-style: none;
+			margin: 0 0 16px;
+		}
 
-	/* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#Customizing_the_disclosure_widget */
-	summary::-webkit-details-marker {
-		display: none;
-	}
+		/* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#Customizing_the_disclosure_widget */
+		summary::-webkit-details-marker {
+			display: none;
+		}
 
-	summary:focus {
-		outline: none;
-	}
-`;
+		summary:focus {
+			outline: none;
+		}
+	`;
+};
 
 export const Container = ({
 	id,
 	title,
 	children,
+	design,
 	pillar,
 	expandForStorybook,
 	atomType,
@@ -50,6 +58,7 @@ export const Container = ({
 }: {
 	id: string;
 	title: string;
+	design?: ArticleDesign;
 	pillar: ArticleTheme;
 	expandForStorybook?: boolean;
 	atomType: string;
@@ -59,7 +68,7 @@ export const Container = ({
 }): JSX.Element => (
 	<div css={containerStyling} data-atom-id={id} data-atom-type={atomType}>
 		<details
-			css={detailStyling}
+			css={detailStyling(design)}
 			data-atom-id={id}
 			data-snippet-type={atomType}
 			open={expandForStorybook}

--- a/libs/@guardian/atoms-rendering/src/fixtures/guideAtom.tsx
+++ b/libs/@guardian/atoms-rendering/src/fixtures/guideAtom.tsx
@@ -1,3 +1,4 @@
+import { ArticleDesign } from '@guardian/libs';
 import { ArticlePillar } from '@guardian/libs';
 
 export const defaultStoryExpanded = {
@@ -72,6 +73,20 @@ export const lifestylePillarStoryExpanded = {
 	html: "<p>The cap, one of the biggest shake-ups of the energy market since privatisation,&nbsp;<a href='https://www.theguardian.com/business/2018/dec/31/millions-to-see-annual-energy-bills-drop-as-price-cap-takes-effect'>came into effect on 1 January 2019</a>&nbsp;for 11m households on default tariffs, known as standard variable tariffs (SVTs). The government told the energy regulator, Ofgem, to set the cap because ministers argued people on SVTs were being ripped off by big energy firms capitalising on consumer loyalty. The limit is not an absolute one but the maximum suppliers can charge per unit of energy and for a standing charge. There is a separate cap for 4m homes on prepayment meters.</p><p><b>Does that mean energy bills will never go up?</b></p><p>No. It is not <a href='https://www.theguardian.com/money/2017/apr/23/energy-prices-tory-cap-miliband-freeze'>a freeze</a>, it is a movable cap. The energy cap has fallen twice since it was put in place because the wholesale price of electricity and gas, the biggest variable influencing prices, have fallen. But if energy market prices climb higher, the cap would move higher, too. Homes may also face higher bills if they use more energy because the cap applies to the price of each unit of energy - not the whole bill.&nbsp;</p><p><b>Is there any way to avoid the increase?</b></p><p>Yes. Homes can save hundreds of pounds a year by spending a few minutes on one of the many comparison sites, or sign up to an <a href='https://www.theguardian.com/money/2019/feb/02/energy-bills-will-these-sites-save-you-a-flipping-fortune'>auto-switching service</a>, and move to a cheaper tariff, either with your existing supplier or a rival one. Fixed tariffs, which are not covered by the cap, are almost always much cheaper than SVTs, although <a href='https://www.theguardian.com/money/2018/oct/22/third-dual-fuel-tariffs-break-government-price-cap'>there are exceptions</a>, so watch out. Several smaller suppliers also offer good customer service and variable tariffs that are well below the cap.&nbsp;</p><p><b>Could bills fall again?</b></p><p>Maybe. Energy market experts believe gas and electricity wholesale prices will remain low through 2020 because energy demand is lower than normal because of the Covid-19 crisis. But wholesale costs are not the only factor in setting the level of the cap. Ofgem, the regulator, includes the cost of using energy networks and paying for government policies, too. These costs are expected to keep rising.&nbsp;</p>",
 	credit: '',
 	pillar: ArticlePillar.Lifestyle,
+	expandForStorybook: true,
+	likeHandler: (): null => null,
+	dislikeHandler: (): null => null,
+	expandCallback: (): null => null,
+};
+
+export const analysisStoryExpanded = {
+	id: 'a76d998e-d4b0-4d00-8afb-773eddb4064c',
+	title: 'Qatar: beyond the football',
+	html: '<p>It was a World Cup like no other. For the last 12 years the Guardian has been reporting on the issues surrounding Qatar 2022, from corruption and human rights abuses to the treatment of migrant workers and discriminatory laws. <br/> The best of our journalism is gathered on our dedicated <a href="https://www.theguardian.com/news/series/qatar-beyond-the-football">Qatar: Beyond the Football</a> home page for those who want to go deeper into the issues beyond the pitch. <br/> <br/> Guardian reporting goes far beyond what happens on the pitch. Support our investigative journalism today.</p>',
+	image:
+		'https://i.guim.co.uk/img/media/48be60e8b3371ffecc4f784e0411526ed9f3f3ba/1700_1199_1330_1331/1330.jpg?width=620&quality=85&auto=format&fit=max&s=8b3ad26c4ab238688c860e907b2cb116',
+	pillar: ArticlePillar.Sport,
+	design: ArticleDesign.Analysis,
 	expandForStorybook: true,
 	likeHandler: (): null => null,
 	dislikeHandler: (): null => null,

--- a/libs/@guardian/atoms-rendering/src/types.ts
+++ b/libs/@guardian/atoms-rendering/src/types.ts
@@ -1,5 +1,5 @@
 import type { CustomParams } from '@guardian/commercial-core';
-import type { ArticleTheme } from '@guardian/libs';
+import type { ArticleDesign, ArticleTheme } from '@guardian/libs';
 
 export type AdTargeting =
 	| {
@@ -44,6 +44,7 @@ export type GuideAtomType = {
 	likeHandler?: () => void;
 	dislikeHandler?: () => void;
 	expandCallback?: () => void;
+	design?: ArticleDesign;
 };
 
 export type InteractiveAtomBlockElementType = {


### PR DESCRIPTION

<!-- In this repo you can label a PR with the "PR Deployment" label to deploy the code to a publicly accessible url -->
## What does this change?
Updates the GuideAtom to optionally take a design, this is because Analysis articles have a light pink background, so we need to use a different Guide background for these pieces.

## Why?
The grey on pink background didn't look right so we had designs to update it.

## Screenshots

| Before      | After      |
|-------------|------------|
| (in article) <img width="706" alt="image" src="https://user-images.githubusercontent.com/26366706/213409344-c44dc6a0-6d14-4a2f-8c47-345984bf485d.png"> | (in storybook) <img width="1008" alt="image" src="https://user-images.githubusercontent.com/26366706/213409652-84cb7719-4ce5-4f4f-8495-f0ed78f4a45c.png"> |

