### PR TITLE
Group radio buttons in `Answers` story so they are selectable

### DIFF
--- a/libs/@guardian/atoms-rendering/src/Answers.stories.tsx
+++ b/libs/@guardian/atoms-rendering/src/Answers.stories.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ArticlePillar } from '@guardian/libs';
-import { Radio } from '@guardian/source-react-components';
+import { Radio, RadioGroup } from '@guardian/source-react-components';
 import {
 	CorrectSelectedAnswer,
 	IncorrectAnswer,
@@ -43,18 +43,14 @@ export const Answers = (): JSX.Element => (
 			theme={ArticlePillar.News}
 		/>
 		<div css={radioButtonWrapperStyles(ArticlePillar.News)}>
-			<Radio
-				value={'answer.text'}
-				label="Selectable unanswered answer"
-				onChange={(e) => console.log(e.target.value)}
-				checked={true}
-			/>
-			<Radio
-				value={'answer.text'}
-				label="Selectable unanswered answer"
-				onChange={(e) => console.log(e.target.value)}
-				checked={false}
-			/>
+			<RadioGroup name="answers">
+				<Radio
+					defaultChecked
+					value="answer one"
+					label="Selectable unanswered answer"
+				/>
+				<Radio value="answer two" label="Selectable unanswered answer" />
+			</RadioGroup>
 		</div>
 	</div>
 );


### PR DESCRIPTION
## What are you changing?

- Wraps the radio buttons in the `<Answers>` story with a `<RadioGroup>` so they are selectable.

## Why?

- The quiz radio buttons override the default Source radio button styles. Whilst reviewing changes to the form element border styles (#478) it was discovered that the examples in these stories were not selectable so that the different interaction states could not be tested.