### PR TITLE
Fix: Identity Auth - Store promise if `getWithoutPrompt` called multiple times.

### DIFF
--- a/.changeset/seven-kings-juggle.md
+++ b/.changeset/seven-kings-juggle.md
@@ -1,0 +1,5 @@
+---
+'@guardian/identity-auth': patch
+---
+
+Only use a single promise if `getWithoutPrompt` called multiple times


### PR DESCRIPTION
## What are you changing?

- Add `#getTokensInProgress` private property to `Token` class, which holds a Promise if there is currently an get tokens flow (OAuth Authorization Code flow) in progress
- Update `getWithoutPrompt` so that if it is called multiple times in succession it used the promise stored in `this.#getTokensInProgress` rather than creating new requests every time

## Why?

- When developing in DCR we noticed that multiple calls were being made to the Okta OAuth Authorization Code flow if no tokens existed to get new tokens, when only one call should be made.
- This was narrowed down to components all attempting to update tokens individually
- Get around this by sharing the token promise if tokens are attempted to get refreshed while one is currently in progress
