### PR TITLE
add optional param to checkboxGroup and radioGroup

### DIFF
--- a/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
@@ -75,6 +75,13 @@ SupportingTextDefaultTheme.args = {
 
 // *****************************************************************************
 
+export const OptionalDefaultTheme = Template.bind({});
+OptionalDefaultTheme.args = {
+	optional: true,
+};
+
+// *****************************************************************************
+
 export const SupportingTextBrandTheme = Template.bind({});
 SupportingTextBrandTheme.parameters = {
 	backgrounds: {

--- a/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.tsx
@@ -17,6 +17,10 @@ export interface CheckboxGroupProps extends Props {
 	 */
 	label?: string;
 	/**
+	 * Adds the word "Optional" after the label
+	 */
+	optional?: boolean;
+	/**
 	 * Appears as a legend at the top of the checkbox group
 	 */
 	hideLabel?: boolean;
@@ -47,6 +51,7 @@ export const CheckboxGroup = ({
 	id,
 	name,
 	label,
+	optional = false,
 	hideLabel,
 	supporting,
 	error,
@@ -56,7 +61,12 @@ export const CheckboxGroup = ({
 }: CheckboxGroupProps): EmotionJSX.Element => {
 	const groupId = id ?? generateSourceId();
 	const legend = label ? (
-		<Legend text={label} supporting={supporting} hideLabel={hideLabel} />
+		<Legend
+			text={label}
+			supporting={supporting}
+			hideLabel={hideLabel}
+			optional={optional}
+		/>
 	) : (
 		''
 	);

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
@@ -122,6 +122,13 @@ ErrorBrandTheme.parameters = {
 
 // *****************************************************************************
 
+export const OptionalDefaultTheme = Template.bind({});
+OptionalDefaultTheme.args = {
+	optional: true,
+};
+
+// *****************************************************************************
+
 export const SupportingMediaWithErrorDefaultTheme = Template.bind({});
 SupportingMediaWithErrorDefaultTheme.args = {
 	error: 'Please select a colour',

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.tsx
@@ -25,6 +25,10 @@ export interface RadioGroupProps
 	 */
 	hideLabel?: boolean;
 	/**
+	 * Adds the word "Optional" after the label
+	 */
+	optional?: boolean;
+	/**
 	 * Additional text or component that appears below the label
 	 */
 	supporting?: string | JSX.Element;
@@ -52,6 +56,7 @@ export const RadioGroup = ({
 	id,
 	name,
 	label,
+	optional = false,
 	hideLabel = false,
 	supporting,
 	orientation = 'vertical',
@@ -61,8 +66,15 @@ export const RadioGroup = ({
 	...props
 }: RadioGroupProps): EmotionJSX.Element => {
 	const groupId = id ?? generateSourceId();
+	console.log(`optional: ${optional.toString()}`);
+
 	const legend = label ? (
-		<Legend text={label} supporting={supporting} hideLabel={hideLabel} />
+		<Legend
+			text={label}
+			supporting={supporting}
+			hideLabel={hideLabel}
+			optional={optional}
+		/>
 	) : (
 		''
 	);
@@ -91,19 +103,21 @@ export const RadioGroup = ({
 	);
 
 	return (
-		<fieldset
-			aria-invalid={!!error}
-			id={groupId}
-			css={(theme: Theme) => [fieldset(theme.radio), cssOverrides]}
-			{...props}
-		>
-			{legend}
-			{message}
-			{orientation === 'vertical' ? (
-				<Stack>{radioContainers}</Stack>
-			) : (
-				<Inline space={5}>{radioContainers}</Inline>
-			)}
-		</fieldset>
+		<>
+			<fieldset
+				aria-invalid={!!error}
+				id={groupId}
+				css={(theme: Theme) => [fieldset(theme.radio), cssOverrides]}
+				{...props}
+			>
+				{legend}
+				{message}
+				{orientation === 'vertical' ? (
+					<Stack>{radioContainers}</Stack>
+				) : (
+					<Inline space={5}>{radioContainers}</Inline>
+				)}
+			</fieldset>
+		</>
 	);
 };


### PR DESCRIPTION
## What are you changing?
This PR adds `optional` param to the `CheckboxGroup` & `RadioGroup` elements
-

## Why?
These elements need to have the `Optional` next to their title if the consumer indicates that they are optional






| Before      |    After      | 
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/221812247-395a1bb9-65a1-4e01-a4d4-4739039d9308.png) | ![image](https://user-images.githubusercontent.com/15894063/221811526-26f118aa-4d4e-4953-98a4-633eb6266182.png) | 
| ![image](https://user-images.githubusercontent.com/15894063/221812181-1fc0cb2f-b695-4dde-bfce-45b160f7b450.png) | ![image](https://user-images.githubusercontent.com/15894063/221811593-bdb42013-0c39-42fe-a54a-b4bdb4d70511.png) | 