### PR TITLE
Revert use of react jsx runtime instead of @emotion/react jsx runtime (#504

### DIFF
--- a/.changeset/thick-dancers-flash.md
+++ b/.changeset/thick-dancers-flash.md
@@ -1,0 +1,5 @@
+---
+'@guardian/ab-react': patch
+---
+
+Use `@emotion/react` jsx runtime instead of `react` jsx runtime

--- a/libs/@guardian/ab-react/package.json
+++ b/libs/@guardian/ab-react/package.json
@@ -6,6 +6,7 @@
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"devDependencies": {
+		"@emotion/react": "11.0.0",
 		"@guardian/ab-core": "4.0.0",
 		"@testing-library/react": "11.2.2",
 		"@types/react": "~17.0",

--- a/libs/@guardian/ab-react/tsconfig.json
+++ b/libs/@guardian/ab-react/tsconfig.json
@@ -1,8 +1,5 @@
 {
 	"extends": "../../../tsconfig.base.json",
-	"include": ["."],
-	"compilerOptions": {
-		"jsx": "react-jsx",
-		"jsxImportSource": "react"
-	}
+	"files": [],
+	"include": ["."]
 }

--- a/libs/@guardian/atoms-rendering/tsconfig.json
+++ b/libs/@guardian/atoms-rendering/tsconfig.json
@@ -1,9 +1,5 @@
 {
 	"extends": "../../../tsconfig.base.json",
-	"compilerOptions": {
-		"jsx": "react-jsx",
-		"jsxImportSource": "@emotion/react"
-	},
 	"files": ["../../../@types/window.d.ts"],
 	"include": [".", ".storybook/*"],
 	"references": [

--- a/libs/@guardian/source-react-components-development-kitchen/tsconfig.json
+++ b/libs/@guardian/source-react-components-development-kitchen/tsconfig.json
@@ -1,9 +1,5 @@
 {
 	"extends": "../../../tsconfig.base.json",
-	"compilerOptions": {
-		"jsx": "react-jsx",
-		"jsxImportSource": "@emotion/react"
-	},
 	"files": [],
 	"include": [".", "../../../@types/window.d.ts", ".storybook/*"],
 	"references": [

--- a/libs/@guardian/source-react-components/tsconfig.json
+++ b/libs/@guardian/source-react-components/tsconfig.json
@@ -1,9 +1,5 @@
 {
 	"extends": "../../../tsconfig.base.json",
-	"compilerOptions": {
-		"jsx": "react-jsx",
-		"jsxImportSource": "@emotion/react"
-	},
 	"files": [],
 	"include": [".", ".storybook/*"],
 	"references": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,7 @@ importers:
 
   libs/@guardian/ab-react:
     specifiers:
+      '@emotion/react': 11.0.0
       '@guardian/ab-core': 4.0.0
       '@testing-library/react': 11.2.2
       '@types/react': ~17.0
@@ -142,6 +143,7 @@ importers:
       tslib: 2.4.1
       typescript: 4.9.5
     devDependencies:
+      '@emotion/react': 11.0.0_wk7fohhuxwcjfgq2kdoh4ny7by
       '@guardian/ab-core': link:../ab-core
       '@testing-library/react': 11.2.2_sfoxds7t5ydpegc3knd667wn6m
       '@types/react': 17.0.1
@@ -3385,6 +3387,29 @@ packages:
       '@types/react': 17.0.1
       hoist-non-react-statics: 3.3.2
       react: 17.0.1
+    dev: true
+
+  /@emotion/react/11.0.0_wk7fohhuxwcjfgq2kdoh4ny7by:
+    resolution: {integrity: sha512-mMQOuJcCVHUHUKZMamCbNnuUEgEff1W1JL3/1jGXFN52Ik5R/2ccVb3FherYFkSJkkjkPC3dUfFSeisXVh9Spg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.20.6
+      '@emotion/cache': 11.10.3
+      '@emotion/serialize': 1.1.1
+      '@emotion/sheet': 1.2.0
+      '@emotion/utils': 1.2.0
+      '@emotion/weak-memoize': 0.2.5
+      '@types/react': 17.0.1
+      hoist-non-react-statics: 3.3.2
+      react: 17.0.2
     dev: true
 
   /@emotion/react/11.1.5_rnawoibddm4mr3vbowjsvrrtn4:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,8 @@
 		"forceConsistentCasingInFileNames": true,
 		"importHelpers": true,
 		"isolatedModules": true,
+		"jsx": "react-jsx",
+		"jsxImportSource": "@emotion/react",
 		"paths": {
 			"@csnx/eslint": ["tools/nx-plugins/eslint"],
 			"@csnx/hello-world": ["libs/@csnx/hello-world/src/index.ts"],


### PR DESCRIPTION
## What are you changing?

- reverting https://github.com/guardian/csnx/pull/489 

## Why?

We're seeing a strange bug where typescript errors in projects when you build a project that is not configured to handle JSX, even if that project contains no jsx itself. This seems related to imports in the dist folder. More details below.

We haven't been able to fix this bug and while CI on csnx passes due to caching, we don't want a footgun like this floating around in the background.  

***

From google chat thread:

Alex Sanders:

After thrashing this out with Mahesh Makani and Joe Cowton all afternoon and some further prodding, the issue seems to arise when:
- you build a project that is not configured to handle JSX 
- Nx doesn't have a cache result for that project (or you skip the cache)
- something in dist has a .d.ts that imports from @guardian/react-components (i.e. dev kitchen)

if you remove all import [whatevers] from "@guardian/source-react-components"; from dist/**/*.d.ts then everything seems fine hence this error

TS has found a declaration file that imports from a package that the paths config resolves to the react components source directory, and because the project is not set up handle jsx, it errors

what i don't know is why TS is worried about declaration files in `dist` at any point, let alone when building an unrelated project

