### PR TITLE
Add Chromatic label instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ To force the tasks in the [`Makefile`](./Makefile) to skip the Nx cache, set `SK
 SKIP_NX_CACHE=true make test
 ```
 
+### Chromatic
+
+To run Chromatic (for visual regression testing) on a PR, add the `run_chromatic` label to the PR in Github. The Chromatic tests are required to pass by CI, so this will _need_ to be done at least once before a PR is merged. We recommend you only add the label once you are happy with any changes made and have checked for visual regressions manually first.
+
 ## Troubleshooting
 
 ### Unable to commit


### PR DESCRIPTION
## What are you changing?

- adding instructions for the new `run_chromatic` label to the readme 

## Why?

- its not obvious that the label will need adding, and its the chromatic tests are required to pass before merging by CI
