### PR TITLE
Give write permissions to changesets and storybook actions

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   NX_BRANCH: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 env:
   NX_BRANCH: ${{ github.event.pull_request.head.ref }}
   NX_RUN_GROUP: ${{ github.run_id }}
@@ -17,6 +13,9 @@ jobs:
   changesets-version:
     name: Manage Changesets Pull Request
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 env:
   NX_BRANCH: ${{ github.event.pull_request.head.ref }}
   NX_RUN_GROUP: ${{ github.run_id }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -16,6 +16,9 @@ on:
     branches: [main]
     types: [completed]
 
+permissions:
+  contents: write
+
 jobs:
   on-success: # only run if CI is successful
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -16,13 +16,12 @@ on:
     branches: [main]
     types: [completed]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   on-success: # only run if CI is successful
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   on-success: # only run if CI is successful


### PR DESCRIPTION
## What are you changing?

- adding `contents: write` and `pull_request: write` permissions for storybook and changesets workflows 

## Why?

- both jobs are currently failing in CI due to lack of permissions
