### PR TITLE
Marji/add optional to checkbox

### DIFF
--- a/.changeset/metal-days-sit.md
+++ b/.changeset/metal-days-sit.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': minor
+---
+
+Adds optional prop to CheckboxGroup element

--- a/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
@@ -75,6 +75,13 @@ SupportingTextDefaultTheme.args = {
 
 // *****************************************************************************
 
+export const OptionalDefaultTheme = Template.bind({});
+OptionalDefaultTheme.args = {
+	optional: true,
+};
+
+// *****************************************************************************
+
 export const SupportingTextBrandTheme = Template.bind({});
 SupportingTextBrandTheme.parameters = {
 	backgrounds: {

--- a/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.tsx
@@ -17,6 +17,10 @@ export interface CheckboxGroupProps extends Props {
 	 */
 	label?: string;
 	/**
+	 * Adds the word "Optional" after the label
+	 */
+	optional?: boolean;
+	/**
 	 * Appears as a legend at the top of the checkbox group
 	 */
 	hideLabel?: boolean;
@@ -48,6 +52,7 @@ export const CheckboxGroup = ({
 	name,
 	label,
 	hideLabel,
+	optional = false,
 	supporting,
 	error,
 	cssOverrides,
@@ -56,7 +61,12 @@ export const CheckboxGroup = ({
 }: CheckboxGroupProps): EmotionJSX.Element => {
 	const groupId = id ?? generateSourceId();
 	const legend = label ? (
-		<Legend text={label} supporting={supporting} hideLabel={hideLabel} />
+		<Legend
+			text={label}
+			supporting={supporting}
+			hideLabel={hideLabel}
+			optional={optional}
+		/>
 	) : (
 		''
 	);


### PR DESCRIPTION
## What are you changing?

This PR adds `optional` param to the `CheckboxGroup` element

## Why?


This element needs to have the `Optional` next to their title if the consumer indicates that they are optional


| Before      |    After      | 
|-------------|------------|
| ![image](https://user-images.githubusercontent.com/15894063/221812247-395a1bb9-65a1-4e01-a4d4-4739039d9308.png) | ![image](https://user-images.githubusercontent.com/15894063/221811526-26f118aa-4d4e-4953-98a4-633eb6266182.png) | 