### PR TITLE
Platform | Run Chromatic on main 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     # Kick chromatic off only once all other steps have passed. This stops us
     # wasting money running checks on PRs that are going to fail anyway.
     needs: validate
-    if: ${{ github.event.label.name == 'run_chromatic' }}
+    if: ${{ github.event.label.name == 'run_chromatic' ||  github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## What does this change?
- Right now the Chromatic job is skipped on the main branch because the conditional check for the `run_chromatic` label fails.
- This extends that conditional check to also be truthy if the branch is `main`
- Follow-on from #498 