### PR TITLE
JSDoc type-checking for @guardian/core-web-vitals

### DIFF
--- a/.changeset/cool-wolves-rule.md
+++ b/.changeset/cool-wolves-rule.md
@@ -1,0 +1,5 @@
+---
+'@guardian/core-web-vitals': patch
+---
+
+Pure JavaScript library with JSDoc type-check

--- a/libs/@guardian/core-web-vitals/project.json
+++ b/libs/@guardian/core-web-vitals/project.json
@@ -8,7 +8,7 @@
 			"executor": "@csnx/npm-package:build",
 			"outputs": ["{options.outputPath}"],
 			"options": {
-				"entry": "libs/@guardian/core-web-vitals/src/index.ts",
+				"entry": "libs/@guardian/core-web-vitals/src/index.js",
 				"tsConfig": "libs/@guardian/core-web-vitals/tsconfig.json",
 				"packageJson": "libs/@guardian/core-web-vitals/package.json",
 				"outputPath": "dist/libs/@guardian/core-web-vitals",

--- a/libs/@guardian/core-web-vitals/src/@types/CoreWebVitalsPayload.ts
+++ b/libs/@guardian/core-web-vitals/src/@types/CoreWebVitalsPayload.ts
@@ -1,9 +1,0 @@
-export type CoreWebVitalsPayload = {
-	page_view_id: string | null;
-	browser_id: string | null;
-	fid: null | number;
-	cls: null | number;
-	lcp: null | number;
-	fcp: null | number;
-	ttfb: null | number;
-};

--- a/libs/@guardian/core-web-vitals/src/index.js
+++ b/libs/@guardian/core-web-vitals/src/index.js
@@ -119,10 +119,10 @@ const getCoreWebVitals = async () => {
 
 /**
  * @typedef {object} InitCoreWebVitalsOptions
- * @property {boolean} isDev used to determine whether to use CODE or PROD endpoints.
- * @property {string | null} [browserId] identifies the browser. Usually available via `getCookie({ name: 'bwid' })`. Defaults to `null`
- * @property {string | null} [pageViewId] identifies the page view. Usually available on `guardian.config.ophan.pageViewId`. Defaults to `null`
- * @property {number} [sampling] sampling rate for sending data. Defaults to `0.01`.
+ * @property {boolean} isDev Used to determine whether to use CODE or PROD endpoints.
+ * @property {string | null} [browserId] Identifies the browser. Usually available via `getCookie({ name: 'bwid' })`. Defaults to `null`.
+ * @property {string | null} [pageViewId] Identifies the page view. Usually available on `guardian.config.ophan.pageViewId`. Defaults to `null`.
+ * @property {number} [sampling] Sampling rate for sending data. Defaults to `0.01`.
  * @property {import('@guardian/libs').TeamName} [team] Optional team to trigger a log event once metrics are queued.
  * */
 
@@ -182,7 +182,7 @@ export const initCoreWebVitals = async ({
 
 /**
  * A method to asynchronously send web vitals after initialization.
- * @param {import('@guardian/libs').TeamName} [team] - Optional team to trigger a log event once metrics are queued.
+ * @param {import('@guardian/libs').TeamName} [team] Optional team to trigger a log event once metrics are queued.
  * @returns {Promise<void>}
  */
 export const bypassCoreWebVitalsSampling = async (team) => {

--- a/libs/@guardian/core-web-vitals/src/index.test.ts
+++ b/libs/@guardian/core-web-vitals/src/index.test.ts
@@ -1,6 +1,6 @@
 import type { Metric, ReportHandler } from 'web-vitals';
-import type { CoreWebVitalsPayload } from './@types/CoreWebVitalsPayload';
-import { _, bypassCoreWebVitalsSampling, initCoreWebVitals } from './index';
+import type { CoreWebVitalsPayload } from './index.js';
+import { _, bypassCoreWebVitalsSampling, initCoreWebVitals } from './index.js';
 
 const { coreWebVitalsPayload, reset } = _;
 

--- a/libs/@guardian/core-web-vitals/src/roundWithDecimals.js
+++ b/libs/@guardian/core-web-vitals/src/roundWithDecimals.js
@@ -1,0 +1,8 @@
+/**
+ * @param {number} value
+ * @param {number} [precision] number of significant digits
+ */
+export const roundWithDecimals = (value, precision = 6) => {
+	const power = Math.pow(10, precision);
+	return Math.round(value * power) / power;
+};

--- a/libs/@guardian/core-web-vitals/src/roundWithDecimals.js
+++ b/libs/@guardian/core-web-vitals/src/roundWithDecimals.js
@@ -1,6 +1,6 @@
 /**
  * @param {number} value
- * @param {number} [precision] number of significant digits
+ * @param {number} [precision] The number of significant digits.
  */
 export const roundWithDecimals = (value, precision = 6) => {
 	const power = Math.pow(10, precision);

--- a/libs/@guardian/core-web-vitals/src/roundWithDecimals.ts
+++ b/libs/@guardian/core-web-vitals/src/roundWithDecimals.ts
@@ -1,4 +1,0 @@
-export const roundWithDecimals = (value: number, precision = 6): number => {
-	const power = Math.pow(10, precision);
-	return Math.round(value * power) / power;
-};

--- a/libs/@guardian/core-web-vitals/tsconfig.json
+++ b/libs/@guardian/core-web-vitals/tsconfig.json
@@ -2,6 +2,12 @@
 	"extends": "../../../tsconfig.base.json",
 	"files": ["../../../@types/window.d.ts"],
 	"include": ["."],
+	"compilerOptions": {
+		"noEmit": true,
+		"declaration": false,
+		"declarationMap": false,
+		"checkJs": true
+	},
 	"references": [
 		{
 			"path": "./tsconfig.spec.json"

--- a/tools/nx-plugins/npm-package/build/index.ts
+++ b/tools/nx-plugins/npm-package/build/index.ts
@@ -50,7 +50,7 @@ const getRollupConfig = (
 		output: {
 			dir: `${options.outputPath}/${format}`,
 			format,
-			sourcemap: true,
+			sourcemap: !compilerOptions.noEmit,
 			preserveModules: true,
 		},
 		plugins: [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,7 +20,7 @@
 				"libs/@guardian/atoms-rendering/src/index.ts"
 			],
 			"@guardian/core-web-vitals": [
-				"libs/@guardian/core-web-vitals/src/index.ts"
+				"libs/@guardian/core-web-vitals/src/index.js"
 			],
 			"@guardian/eslint-plugin-source-foundations": [
 				"libs/@guardian/eslint-plugin-source-foundations/src/index.ts"


### PR DESCRIPTION
## What are you changing?

- Convert `@guardian/core-web-vitals` to pure JavaScript
- Rely on [JSDoc comments for type-checking](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html)

## Why?

- Reduce the burden of using TypeScript for our library code.
- Faster builds
- Easier to introspect: no source maps, no declaration file, copy-and-paste anywhere, [jsdelivr-compatible](https://cdn.jsdelivr.net/gh/guardian/csnx@mxdvl/core-web-vitals-js/libs/%40guardian/core-web-vitals/src/index.js)
- Consumers will bundle the code again, [we already target ES2020](https://github.com/guardian/csnx/blob/96dad00147b631d22095dd70d48b69ecc55aad88/libs/%40guardian/libs/README.md#bundling) / [ES2018](https://github.com/guardian/csnx/blob/96dad00147b631d22095dd70d48b69ecc55aad88/tools/nx-plugins/npm-package/build/index.ts#L44-L47)
- Smaller than #497 


## Known issues

This goes against [our current recommendation](https://github.com/guardian/recommendations/blob/main/npm-packages.md#authoring):

> ### Authoring
> 
> Write your library in [TypeScript](https://www.typescriptlang.org).

However, this is an attempt at revisiting this recommendation.