### PR TITLE
Refactor chromatic workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,36 +69,3 @@ jobs:
           exitOnceUploaded: true
           onlyChanged: '!(main)' # turbosnap on non-main branches
 
-  # This deploys the root-level storybook to GitHub Pages.
-  #
-  # It composes the individual project storybooks, which are built and deployed
-  # by AWS Amplify projects on commits to main branch.
-  #
-  # To add another project storybook, you need to add a new AWS Amplify project.
-  #
-  # See the existing projects (prefixed with "csnx/storybooks-") at
-  # https://eu-west-1.console.aws.amazon.com/amplify/home?region=eu-west-1 for
-  # examples of how to do this.
-  deploy-root-storybook:
-    needs: validate
-
-    # only runs on main branch
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      # enables use to use the cache in actions/setup-node
-      - uses: pnpm/action-setup@v2.2.4
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-
-      - name: Build root storybook
-        run: pnpm nx run csnx:build-storybook
-
-      - name: Deploy root storybook to github pages
-        run: pnpm storybook-to-ghpages --ci --existing-output-dir dist/storybook/apps/csnx
-        env:
-          GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # for chromatic to work
 
       # enables use to use the cache in actions/setup-node
       - uses: pnpm/action-setup@v2.2.4
@@ -30,41 +28,44 @@ jobs:
       - run: make e2e
       - run: make build-storybooks
 
-      # Kick chromatic off only once all other steps have passed. This stops us
-      # wasting money running checks on PRs that are going to fail anyway.
-      - name: Upload @guardian/atoms-rendering storybook to Chromatic
-        uses: chromaui/action@v1
+  chromatic:
+    # Kick chromatic off only once all other steps have passed. This stops us
+    # wasting money running checks on PRs that are going to fail anyway.
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lib:
+          [
+            'atoms-rendering',
+            'source-foundations',
+            'source-react-components',
+            'source-react-components-development-kitchen',
+          ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # for chromatic to work
+
+      # enables use to use the cache in actions/setup-node
+      - uses: pnpm/action-setup@v2.2.4
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      # This will just retrieve the output created in `validate` from Nx's build
+      # cache. It's simpler than using github actions cache.
+      - run: make build-storybooks
+
+      - uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_ATOMS_RENDERING_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          storybookBuildDir: 'dist/storybook/libs/@guardian/atoms-rendering'
-          exitOnceUploaded: true
-          onlyChanged: '!(main)' # turbosnap on non-main branches
-
-      - name: Upload @guardian/source-foundations storybook to Chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_SOURCE_FOUNDATIONS_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          storybookBuildDir: 'dist/storybook/libs/@guardian/source-foundations'
-          exitOnceUploaded: true
-          onlyChanged: '!(main)' # turbosnap on non-main branches
-
-      - name: Upload @guardian/source-react-components storybook to Chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_SOURCE_REACT_COMPONENTS_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          storybookBuildDir: 'dist/storybook/libs/@guardian/source-react-components'
-          exitOnceUploaded: true
-          onlyChanged: '!(main)' # turbosnap on non-main branches
-
-      - name: Upload @guardian/source-react-components-development-kitchen storybook to Chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_SOURCE_REACT_COMPONENTS_DEVELOPMENT_KITCHEN_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          storybookBuildDir: 'dist/storybook/libs/@guardian/source-react-components-development-kitchen'
+          storybookBuildDir: 'dist/storybook/libs/@guardian/${{ matrix.lib }}'
           exitOnceUploaded: true
           onlyChanged: '!(main)' # turbosnap on non-main branches
 
@@ -80,6 +81,8 @@ jobs:
   # examples of how to do this.
   deploy-root-storybook:
     needs: validate
+
+    # only runs on main branch
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,38 @@
+# This deploys the root-level storybook to GitHub Pages once CI has completed on main.
+#
+# It composes the individual project storybooks, which are built and deployed
+# by AWS Amplify projects on commits to main branch.
+#
+# To add another project storybook, you need to add a new AWS Amplify project.
+#
+# See the existing projects (prefixed with "csnx/storybooks-") at
+# https://eu-west-1.console.aws.amazon.com/amplify/home?region=eu-west-1 for
+# examples of how to do this.
+
+name: Storybook
+on:
+  workflow_run:
+    workflows: [CI]
+    branches: [main]
+    types: [completed]
+
+jobs:
+  on-success: # only run if CI is successful
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # enables use to use the cache in actions/setup-node
+      - uses: pnpm/action-setup@v2.2.4
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build root storybook
+        run: pnpm nx run csnx:build-storybook
+
+      - name: Deploy root storybook to github pages
+        run: pnpm storybook-to-ghpages --ci --existing-output-dir dist/storybook/apps/csnx
+        env:
+          GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -21,12 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       # enables use to use the cache in actions/setup-node
       - uses: pnpm/action-setup@v2.2.4
+
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+
       - run: pnpm install --frozen-lockfile
 
       - name: Build root storybook


### PR DESCRIPTION
## What are you changing?

- move github pages storybook deployment to its own workflow (triggered by successful CI workflow run, only on main)
- run the chromatic tests in a matrix

## Why?

- simplifies the workflow files
- the chromatic jobs can run in parallel

## Before 
`3m 23s` (made longer by the number of chromatic runs)

<img width="288" alt="image" src="https://user-images.githubusercontent.com/867233/223467203-fea1ebb8-c91f-4c20-8089-de6a4803cba4.png"/>

## After
`2m 59s` (only made longer by the longest chromatic run)

<img width="629" alt="image" src="https://user-images.githubusercontent.com/867233/223466993-df6b9432-594a-489a-83eb-75a5f03fc745.png"/>

