### PR TITLE
Use `onXXX` method names from `web-vitals`

### DIFF
--- a/libs/@guardian/core-web-vitals/src/index.ts
+++ b/libs/@guardian/core-web-vitals/src/index.ts
@@ -87,13 +87,13 @@ const listener = (e: Event): void => {
 
 const getCoreWebVitals = async (): Promise<void> => {
 	const webVitals = await import('web-vitals');
-	const { getCLS, getFCP, getFID, getLCP, getTTFB } = webVitals;
+	const { onCLS, onFCP, onFID, onLCP, onTTFB } = webVitals;
 
-	getCLS(onReport, { reportAllChanges: false });
-	getFID(onReport);
-	getLCP(onReport);
-	getFCP(onReport);
-	getTTFB(onReport);
+	onCLS(onReport, { reportAllChanges: false });
+	onFID(onReport);
+	onLCP(onReport);
+	onFCP(onReport);
+	onTTFB(onReport);
 
 	// Report all available metrics when the page is unloaded or in background.
 	addEventListener('visibilitychange', listener);


### PR DESCRIPTION
## What are you changing?

- Update imports from `web-vitals`

## Why?

- The methods name have changed https://github.com/GoogleChrome/web-vitals/pull/222
