### PR TITLE
Add some detail to the colour export deprecation notice

### DIFF
--- a/.changeset/thick-planets-teach.md
+++ b/.changeset/thick-planets-teach.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-foundations': patch
+---
+
+Indicate how to resolve the colour import deprecation notice

--- a/libs/@guardian/source-foundations/src/index.ts
+++ b/libs/@guardian/source-foundations/src/index.ts
@@ -19,7 +19,10 @@ export { between, from, until } from './mq/mq';
 // palette
 export { palette };
 
-/** @deprecated exports - to be removed in a future major version */
+/**
+ * @deprecated exports - to be removed in a future major version.
+ * Colours should now be imported from the `palette` object.
+ */
 export {
 	background,
 	brandBackground,
@@ -35,7 +38,10 @@ export {
 	brandAltText,
 } from './colour/palette';
 
-/** @deprecated exports - to be removed in a future major version */
+/**
+ * @deprecated exports - to be removed in a future major version.
+ * Colours should now be imported from the `palette` object.
+ */
 export const {
 	brand,
 	brandAlt,


### PR DESCRIPTION
## What are you changing?

- Adds some detail to the colour deprecation notice, pointing users to the `palette` object.

## Why?

- So that users know what to do to resolve the deprecation warning.

Prompted by @cemms1 earlier change to give deprecation feedback to users in https://github.com/guardian/csnx/pull/457 thanks!
