### PR TITLE
Update changeset codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,8 @@
 
 * @guardian/client-side-infra
 
+.changeset/* @guardian/client-side-infra @guardian/dotcom-platform @guardian/commercial-dev @guardian/source @guardian/identity
+
 libs/@guardian/atoms-rendering/* @guardian/dotcom-platform @guardian/commercial-dev @guardian/client-side-infra
 
 libs/@guardian/source-foundations/* @guardian/source


### PR DESCRIPTION
## What are you changing?

- Updating the codeowners file to provide ownership of the .changeset folder to teams who already have ownership over parts of the csnx repo.

## Why?

- Better workflow as CSTI will no longer be required to approve every PR in order for a package (or an update to one) to be published (which is currently the case as only CSTI have ownership over the .changeset folder, which needs to get updated as part of a PR which aims to publish to npm).
