### PR TITLE
unscope gh workflow permissions for changesets

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   NX_BRANCH: ${{ github.event.pull_request.head.ref }}
   NX_RUN_GROUP: ${{ github.run_id }}
@@ -13,9 +17,6 @@ jobs:
   changesets-version:
     name: Manage Changesets Pull Request
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## What are you changing?

- update permissions for gh actions

## Why?

- currently changesets is erroring at the release stage: https://github.com/guardian/csnx/actions/runs/5176449823/jobs/9325577780
