### PR TITLE
Prevent unnecessary throwing of SecurityError errors

### DIFF
--- a/libs/@guardian/libs/src/storage/storage.ts
+++ b/libs/@guardian/libs/src/storage/storage.ts
@@ -4,14 +4,13 @@ import { isString } from '../isString/isString';
 class StorageFactory {
 	#storage: Storage | undefined; // https://mdn.io/Private_class_fields
 
-	constructor(storage: Storage) {
+	constructor(storageHandler: 'localStorage' | 'sessionStorage') {
 		try {
+			const storage = window[storageHandler];
 			const uid = new Date().toString();
 			storage.setItem(uid, uid);
-
 			const available = storage.getItem(uid) == uid;
 			storage.removeItem(uid);
-
 			if (available) this.#storage = storage;
 		} catch (e) {
 			// do nothing
@@ -119,10 +118,10 @@ export const storage = new (class {
 	// when it's accessed i.e. we know we're going to use it
 
 	get local() {
-		return (this.#local ||= new StorageFactory(localStorage));
+		return (this.#local ||= new StorageFactory('localStorage'));
 	}
 
 	get session() {
-		return (this.#session ||= new StorageFactory(sessionStorage));
+		return (this.#session ||= new StorageFactory('sessionStorage'));
 	}
 })();


### PR DESCRIPTION
## Background

`SecurityError: The operation is insecure` and related promise rejection errors account for approx 20-30% of DCR Sentry errors.

The primary cause of this error is users or CSP disabling their browser's storage APIs.

For example in Safari the 'Block all cookies' setting also disables localStorage:

<img width="362" alt="Screenshot 2023-01-29 at 22 24 28" src="https://user-images.githubusercontent.com/7014230/215359677-628a0fa8-b70c-4ba2-acff-4e73644c262e.png">

When using localStorage it is good practice to check if it is supported _and_ available as per the docs:

https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#feature-detecting_localstorage

> Browsers that support localStorage have a property on the window object named localStorage. However, just asserting that the property exists may throw exceptions. If the localStorage object does exist, there is still no guarantee that the localStorage API is actually available, as various browsers offer settings that disable localStorage. So a browser may support localStorage, but not make it available to the scripts on the page.

## Problem

We seemingly guard against invalid access in `@guardian/libs/storage` with a try catch around the `StorageFactory` constructor:

https://github.com/guardian/csnx/blob/c1d3b115735bca8b6df87dcbdd95737eb3d4de6b/libs/%40guardian/libs/src/storage/storage.ts#L7-L19

⚠️ However even **attempting to reference** localStorage or sessionStorage can cause a `SecurityError` in some browsers (afaik Safari and Firefox):

https://github.com/magento/magento2/issues/13865
https://stackoverflow.com/questions/35042340/firefox-securityerror-the-operation-is-insecure

The current `@guardian/libs/storage` util does not handle this scenario and will throw a `SecurityError` as it attempts to pass localStorage or sessionStorage as a parameter to the `StorageFactory` constructor.

https://github.com/guardian/csnx/blob/c1d3b115735bca8b6df87dcbdd95737eb3d4de6b/libs/%40guardian/libs/src/storage/storage.ts#L121-L127

## This change 

By moving the reference to localStorage and sessionStorage into the `StorageFactory` constructor try-catch we can also catch `SecurityError` errors when the browser has disallowed access.

| Before      | After      |
|-------------|------------|
| Single page load - 18 SecurityErrors  | Single page load - 3 SecurityErrors |
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/7014230/215360149-a427ee97-501d-49de-8e79-8bc41065ad15.png
[after]: https://user-images.githubusercontent.com/7014230/215360157-801e8c4d-58a0-4f24-9e08-dc7f368bef60.png

There are still instances of the error from direct usage of localStorage but the majority of errors i.e. from `@guardian/libs/logger` should now be handled.

### Aside

Incidentally the `SecurityError` error we see in Sentry from `doHydration.tsx`:

`Unhandled Promise Rejection: SecurityError: The operation is insecure. doHydration.tsx:22`

... has nothing to do with hydration :) It is coming from the use of `@guardian/libs/logger` which internally uses `@guardian/libs/storage`:

https://github.com/guardian/dotcom-rendering/blob/f02bf6226bbfe024a578b1ce382d7928f21b9b2e/dotcom-rendering/src/web/browser/islands/doHydration.tsx#L77-L80

## Next steps

There are still instances of `SecurityError` in DCR caused by direct references to window.localStorage. All references to localStorage in DCR should be moved to use `@guardian/logs/storage` to make sure that exceptions are properly handled.

