### PR TITLE
Fix labeler permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,9 @@ on:
 
 jobs:
   label-pr:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4


### PR DESCRIPTION
## What are you changing?

- fixing labeler permissions as per: https://github.com/guardian/dotcom-rendering/pull/7726

## Why?

- currently CI is broken
