### PR TITLE
Export `isNonNullable` from `@guardian/libs`

### DIFF
--- a/.changeset/young-bugs-learn.md
+++ b/.changeset/young-bugs-learn.md
@@ -2,4 +2,4 @@
 '@guardian/libs': minor
 ---
 
-Actaully export `isNonNullable`
+Actually export `isNonNullable`

--- a/.changeset/young-bugs-learn.md
+++ b/.changeset/young-bugs-learn.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Actaully export `isNonNullable`

--- a/libs/@guardian/libs/README.md
+++ b/libs/@guardian/libs/README.md
@@ -34,6 +34,10 @@ Get the active switches on theguardian.com.
 
 Check whether a value is a boolean.
 
+### [`isNonNullable`](./src/isNonNullable)
+
+Check whether a value is a [`NonNullable`](https://www.typescriptlang.org/docs/handbook/utility-types.html#nonnullabletype).
+
 ### [`isObject`](./src/isObject)
 
 Checks whether a value is a plain object (i.e. `{}`-like).

--- a/libs/@guardian/libs/src/index.test.ts
+++ b/libs/@guardian/libs/src/index.test.ts
@@ -15,6 +15,7 @@ describe('The package', () => {
 			'getLocale',
 			'getSwitches',
 			'isBoolean',
+			'isNonNullable',
 			'isObject',
 			'isString',
 			'isUndefined',

--- a/libs/@guardian/libs/src/index.ts
+++ b/libs/@guardian/libs/src/index.ts
@@ -22,6 +22,7 @@ export { ArticleSpecial } from './format/ArticleSpecial';
 export type { ArticleTheme } from './format/ArticleTheme';
 
 export { isBoolean } from './isBoolean/isBoolean';
+export { isNonNullable } from './isNonNullable/isNonNullable';
 export { isObject } from './isObject/isObject';
 export { isString } from './isString/isString';
 export { isUndefined } from './isUndefined/isUndefined';


### PR DESCRIPTION
## What are you changing?

- export `isNonNullable` from `@guardian/libs`

## Why?

- `isNonNullable` was added the source in #313 but wasn't exported
