### PR TITLE
Skip Chromatic in Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,14 @@ jobs:
       - run: make build-storybooks
 
   chromatic:
-    # Kick chromatic off only once all other steps have passed. This stops us
+    # Kick Chromatic off only once all other steps have passed. This stops us
     # wasting money running checks on PRs that are going to fail anyway.
+    # Chromatic is only run if the PR is labelled with `run_chromatic`, or we're
+    # on the `main` branch.
     needs: validate
-    if: contains(github.event.pull_request.labels.*.name, 'run_chromatic') ||  github.ref == 'refs/heads/main'
+    if: |
+      (contains(github.event.pull_request.labels.*.name, 'run_chromatic') || github.ref == 'refs/heads/main') &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -72,3 +76,39 @@ jobs:
           exitOnceUploaded: true
           onlyChanged: '!(main)' # turbosnap on non-main branches
 
+  chromatic-dependabot:
+    # Run Chromatic with `skip` flag for Dependabot PRs. This ensures tests are
+    # marked as passing and prevents the PR being blocked by merge checks.
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - lib: atoms-rendering
+            token: CHROMATIC_ATOMS_RENDERING_TOKEN
+          - lib: source-foundations
+            token: CHROMATIC_SOURCE_FOUNDATIONS_TOKEN
+          - lib: source-react-components
+            token: CHROMATIC_SOURCE_REACT_COMPONENTS_TOKEN
+          - lib: source-react-components-development-kitchen
+            token: CHROMATIC_SOURCE_REACT_COMPONENTS_DEVELOPMENT_KITCHEN_TOKEN
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # for chromatic to work
+
+      # enables use to use the cache in actions/setup-node
+      - uses: pnpm/action-setup@v2.2.4
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets[matrix.token] }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          skip: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,15 @@ jobs:
   chromatic:
     # Kick Chromatic off only once all other steps have passed. This stops us
     # wasting money running checks on PRs that are going to fail anyway.
-    # Chromatic is only run if the PR is labelled with `run_chromatic`, or we're
-    # on the `main` branch.
+    # Chromatic is only run if the PR is labelled with `run_chromatic`, this is
+    # the `main` branch, or this is a Dependabot PR. For Dependabot PRs we then
+    # apply the `skip` flag as we don't want to create snapshots, but this
+    # ensures the UI tests are marked as passing allowing the PR to be merged.
     needs: validate
     if: |
-      (contains(github.event.pull_request.labels.*.name, 'run_chromatic') || github.ref == 'refs/heads/main') &&
-      github.actor != 'dependabot[bot]'
+      (contains(github.event.pull_request.labels.*.name, 'run_chromatic') ||
+      github.ref == 'refs/heads/main') ||
+      github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -75,41 +78,4 @@ jobs:
           storybookBuildDir: 'dist/storybook/libs/@guardian/${{ matrix.lib }}'
           exitOnceUploaded: true
           onlyChanged: '!(main)' # turbosnap on non-main branches
-
-  chromatic-dependabot:
-    # Run Chromatic with `skip` flag for Dependabot PRs. This ensures tests are
-    # marked as passing and prevents the PR being blocked by merge checks.
-    if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - lib: atoms-rendering
-            token: CHROMATIC_ATOMS_RENDERING_TOKEN
-          - lib: source-foundations
-            token: CHROMATIC_SOURCE_FOUNDATIONS_TOKEN
-          - lib: source-react-components
-            token: CHROMATIC_SOURCE_REACT_COMPONENTS_TOKEN
-          - lib: source-react-components-development-kitchen
-            token: CHROMATIC_SOURCE_REACT_COMPONENTS_DEVELOPMENT_KITCHEN_TOKEN
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # for chromatic to work
-
-      # enables use to use the cache in actions/setup-node
-      - uses: pnpm/action-setup@v2.2.4
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - run: pnpm install --frozen-lockfile
-
-      - uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets[matrix.token] }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          storybookBuildDir: 'dist/storybook/libs/@guardian/${{ matrix.lib }}'
-          skip: true
+          skip: ${{ github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,4 +111,5 @@ jobs:
         with:
           projectToken: ${{ secrets[matrix.token] }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          storybookBuildDir: 'dist/storybook/libs/@guardian/${{ matrix.lib }}'
           skip: true


### PR DESCRIPTION
## What are you changing?

- Runs Chromatic against Dependabot PRs with the `skip` flag enabled.
- Resolves #570

## Why?

- To cut down on the number of Chromatic snapshots we don't want to run Chromatic against Dependabot PRs as they tend to hang around for a while before being merged and get rebased multiple causing unnecessary runs. As the UI tests are a required merge check we run Chromatic with the `skip` flag which marks these as passing and does not prevent merging of the PR.
