### PR TITLE
Enforce healthy `package.json` files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Setup deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.33.2
+
+      - run: make package-health
       - run: make lint
       - run: make test
       - run: make build

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ lint: install
 	@corepack pnpm nx run-many --target=lint --all=true --skip-nx-cache=$(SKIP_NX_CACHE)
 	@node ./tools/scripts/check-packages-for-tslib.mjs
 
+# checks all package.json for health issues
+.PHONY: package-health
+package-health:
+	$(call log,"Checking all package.json are healthy")
+	@deno run --allow-read --allow-net ./tools/scripts/deno/package-health.ts
+
 # attemps to fix lint errors across all projects
 .PHONY: fix
 fix: install

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Tasks are defined in the [`Makefile`](./Makefile).
 - `make e2e` _runs the e2e tests for all projects_
 - `make fix` _attemps to fix lint errors across all projects_
 - `make lint` _checks all projects for lint errors_
+- `make package-health` _checks all package.json for health issues_
 - `make storybooks` _runs storybook for all projects in single instance_
 - `make test` _runs the unit tests for all projects_
 - `make validate` _makes sure absolutely everything is working_

--- a/libs/@guardian/atoms-rendering/package.json
+++ b/libs/@guardian/atoms-rendering/package.json
@@ -24,7 +24,8 @@
 		"@types/react-dom": "18.2.3",
 		"@types/testing-library__jest-dom": "5.14.5",
 		"@types/youtube": "0.0.46",
-		"eslint-plugin-react": "^7.29.4",
+		"eslint": "8.40.0",
+		"eslint-plugin-react": "7.29.4",
 		"lodash.debounce": "4.0.6",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
@@ -54,5 +55,10 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"known_issues": {
+		"@testing-library/jest-dom@5.16.5": [
+			"@types/testing-library__jest-dom@5.14.5"
+		]
 	}
 }

--- a/libs/@guardian/eslint-config/package.json
+++ b/libs/@guardian/eslint-config/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"eslint": "8.0.0",
-		"tslib": "^2.4.1"
+		"tslib": "2.4.1"
 	},
 	"peerDependencies": {
 		"eslint": "^8.0.0",

--- a/libs/@guardian/eslint-plugin-source-foundations/package.json
+++ b/libs/@guardian/eslint-plugin-source-foundations/package.json
@@ -27,5 +27,10 @@
 		"typescript": {
 			"optional": true
 		}
+	},
+	"known_issues": {
+		"eslint@8.0.0": [
+			"@types/eslint@8.4.6"
+		]
 	}
 }

--- a/libs/@guardian/eslint-plugin-source-react-components/package.json
+++ b/libs/@guardian/eslint-plugin-source-react-components/package.json
@@ -30,5 +30,10 @@
 		"typescript": {
 			"optional": true
 		}
+	},
+	"known_issues": {
+		"eslint@8.0.0": [
+			"@types/eslint@8.4.6"
+		]
 	}
 }

--- a/libs/@guardian/source-react-components/package.json
+++ b/libs/@guardian/source-react-components/package.json
@@ -16,6 +16,7 @@
 		"@svgr/plugin-prettier": "6.5.1",
 		"@svgr/plugin-svgo": "6.5.1",
 		"@types/mkdirp": "1.0.2",
+		"@types/node": "18.11.13",
 		"@types/prettier": "2.4.0",
 		"@types/react": "18.2.0",
 		"@types/svgo": "2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@guardian/csnx",
 	"version": "0.1.0",
-	"private": "true",
+	"private": true,
 	"scripts": {
 		"build": "./tools/scripts/use-make-instead",
 		"prepare": "husky install",
@@ -45,7 +45,7 @@
 		"eslint": "8.40.0",
 		"eslint-plugin-eslint-comments": "3.2.0",
 		"eslint-plugin-import": "2.27.5",
-		"eslint-plugin-storybook": "^0.6.12",
+		"eslint-plugin-storybook": "0.6.12",
 		"husky": "8.0.2",
 		"lint-staged": "13.1.0",
 		"nx": "16.1.4",
@@ -62,13 +62,16 @@
 		"webpack": "5.76.0"
 	},
 	"packageManager": "pnpm@7.18.1",
+	"known_issues": {
+		"@babel/core@7.21.4": [
+			"https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/babel__core",
+			"@types/babel__core@7.20.0"
+		]
+	},
 	"pnpm": {
 		"peerDependencyRules": {
 			"ignoreMissing": [
-				"@types/node",
-				"eslint",
-				"nx",
-				"prettier"
+				"nx"
 			]
 		},
 		"updateConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
       eslint: 8.40.0
       eslint-plugin-eslint-comments: 3.2.0
       eslint-plugin-import: 2.27.5
-      eslint-plugin-storybook: ^0.6.12
+      eslint-plugin-storybook: 0.6.12
       husky: 8.0.2
       lint-staged: 13.1.0
       nx: 16.1.4
@@ -175,7 +175,8 @@ importers:
       '@types/react-dom': 18.2.3
       '@types/testing-library__jest-dom': 5.14.5
       '@types/youtube': 0.0.46
-      eslint-plugin-react: ^7.29.4
+      eslint: 8.40.0
+      eslint-plugin-react: 7.29.4
       is-mobile: 3.1.1
       lodash.debounce: 4.0.6
       react: 18.2.0
@@ -186,7 +187,7 @@ importers:
       is-mobile: 3.1.1
     devDependencies:
       '@babel/core': 7.21.4
-      '@emotion/eslint-plugin': 11.7.0
+      '@emotion/eslint-plugin': 11.7.0_eslint@8.40.0
       '@emotion/react': 11.1.5_q35hynawvquf32rmovmnsbejtu
       '@guardian/ab-core': link:../ab-core
       '@guardian/commercial-core': 7.0.0_ukyo5qdbajvi2lioa5llmbcz4a
@@ -204,7 +205,8 @@ importers:
       '@types/react-dom': 18.2.3
       '@types/testing-library__jest-dom': 5.14.5
       '@types/youtube': 0.0.46
-      eslint-plugin-react: 7.31.11
+      eslint: 8.40.0
+      eslint-plugin-react: 7.29.4_eslint@8.40.0
       lodash.debounce: 4.0.6
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -239,7 +241,7 @@ importers:
       eslint-config-prettier: 8.5.0
       eslint-plugin-eslint-comments: 3.2.0
       eslint-plugin-import: 2.26.0
-      tslib: ^2.4.1
+      tslib: 2.4.1
     dependencies:
       eslint-config-prettier: 8.5.0_eslint@8.0.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.0.0
@@ -377,6 +379,7 @@ importers:
       '@svgr/plugin-prettier': 6.5.1
       '@svgr/plugin-svgo': 6.5.1
       '@types/mkdirp': 1.0.2
+      '@types/node': 18.11.13
       '@types/prettier': 2.4.0
       '@types/react': 18.2.0
       '@types/svgo': 2.6.4
@@ -398,6 +401,7 @@ importers:
       '@svgr/plugin-prettier': 6.5.1_@svgr+core@6.5.1
       '@svgr/plugin-svgo': 6.5.1_@svgr+core@6.5.1
       '@types/mkdirp': 1.0.2
+      '@types/node': 18.11.13
       '@types/prettier': 2.4.0
       '@types/react': 18.2.0
       '@types/svgo': 2.6.4
@@ -406,7 +410,7 @@ importers:
       mkdirp: 1.0.4
       prettier: 2.4.0
       react: 18.2.0
-      ts-node: 10.9.1_typescript@4.9.5
+      ts-node: 10.9.1_ebv7jpk5iu7ytdhj56oi5mjoga
       tslib: 2.4.1
       typescript: 4.9.5
 
@@ -643,7 +647,7 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.4
+      '@babel/types': 7.21.5
 
   /@babel/helper-function-name/7.21.0:
     resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
@@ -797,8 +801,8 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.21.0
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.4
-      '@babel/types': 7.21.4
+      '@babel/traverse': 7.21.5
+      '@babel/types': 7.21.5
     transitivePeerDependencies:
       - supports-color
 
@@ -875,8 +879,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/helper-create-class-features-plugin': 7.21.4_@babel+core@7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-create-class-features-plugin': 7.21.8_@babel+core@7.21.4
+      '@babel/helper-plugin-utils': 7.21.5
     transitivePeerDependencies:
       - supports-color
 
@@ -1104,7 +1108,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
   /@babel/plugin-syntax-import-assertions/7.20.0_@babel+core@7.21.4:
@@ -1350,7 +1354,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-flow': 7.21.4_@babel+core@7.21.4
     dev: true
 
@@ -1757,7 +1761,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-validator-option': 7.21.0
       '@babel/plugin-transform-flow-strip-types': 7.21.0_@babel+core@7.21.4
     dev: true
@@ -2149,14 +2153,13 @@ packages:
       stylis: 4.1.3
     dev: true
 
-  /@emotion/eslint-plugin/11.7.0:
+  /@emotion/eslint-plugin/11.7.0_eslint@8.40.0:
     resolution: {integrity: sha512-k6H0OxBgkPDVG5M16AWnu3z15OmmKNvGmJiYTcamoOIDhiGE5+no+BiVAiHPOwJf/NOsDei2S9i015cMwlO5sA==}
     engines: {node: '>=6'}
     peerDependencies:
       eslint: 6 || 7 || 8
-    peerDependenciesMeta:
-      eslint:
-        optional: true
+    dependencies:
+      eslint: 8.40.0
     dev: true
 
   /@emotion/hash/0.9.0:
@@ -2527,9 +2530,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       eslint: 8.40.0
       eslint-visitor-keys: 3.4.1
@@ -3052,31 +3052,25 @@ packages:
     resolution: {integrity: sha512-2DvTstVZb91m+d4wqUJMBHQ3elxyabdmFE6/3aXmtOGeDxTyXyDzf/1O6JvBBiL8K6XC3ZYchjtxUHgxl/NJ5A==}
     peerDependencies:
       nx: '>= 14.1 <= 16'
-    peerDependenciesMeta:
-      nx:
-        optional: true
     dependencies:
       ejs: 3.1.9
       ignore: 5.2.4
       semver: 7.3.4
       tmp: 0.2.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@nrwl/devkit/15.9.2_nx@15.9.2:
     resolution: {integrity: sha512-2DvTstVZb91m+d4wqUJMBHQ3elxyabdmFE6/3aXmtOGeDxTyXyDzf/1O6JvBBiL8K6XC3ZYchjtxUHgxl/NJ5A==}
     peerDependencies:
       nx: '>= 14.1 <= 16'
-    peerDependenciesMeta:
-      nx:
-        optional: true
     dependencies:
       ejs: 3.1.9
       ignore: 5.2.4
       nx: 15.9.2
       semver: 7.3.4
       tmp: 0.2.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@nrwl/devkit/16.1.4_nx@16.1.4:
@@ -3128,7 +3122,7 @@ packages:
       '@babel/plugin-transform-runtime': 7.21.4_@babel+core@7.21.4
       '@babel/preset-env': 7.21.4_@babel+core@7.21.4
       '@babel/preset-typescript': 7.21.4_@babel+core@7.21.4
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
       '@nrwl/devkit': 15.9.2
       '@nrwl/workspace': 15.9.2
       '@phenomnomnominal/tsquery': 4.1.1_typescript@4.9.5
@@ -3143,7 +3137,7 @@ packages:
       minimatch: 3.0.5
       source-map-support: 0.5.19
       tree-kill: 1.2.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - '@swc-node/register'
       - '@swc/core'
@@ -3319,8 +3313,8 @@ packages:
       open: 8.4.2
       rxjs: 6.6.7
       tmp: 0.2.1
-      tslib: 2.4.1
-      yargs: 17.7.1
+      tslib: 2.5.0
+      yargs: 17.7.2
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@swc-node/register'
@@ -3342,9 +3336,6 @@ packages:
     resolution: {integrity: sha512-tyAnpQShhKhR6FwmT7hJTaT/8B8YxFWhgBW0mLi9PhXYS9xRdgZ+ag8/T3EtJudIGMIdn4JhA1YL2zSuziHABQ==}
     peerDependencies:
       nx: '>= 15 <= 17'
-    peerDependenciesMeta:
-      nx:
-        optional: true
     dependencies:
       '@nrwl/devkit': 16.1.4_nx@16.1.4
       ejs: 3.1.9
@@ -3592,7 +3583,7 @@ packages:
       open: 8.4.2
       picocolors: 1.0.0
       tiny-glob: 0.2.9
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /@pmmmwh/react-refresh-webpack-plugin/0.5.10_6amjs7vuycqvm7ujodxt7nfvgm:
@@ -4569,7 +4560,7 @@ packages:
       flat-cache: 3.0.4
       micromatch: 4.0.5
       react-docgen-typescript: 2.2.2_typescript@4.9.5
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.9.5
       webpack: 5.76.0_@swc+core@1.3.22
     transitivePeerDependencies:
@@ -4911,7 +4902,7 @@ packages:
     resolution: {integrity: sha512-PA4p7nC5LwPdEVcQXFxMTpfvizYPeMoB55nIIx+yC3FiLnyPgC2hcpUitPy5h8RRGdCZ/Mvb2ryEcVYS8nI6YA==}
     dependencies:
       source-map-support: 0.5.21
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /@swc/core-darwin-arm64/1.3.22:
@@ -5311,7 +5302,7 @@ packages:
   /@types/mkdirp/1.0.2:
     resolution: {integrity: sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 18.11.13
     dev: true
 
   /@types/node-fetch/2.6.3:
@@ -5332,10 +5323,6 @@ packages:
   /@types/node/17.0.45:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
     dev: false
-
-  /@types/node/18.11.11:
-    resolution: {integrity: sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==}
-    dev: true
 
   /@types/node/18.11.13:
     resolution: {integrity: sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==}
@@ -5431,7 +5418,7 @@ packages:
   /@types/svgo/2.6.4:
     resolution: {integrity: sha512-l4cmyPEckf8moNYHdJ+4wkHvFxjyW6ulm9l4YGaOxeyBWPhBOT0gvni1InpFPdzx1dKf/2s62qGITwxNWnPQng==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 18.11.13
     dev: true
 
   /@types/testing-library__jest-dom/5.14.5:
@@ -5478,8 +5465,6 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
-      eslint:
-        optional: true
       typescript:
         optional: true
     dependencies:
@@ -5507,8 +5492,6 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
-      eslint:
-        optional: true
       typescript:
         optional: true
     dependencies:
@@ -5536,8 +5519,6 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
-      eslint:
-        optional: true
       typescript:
         optional: true
     dependencies:
@@ -5558,8 +5539,6 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
-      eslint:
-        optional: true
       typescript:
         optional: true
     dependencies:
@@ -5596,8 +5575,6 @@ packages:
       eslint: '*'
       typescript: '*'
     peerDependenciesMeta:
-      eslint:
-        optional: true
       typescript:
         optional: true
     dependencies:
@@ -5618,8 +5595,6 @@ packages:
       eslint: '*'
       typescript: '*'
     peerDependenciesMeta:
-      eslint:
-        optional: true
       typescript:
         optional: true
     dependencies:
@@ -5690,9 +5665,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       '@types/json-schema': 7.0.11
       '@types/semver': 7.3.13
@@ -5713,9 +5685,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0_eslint@8.40.0
       '@types/json-schema': 7.0.11
@@ -5873,19 +5842,11 @@ packages:
       esbuild: '>=0.10.0'
     dependencies:
       esbuild: 0.17.16
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /@yarnpkg/lockfile/1.1.0:
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
-
-  /@yarnpkg/parsers/3.0.0-rc.42:
-    resolution: {integrity: sha512-eW9Mbegmb5bJjwawJM9ghjUjUqciNMhC6L7XrQPF/clXS5bbP66MstsgCT5hy9VlfUh/CfBT+0Wucf531dMjHA==}
-    engines: {node: '>=14.15.0'}
-    dependencies:
-      js-yaml: 3.14.1
-      tslib: 2.4.1
-    dev: false
 
   /@yarnpkg/parsers/3.0.0-rc.43:
     resolution: {integrity: sha512-AhFF3mIDfA+jEwQv2WMHmiYhOvmdbh2qhUkDVQfiqzQtUwS4BgoWwom5NpSPg4Ix5vOul+w1690Bt21CkVLpgg==}
@@ -5893,7 +5854,6 @@ packages:
     dependencies:
       js-yaml: 3.14.1
       tslib: 2.5.0
-    dev: true
 
   /@zkochan/js-yaml/0.0.6:
     resolution: {integrity: sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==}
@@ -6217,16 +6177,6 @@ packages:
       es-shim-unscopables: 1.0.0
     dev: true
 
-  /array.prototype.tosorted/1.1.1:
-    resolution: {integrity: sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
-      es-shim-unscopables: 1.0.0
-      get-intrinsic: 1.1.3
-    dev: true
-
   /arrify/1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
@@ -6255,21 +6205,21 @@ packages:
     resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /ast-types/0.15.2:
     resolution: {integrity: sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /ast-types/0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /astral-regex/2.0.0:
@@ -6797,7 +6747,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /camelcase-keys/6.2.2:
@@ -7709,7 +7659,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /dotenv-expand/10.0.0:
@@ -8027,9 +7977,6 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       eslint: 8.0.0
     dev: false
@@ -8059,9 +8006,6 @@ packages:
     peerDependencies:
       eslint: '*'
       eslint-plugin-import: '*'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
@@ -8197,9 +8141,6 @@ packages:
     engines: {node: '>=6.5.0'}
     peerDependencies:
       eslint: '>=4.19.1'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       escape-string-regexp: 1.0.5
       eslint: 8.0.0
@@ -8211,9 +8152,6 @@ packages:
     engines: {node: '>=6.5.0'}
     peerDependencies:
       eslint: '>=4.19.1'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       escape-string-regexp: 1.0.5
       eslint: 8.40.0
@@ -8228,8 +8166,6 @@ packages:
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
     peerDependenciesMeta:
       '@typescript-eslint/parser':
-        optional: true
-      eslint:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.46.1_e33pqjfwvjdek2eycaqtrjorje
@@ -8262,8 +8198,6 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
-      eslint:
-        optional: true
     dependencies:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
@@ -8293,8 +8227,6 @@ packages:
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
     peerDependenciesMeta:
       '@typescript-eslint/parser':
-        optional: true
-      eslint:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.46.1_e33pqjfwvjdek2eycaqtrjorje
@@ -8327,8 +8259,6 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
-      eslint:
-        optional: true
     dependencies:
       '@typescript-eslint/parser': 5.59.5_jgkqkwom7vrxl4kyi454n2sy2i
       array-includes: 3.1.6
@@ -8353,19 +8283,16 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-react/7.31.11:
-    resolution: {integrity: sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==}
+  /eslint-plugin-react/7.29.4_eslint@8.40.0:
+    resolution: {integrity: sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       array-includes: 3.1.6
       array.prototype.flatmap: 1.3.1
-      array.prototype.tosorted: 1.1.1
       doctrine: 2.1.0
+      eslint: 8.40.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
@@ -8384,9 +8311,6 @@ packages:
     engines: {node: 12.x || 14.x || >= 16}
     peerDependencies:
       eslint: '>=6'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       '@storybook/csf': 0.0.1
       '@typescript-eslint/utils': 5.59.5_jgkqkwom7vrxl4kyi454n2sy2i
@@ -8425,9 +8349,6 @@ packages:
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
     dependencies:
       eslint: 8.0.0
       eslint-visitor-keys: 2.1.0
@@ -8607,8 +8528,8 @@ packages:
     resolution: {integrity: sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==}
     engines: {node: '>=8.3.0'}
     dependencies:
-      '@babel/traverse': 7.21.4
-      '@babel/types': 7.21.4
+      '@babel/traverse': 7.21.5
+      '@babel/types': 7.21.5
       c8: 7.13.0
     transitivePeerDependencies:
       - supports-color
@@ -9156,7 +9077,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.20.4
+      es-abstract: 1.21.2
       functions-have-names: 1.2.3
 
   /functional-red-black-tree/1.0.1:
@@ -9187,14 +9108,6 @@ packages:
   /get-caller-file/2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-
-  /get-intrinsic/1.1.3:
-    resolution: {integrity: sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==}
-    dependencies:
-      function-bind: 1.1.1
-      has: 1.0.3
-      has-symbols: 1.0.3
-    dev: true
 
   /get-intrinsic/1.2.0:
     resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
@@ -9322,7 +9235,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.5
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -9896,6 +9809,7 @@ packages:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
+    dev: false
 
   /is-core-module/2.12.0:
     resolution: {integrity: sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==}
@@ -11212,7 +11126,7 @@ packages:
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /lru-cache/4.1.5:
@@ -11596,7 +11510,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /node-abort-controller/3.1.1:
@@ -11663,7 +11577,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.1
+      resolve: 1.22.2
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: true
@@ -11754,7 +11668,7 @@ packages:
       '@nrwl/tao': 15.9.2
       '@parcel/watcher': 2.0.4
       '@yarnpkg/lockfile': 1.1.0
-      '@yarnpkg/parsers': 3.0.0-rc.42
+      '@yarnpkg/parsers': 3.0.0-rc.43
       '@zkochan/js-yaml': 0.0.6
       axios: 1.4.0
       chalk: 4.1.2
@@ -11781,9 +11695,9 @@ packages:
       tar-stream: 2.2.0
       tmp: 0.2.1
       tsconfig-paths: 4.2.0
-      tslib: 2.4.1
+      tslib: 2.5.0
       v8-compile-cache: 2.3.0
-      yargs: 17.7.1
+      yargs: 17.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
       '@nrwl/nx-darwin-arm64': 15.9.2
@@ -11937,8 +11851,8 @@ packages:
   /object.hasown/1.1.2:
     resolution: {integrity: sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==}
     dependencies:
-      define-properties: 1.1.4
-      es-abstract: 1.20.4
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
     dev: true
 
   /object.pick/1.3.0:
@@ -12136,7 +12050,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /parent-module/1.0.1:
@@ -12188,7 +12102,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /pascalcase/0.1.1:
@@ -12313,7 +12227,7 @@ packages:
     resolution: {integrity: sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.21.5
     dev: true
 
   /posix-character-classes/0.1.1:
@@ -12625,8 +12539,8 @@ packages:
     hasBin: true
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/generator': 7.21.4
-      '@babel/runtime': 7.21.0
+      '@babel/generator': 7.21.5
+      '@babel/runtime': 7.21.5
       ast-types: 0.14.2
       commander: 2.20.3
       doctrine: 3.0.0
@@ -12780,7 +12694,7 @@ packages:
       ast-types: 0.15.2
       esprima: 4.0.1
       source-map: 0.6.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /recast/0.23.1:
@@ -12791,7 +12705,7 @@ packages:
       ast-types: 0.16.1
       esprima: 4.0.1
       source-map: 0.6.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /rechoir/0.6.2:
@@ -12983,6 +12897,7 @@ packages:
       is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: false
 
   /resolve/1.22.2:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
@@ -12996,7 +12911,7 @@ packages:
     resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==}
     hasBin: true
     dependencies:
-      is-core-module: 2.11.0
+      is-core-module: 2.12.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -13106,7 +13021,7 @@ packages:
   /rxjs/7.8.0:
     resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /rxjs/7.8.1:
@@ -13657,7 +13572,7 @@ packages:
       get-intrinsic: 1.2.0
       has-symbols: 1.0.3
       internal-slot: 1.0.5
-      regexp.prototype.flags: 1.4.3
+      regexp.prototype.flags: 1.5.0
       side-channel: 1.0.4
     dev: true
 
@@ -13674,14 +13589,14 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.20.4
+      es-abstract: 1.21.2
 
   /string.prototype.trimstart/1.0.6:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.20.4
+      es-abstract: 1.21.2
 
   /string_decoder/1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -13816,7 +13731,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/utils': 2.3.1
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
 
   /tapable/2.2.1:
@@ -13956,7 +13871,7 @@ packages:
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.2
-      acorn: 8.8.1
+      acorn: 8.8.2
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: true
@@ -14136,7 +14051,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node/10.9.1_typescript@4.9.5:
+  /ts-node/10.9.1_ebv7jpk5iu7ytdhj56oi5mjoga:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -14149,14 +14064,13 @@ packages:
         optional: true
       '@swc/wasm':
         optional: true
-      '@types/node':
-        optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
+      '@types/node': 18.11.13
       acorn: 8.8.1
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -14221,6 +14135,7 @@ packages:
 
   /tslib/2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+    dev: true
 
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
@@ -14750,6 +14665,7 @@ packages:
 
   /which/1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
     dependencies:
       isexe: 2.0.0
     dev: true
@@ -14972,6 +14888,7 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    dev: true
 
   /yargs/17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -14984,7 +14901,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: true
 
   /yauzl/2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}

--- a/tools/scripts/deno/package-health.ts
+++ b/tools/scripts/deno/package-health.ts
@@ -1,0 +1,24 @@
+import { package_health } from 'https://deno.land/x/package_health@0.4.6/src/main.ts';
+import { walk } from 'https://deno.land/std@0.187.0/fs/mod.ts';
+import {
+	dirname,
+	fromFileUrl,
+	globToRegExp,
+	resolve,
+} from 'https://deno.land/std@0.187.0/path/mod.ts';
+
+const root = resolve(dirname(fromFileUrl(import.meta.url)), '..', '..', '..');
+
+for await (const { path } of walk(root, {
+	includeDirs: false,
+	match: [
+		globToRegExp(root + '/package.json'),
+		globToRegExp(root + '/apps/**/package.json', { globstar: true }),
+		globToRegExp(root + '/libs/**/package.json', { globstar: true }),
+	],
+})) {
+	const contents = JSON.parse(await Deno.readTextFile(path));
+	await package_health(contents, { verbose: true });
+
+	console.log('\n');
+}


### PR DESCRIPTION
## What are you changing?

- Introduce a check for `package.json` health

## Why?

- It allows automatic applications of our [JavaScript](https://github.com/guardian/recommendations/blob/main/dependencies.md#javascript) & [NPM recommendations](https://github.com/guardian/recommendations/blob/main/npm-packages.md#pin-the-lowest-possible-version-of-peerdependencies-in-your-packages-devdependencies)
