### PR TITLE
Remove esmodule: true from rollup config

### DIFF
--- a/.changeset/pretty-tools-end.md
+++ b/.changeset/pretty-tools-end.md
@@ -1,0 +1,6 @@
+---
+'@guardian/source-react-components': patch
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Update build output config

--- a/libs/@guardian/ab-core/src/e2e.test.ts
+++ b/libs/@guardian/ab-core/src/e2e.test.ts
@@ -2,7 +2,7 @@ import * as packageExports from './index';
 
 describe('The package', () => {
 	it('exports everything it did before', () => {
-		expect(Object.keys(packageExports).sort()).toEqual(['AB']);
+		expect(Object.keys(packageExports).sort()).toEqual(['AB', 'default']);
 	});
 });
 

--- a/libs/@guardian/atoms-rendering/src/index.test.ts
+++ b/libs/@guardian/atoms-rendering/src/index.test.ts
@@ -17,6 +17,7 @@ describe('The package', () => {
 			'TimelineAtom',
 			'VideoAtom',
 			'YoutubeAtom',
+			'default',
 		]);
 	});
 });

--- a/libs/@guardian/core-web-vitals/src/e2e.test.ts
+++ b/libs/@guardian/core-web-vitals/src/e2e.test.ts
@@ -5,6 +5,7 @@ describe('The package', () => {
 		expect(Object.keys(packageExports).sort()).toEqual([
 			'_',
 			'bypassCoreWebVitalsSampling',
+			'default',
 			'initCoreWebVitals',
 		]);
 	});

--- a/libs/@guardian/eslint-plugin-source-foundations/src/index.test.ts
+++ b/libs/@guardian/eslint-plugin-source-foundations/src/index.test.ts
@@ -1,5 +1,9 @@
 import * as pkgExports from './index';
 
 it('Should have exactly these exports', () => {
-	expect(Object.keys(pkgExports).sort()).toEqual(['configs', 'rules']);
+	expect(Object.keys(pkgExports).sort()).toEqual([
+		'configs',
+		'default',
+		'rules',
+	]);
 });

--- a/libs/@guardian/eslint-plugin-source-react-components/src/index.test.ts
+++ b/libs/@guardian/eslint-plugin-source-react-components/src/index.test.ts
@@ -1,5 +1,9 @@
 import * as pkgExports from './index';
 
 it('Should have exactly these exports', () => {
-	expect(Object.keys(pkgExports).sort()).toEqual(['configs', 'rules']);
+	expect(Object.keys(pkgExports).sort()).toEqual([
+		'configs',
+		'default',
+		'rules',
+	]);
 });

--- a/libs/@guardian/libs/src/index.test.ts
+++ b/libs/@guardian/libs/src/index.test.ts
@@ -10,6 +10,7 @@ describe('The package', () => {
 			'ArticleSpecial',
 			'countries',
 			'debug',
+			'default',
 			'getCookie',
 			'getCountryByCountryCode',
 			'getLocale',

--- a/libs/@guardian/source-foundations/src/index.test.ts
+++ b/libs/@guardian/source-foundations/src/index.test.ts
@@ -45,6 +45,7 @@ it('Should have exactly these exports', () => {
 		'brandText',
 		'breakpoints',
 		'culture',
+		'default',
 		'descriptionId',
 		'error',
 		'focus',

--- a/libs/@guardian/source-react-components-development-kitchen/src/index.test.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/index.test.ts
@@ -47,6 +47,7 @@ it('Should have exactly these exports', () => {
 		'Tabs',
 		'ToggleSwitch',
 		'ToggleSwitchApps',
+		'default',
 		'defaultGuardianLinks',
 		'expandingWrapperDarkTheme',
 		'expandingWrapperThemeDefault',

--- a/libs/@guardian/source-react-components/src/index.test.ts
+++ b/libs/@guardian/source-react-components/src/index.test.ts
@@ -219,6 +219,7 @@ it('Should have exactly these exports', () => {
 		'checkboxThemeBrand',
 		'checkboxThemeDefault',
 		'choiceCardThemeDefault',
+		'default',
 		'footerThemeBrand',
 		'labelThemeBrand',
 		'labelThemeDefault',

--- a/tools/nx-plugins/npm-package/build/index.ts
+++ b/tools/nx-plugins/npm-package/build/index.ts
@@ -52,6 +52,7 @@ const getRollupConfig = (
 			format,
 			sourcemap: true,
 			preserveModules: true,
+			esmModule: 'if-default-prop',
 		},
 		plugins: [
 			nodeResolve({

--- a/tools/nx-plugins/npm-package/build/index.ts
+++ b/tools/nx-plugins/npm-package/build/index.ts
@@ -52,7 +52,6 @@ const getRollupConfig = (
 			format,
 			sourcemap: true,
 			preserveModules: true,
-			esModule: true,
 		},
 		plugins: [
 			nodeResolve({


### PR DESCRIPTION
## What are you changing?

- updating rollup config

## Why?

- we introduced this in a [recent rollup upgrade](https://github.com/guardian/csnx/pull/627/files), however we're having issues with @guardian packages on DCR (which uses cjs) so this is an attempt to fix those
