### PR TITLE
Debug: echo workflow run actor and context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,15 @@ on:
     types: [opened, labeled, synchronize]
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "github.actor = ${{ github.actor }}"
+          echo "github.triggering_actor = ${{ github.triggering_actor }}"
+          echo "github.event.pull_request.user.login = ${{ github.event.pull_request.user.login }}"
+          echo "${{ toJSON(github) }}"
+
   validate:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What are you changing?

- Echos the workflow run actor and context for the run from the CI workflow.

## Why?

- We're trying to reliably detect PRs created by Dependabot. `github.actor` returns `dependabot[bot]` when a PR is first created and for any subsequent workflow runs triggered by Dependabot. However, if another user interacts with the PR then `github.actor` will return their username in any triggered workflow runs.
