### PR TITLE
Source - Include a changeset for the recent Tabs styling change

### DIFF
--- a/.changeset/healthy-apples-kick.md
+++ b/.changeset/healthy-apples-kick.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Updates the tab styling so that single tabs get 2 rounded corners

--- a/libs/@guardian/source-react-components-development-kitchen/src/tabs/Tabs.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/tabs/Tabs.stories.tsx
@@ -54,7 +54,6 @@ const tabs = (): ReactElement => {
 	);
 };
 const singleTab = (): ReactElement => {
-	// const [selectedTab, setSelectedTab] = useState('cat');
 	return (
 		<Tabs
 			tabsLabel="Pets"


### PR DESCRIPTION
## What are you changing?

This removes a comment, and also includes a changeset for the r[ecently merged tabs change](https://github.com/guardian/csnx/pull/398)
