### PR TITLE
Fix a dead link for Locale

### DIFF
--- a/libs/@guardian/libs/README.md
+++ b/libs/@guardian/libs/README.md
@@ -22,7 +22,7 @@ Country data and methods to access it.
 
 Codified editorial design and information architecture.
 
-### [Locale](./src/getLocale)
+### [Locale](./src/locale)
 
 Get the user’s current location.
 


### PR DESCRIPTION
## What are you changing?

- Link to Locale in `libs/@guardian/libs/README.md`.

## Why?

- The link is broken, `getLocale` folder doesn't exist.
