### PR TITLE
Update how we detect Dependabot PRs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
     # ensures the UI tests are marked as passing allowing the PR to be merged.
     needs: validate
     if: |
-      (contains(github.event.pull_request.labels.*.name, 'run_chromatic') ||
-      github.ref == 'refs/heads/main') ||
-      github.actor == 'dependabot[bot]'
+      contains(github.event.pull_request.labels.*.name, 'run_chromatic') ||
+      github.ref == 'refs/heads/main' ||
+      github.event.pull_request.user.login == 'dependabot'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -78,4 +78,4 @@ jobs:
           storybookBuildDir: 'dist/storybook/libs/@guardian/${{ matrix.lib }}'
           exitOnceUploaded: true
           onlyChanged: '!(main)' # turbosnap on non-main branches
-          skip: ${{ github.actor == 'dependabot[bot]' }}
+          skip: ${{ github.event.pull_request.user.login == 'dependabot' }}


### PR DESCRIPTION
## What are you changing?

- Use `github.event.pull_request.user.login` to detect Dependabot PRs rather than `github.actor`.

## Why?

- `github.actor` returns the username of the user who triggered the workflow. Whilst this _will_ be Dependabot initially, if somebody manually interacts with the PR and triggers the CI workflow this will return _their_ username instead. This will leave the PR in an un-mergeable state as Chromatic will be not be run with the `skip` flag.