### PR TITLE
Rerun Chromatic when changes made to PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [labeled, synchronize]
+    types: [opened, labeled, synchronize]
 
 jobs:
   validate:
@@ -33,7 +33,7 @@ jobs:
     # Kick chromatic off only once all other steps have passed. This stops us
     # wasting money running checks on PRs that are going to fail anyway.
     needs: validate
-    if: ${{ github.event.label.name == 'run_chromatic' ||  github.ref == 'refs/heads/main' }}
+    if: contains(github.event.pull_request.labels.*.name, 'run_chromatic') ||  github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## What are you changing?

- Reruns Chromatic when changes are made to a PR if `run_chromatic` label is present.

## Why?

- With the existing workflow (#498) Chromatic is only triggered when the label is first added. Subsequent pushes _do not_ trigger Chromatic without removing and adding the label again which adds friction.
 
