### PR TITLE
Align ToggleSwitch perfectly

### DIFF
--- a/.changeset/early-panthers-help.md
+++ b/.changeset/early-panthers-help.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+`ToggleSwitch` is now perfectly aligned.

--- a/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import type { Props } from '../../../source-react-components/src/@types/Props';
 import {
 	buttonStyles,
+	buttonStylesMargin,
 	labelBorderStyles,
 	labelStyles,
 	toggleStyles,
@@ -126,7 +127,11 @@ export const ToggleSwitch = ({
 			{labelPosition === 'left' && label}
 			<button
 				id={buttonId}
-				css={[buttonStyles(labelPosition), toggleStyles(format)]}
+				css={[
+					buttonStyles,
+					buttonStylesMargin(labelPosition),
+					toggleStyles(format),
+				]}
 				role="switch"
 				aria-checked={isChecked()}
 				aria-labelledby={labelId}

--- a/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
@@ -71,7 +71,7 @@ export const toggleStyles = (format?: ArticleFormat): SerializedStyles => {
 			top: 5px;
 			height: 11px;
 			width: 6px;
-			right: 10px;
+			right: 8px;
 			opacity: 0;
 			border-bottom: 2px solid ${success[400]};
 			border-right: 2px solid ${success[400]};
@@ -84,7 +84,7 @@ export const toggleStyles = (format?: ArticleFormat): SerializedStyles => {
 			height: 18px;
 			width: 18px;
 			top: 2px;
-			left: 4px;
+			left: 2px;
 		}
 
 		&[aria-checked='false'] {

--- a/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
@@ -24,12 +24,10 @@ const toggleBorder = 'rgba(255, 255, 255, 0.6)';
  */
 const toggleBorderGreen = '#A7CFB8';
 
-export const buttonStyles = (
-	labelPosition: LabelPosition,
-): SerializedStyles => css`
+export const buttonStyles = css`
 	flex: none;
 	border: none;
-	margin: ${labelPosition === 'left' ? '0px 0px 0px 8px' : '0px 8px 0px 0px'};
+	margin: 0;
 	padding: 0;
 	display: inline-block;
 	text-align: center;
@@ -51,6 +49,21 @@ export const buttonStyles = (
 		visibility: visible;
 	}
 `;
+
+export const buttonStylesMargin = (
+	labelPosition: LabelPosition,
+): SerializedStyles => {
+	switch (labelPosition) {
+		case 'left':
+			return css`
+				margin-left: 8px;
+			`;
+		case 'right':
+			return css`
+				margin-right: 8px;
+			`;
+	}
+};
 
 export const toggleStyles = (format?: ArticleFormat): SerializedStyles => {
 	return css`


### PR DESCRIPTION
## What are you changing?

- `ToggleSwitch` alignment
   <img width="130" alt="image" src="https://user-images.githubusercontent.com/76776/217859642-7ac6921e-06b9-404f-b278-ccfad0588744.png">

- Extract out the dynamic part of styles

## Why?

- Things are more precisely aligned
- Styles are more performant when more static
