### PR TITLE
docs: fix link to CSS Resets docs

### DIFF
--- a/libs/@guardian/source-foundations/src/utils/resets.ts
+++ b/libs/@guardian/source-foundations/src/utils/resets.ts
@@ -115,7 +115,7 @@ const resetCSS = `
 `;
 
 /**
- * [Storybook](https://guardian.github.io/csnx/?path=/docs/source-foundations_css-reset--page)
+ * [Storybook](https://guardian.github.io/csnx/?path=/docs/source-foundations_css-reset--docs)
  *
  * `resets.resetCSS`: sensible default CSS rules to provide a base for a consistent environment across projects and browsers.
  */


### PR DESCRIPTION
## What are you changing?

- The link to the CSS resets documentation

## Why?

- It was out of date
