### PR TITLE
Add linkComponents to eslint settings

### DIFF
--- a/.changeset/ninety-dogs-thank.md
+++ b/.changeset/ninety-dogs-thank.md
@@ -1,0 +1,9 @@
+---
+'@guardian/eslint-plugin-source-react-components': major
+---
+
+Add linkComponents to settings
+
+eslint allows us to specify components which should be treated as 'link components' for linting purposes.
+In source-react-components, both Link and ButtonLink will apply props directly to an `<a>` tag. Listing them as link components allows rules like `jsx-no-target-blank` to identify them as links, and to lint their props accordingly.
+If you don't have any linting rules which look for link elements then this update should not cause any changes. If you do have rules like this then it is possible that new errors or warnings will be raised, but these will be identifying pre-existing issues in your code.

--- a/libs/@guardian/eslint-plugin-source-react-components/src/index.ts
+++ b/libs/@guardian/eslint-plugin-source-react-components/src/index.ts
@@ -7,9 +7,15 @@ export const rules = {
 export const configs = {
 	recommended: {
 		plugins: ['@guardian/source-react-components'],
-
 		rules: {
 			'@guardian/source-react-components/valid-import-path': 'error',
+		},
+		settings: {
+			linkComponents: [
+				// Components used as alternatives to <a> for linking, eg. <Link to={ url } />
+				{ name: 'LinkButton', linkAttribute: 'href' },
+				{ name: 'Link', linkAttribute: 'href' },
+			],
 		},
 	},
 };


### PR DESCRIPTION
## What are you changing?

Adding `Link` and `LinkButton` to the recommended eslint config for `source-react-components`.

## Why?

The `linkComponents` setting allows eslint rules to identify custom JSX elements which are being used as links.
For instance, adding this setting allows the
[`jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) rule to know that it should check both `<Link>` and `<LinkButton>` from Source components.

It felt like it might belong here (rather than in the DCR eslint config) because this is where the components are created and maintained (so the settings could be removed if the API for these components was changed). But I'd be happy to add it to DCR instead if the maintainers of source components would prefer.