### PR TITLE
`loadScript` rejects with an Error

### DIFF
--- a/.changeset/thirty-pianos-occur.md
+++ b/.changeset/thirty-pianos-occur.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': major
+---
+
+loadScript rejects with an Error

--- a/libs/@guardian/libs/src/loadScript/loadScript.test.ts
+++ b/libs/@guardian/libs/src/loadScript/loadScript.test.ts
@@ -75,6 +75,12 @@ describe('loadScript', () => {
 	});
 
 	it('rejects if the script fails to load', async () => {
-		await expect(loadScript(badURL)).rejects.toMatch(badURL);
+		expect.assertions(2);
+		try {
+			await loadScript(badURL);
+		} catch (error) {
+			expect(error instanceof Error).toEqual(true);
+			expect((error as Error).message).toEqual('Error loading script: bad-url');
+		}
 	});
 });

--- a/libs/@guardian/libs/src/loadScript/loadScript.ts
+++ b/libs/@guardian/libs/src/loadScript/loadScript.ts
@@ -35,26 +35,22 @@ export const loadScript = (
 		) => {
 			if (error) {
 				reject(error);
-
 				return;
 			}
 
 			if (typeof event === 'string') {
-				reject(`Error loading script: ${event}`);
-
+				reject(new Error(`Error loading script: ${event}`));
 				return;
 			}
 
 			if (event instanceof Event) {
 				const target = event.target as Element;
-				const src = target.getAttribute('src') ?? '';
-
-				reject(`Error loading script: ${src}`);
-
+				const targetSrc = target.getAttribute('src') ?? '';
+				reject(new Error(`Error loading script: ${targetSrc}`));
 				return;
 			}
 
-			reject(`Error loading script`);
+			reject(new Error(`Error loading script: ${src}`));
 		};
 
 		const ref = document.scripts[0];


### PR DESCRIPTION
## Background

The current most frequent error in Sentry, accounting for ~20% of DCR's errors is:

`Non-Error exception captured with keys: currentTarget, isTrusted, target, type`

This generic error is from Sentry complaining that it requires rejected promises to return a proper Error type:

https://github.com/getsentry/sentry-javascript/issues/2546#issuecomment-703331367

The errors look to be coming from `loadScript` given the serialised object reported by Sentry e.g.:

```js
{
  currentTarget: [object Null], 
  isTrusted: True, 
  target: head > script#ipsos[type="text/javascript"], 
  type: error
}
```

```js
{
  currentTarget: [object Null], 
  isTrusted: True, 
  target: head > script, 
  type: error
}
```

## This change

Updates promise rejections to return an Error type.

Changing the promise rejection won't reduce the errors but it will give us better insight into the errors reported by Sentry.

I suspect the underlying errors are the result of ad-blockers but we can't be sure without more detailed errors.

## Why?

To get better insight into high volume errors reported by Sentry
