### PR TITLE
Add more metadata to `loadScript` errors

### DIFF
--- a/.changeset/two-shrimps-trade.md
+++ b/.changeset/two-shrimps-trade.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Add more metadata to loadScript errors

--- a/libs/@guardian/libs/src/loadScript/loadScript.test.ts
+++ b/libs/@guardian/libs/src/loadScript/loadScript.test.ts
@@ -80,7 +80,9 @@ describe('loadScript', () => {
 			await loadScript(badURL);
 		} catch (error) {
 			expect(error instanceof Error).toEqual(true);
-			expect((error as Error).message).toEqual('Error loading script: bad-url');
+			expect((error as Error).message).toEqual(
+				'Error loading script: src: bad-url targetSrc: bad-url',
+			);
 		}
 	});
 });

--- a/libs/@guardian/libs/src/loadScript/loadScript.ts
+++ b/libs/@guardian/libs/src/loadScript/loadScript.ts
@@ -39,18 +39,22 @@ export const loadScript = (
 			}
 
 			if (typeof event === 'string') {
-				reject(new Error(`Error loading script: ${event}`));
+				reject(new Error(`Error loading script: src: ${src} event: ${event}`));
 				return;
 			}
 
 			if (event instanceof Event) {
 				const target = event.target as Element;
 				const targetSrc = target.getAttribute('src') ?? '';
-				reject(new Error(`Error loading script: ${targetSrc}`));
+				reject(
+					new Error(
+						`Error loading script: src: ${src} targetSrc: ${targetSrc}`,
+					),
+				);
 				return;
 			}
 
-			reject(new Error(`Error loading script: ${src}`));
+			reject(new Error(`Error loading script: src: ${src}`));
 		};
 
 		const ref = document.scripts[0];


### PR DESCRIPTION
## What are you changing?

Small update to #391  to add more metadata to the error messages and to help distinguish them from each other.

I've seen that `targetSrc` can be undefined as I assume ad-blockers are removing them from the dom. However we still have reference to `src` from the closure so report that in all cases.

