### PR TITLE
Rolling back `npm-package` to use TS 4.9.5

### DIFF
--- a/.changeset/pretty-tools-end.md
+++ b/.changeset/pretty-tools-end.md
@@ -1,0 +1,6 @@
+---
+'@guardian/source-react-components': patch
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Update build output config

--- a/.changeset/pretty-tools-end.md
+++ b/.changeset/pretty-tools-end.md
@@ -1,6 +1,0 @@
----
-'@guardian/source-react-components': patch
-'@guardian/source-react-components-development-kitchen': patch
----
-
-Update build output config

--- a/libs/@guardian/ab-react/CHANGELOG.md
+++ b/libs/@guardian/ab-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/ab-react
 
+## 6.0.1
+
+### Patch Changes
+
+- Update build output config
+
 ## 6.0.0
 
 ### Major Changes

--- a/libs/@guardian/ab-react/package.json
+++ b/libs/@guardian/ab-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/ab-react",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"private": false,
 	"description": "A React library for A/B & multivariate testing",
 	"license": "Apache-2.0",

--- a/libs/@guardian/atoms-rendering/CHANGELOG.md
+++ b/libs/@guardian/atoms-rendering/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/atoms-rendering
 
+## 32.0.1
+
+### Patch Changes
+
+- Update build output config
+
 ## 32.0.0
 
 ### Major Changes

--- a/libs/@guardian/atoms-rendering/package.json
+++ b/libs/@guardian/atoms-rendering/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/atoms-rendering",
-	"version": "32.0.0",
+	"version": "32.0.1",
 	"dependencies": {
 		"is-mobile": "3.1.1"
 	},
@@ -15,7 +15,7 @@
 		"@guardian/eslint-plugin-source-react-components": "17.0.0",
 		"@guardian/libs": "15.1.0",
 		"@guardian/source-foundations": "12.0.0",
-		"@guardian/source-react-components": "15.0.0",
+		"@guardian/source-react-components": "15.0.1",
 		"@testing-library/dom": "9.3.1",
 		"@testing-library/jest-dom": "5.16.5",
 		"@testing-library/react": "14.0.0",
@@ -37,7 +37,7 @@
 		"@guardian/consent-management-platform": "^13.5.0",
 		"@guardian/libs": "^15.1.0",
 		"@guardian/source-foundations": "^12.0.0",
-		"@guardian/source-react-components": "^15.0.0",
+		"@guardian/source-react-components": "^15.0.1",
 		"lodash.debounce": "^4.0.8",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/libs/@guardian/source-react-components-development-kitchen/CHANGELOG.md
+++ b/libs/@guardian/source-react-components-development-kitchen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/source-react-components-development-kitchen
 
+## 13.0.1
+
+### Patch Changes
+
+- Update build output config
+
 ## 13.0.0
 
 ### Major Changes

--- a/libs/@guardian/source-react-components-development-kitchen/package.json
+++ b/libs/@guardian/source-react-components-development-kitchen/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "@guardian/source-react-components-development-kitchen",
-	"version": "13.0.0",
+	"version": "13.0.1",
 	"sideEffects": false,
 	"devDependencies": {
 		"@babel/core": "7.22.1",
 		"@emotion/react": "11.11.1",
 		"@guardian/libs": "15.0.0",
 		"@guardian/source-foundations": "12.0.0",
-		"@guardian/source-react-components": "15.0.0",
+		"@guardian/source-react-components": "15.0.1",
 		"@types/react": "18.2.11",
 		"react": "18.2.0",
 		"tslib": "2.5.3",
@@ -17,7 +17,7 @@
 		"@emotion/react": "^11.11.1",
 		"@guardian/libs": "^15.0.0",
 		"@guardian/source-foundations": "^12.0.0",
-		"@guardian/source-react-components": "^15.0.0",
+		"@guardian/source-react-components": "^15.0.1",
 		"react": "^18.2.0",
 		"tslib": "^2.5.3",
 		"typescript": "~5.1.3"

--- a/libs/@guardian/source-react-components/CHANGELOG.md
+++ b/libs/@guardian/source-react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/source-react-components
 
+## 15.0.1
+
+### Patch Changes
+
+- Update build output config
+
 ## 15.0.0
 
 ### Major Changes

--- a/libs/@guardian/source-react-components/package.json
+++ b/libs/@guardian/source-react-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/source-react-components",
-	"version": "15.0.0",
+	"version": "15.0.1",
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,7 +465,7 @@ importers:
       sort-package-json: 1.57.0
       tslib: 2.5.3
       type-fest: 3.3.0
-      typescript: 5.1.3
+      typescript: 4.9.5
       write-pkg: 5.1.0
     dependencies:
       '@guardian/libs': link:../../../libs/@guardian/libs
@@ -476,11 +476,11 @@ importers:
       execa: 7.1.1
       read-pkg: 7.1.0
       rollup: 3.24.0
-      rollup-plugin-ts: 3.2.0_pgjen54w7efektgwm6vmu7pcsa
+      rollup-plugin-ts: 3.2.0_ollrytiw5favcwcsi5344oeg6e
       sort-package-json: 1.57.0
       tslib: 2.5.3
       type-fest: 3.3.0
-      typescript: 5.1.3
+      typescript: 4.9.5
       write-pkg: 5.1.0
 
 packages:
@@ -9666,14 +9666,14 @@ packages:
   /commondir/1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
-  /compatfactory/2.0.9_typescript@5.1.3:
+  /compatfactory/2.0.9_typescript@4.9.5:
     resolution: {integrity: sha512-fvO+AWcmbO7P1S+A3mwm3IGr74eHMeq5ZLhNhyNQc9mVDNHT4oe0Gg0ksdIFFNXLK7k7Z/TYcLAUSQdRgh1bsA==}
     engines: {node: '>=14.9.0'}
     peerDependencies:
       typescript: '>=3.x || >= 4.x'
     dependencies:
       helpertypes: 0.0.19
-      typescript: 5.1.3
+      typescript: 4.9.5
     dev: false
 
   /component-emitter/1.3.0:
@@ -15727,7 +15727,7 @@ packages:
     dependencies:
       glob: 7.2.3
 
-  /rollup-plugin-ts/3.2.0_pgjen54w7efektgwm6vmu7pcsa:
+  /rollup-plugin-ts/3.2.0_ollrytiw5favcwcsi5344oeg6e:
     resolution: {integrity: sha512-KkTLVifkUexEiAXS9VtSjDrjKr0TyusmNJpb2ZTAzI9VuPumSu4AktIaVNnwv70iUEitHwZtET7OAM+5n1u1tg==}
     engines: {node: '>=14.9.0', npm: '>=7.0.0', pnpm: '>=3.2.0', yarn: '>=1.13'}
     peerDependencies:
@@ -15761,13 +15761,13 @@ packages:
       ansi-colors: 4.1.3
       browserslist: 4.21.5
       browserslist-generator: 2.0.3
-      compatfactory: 2.0.9_typescript@5.1.3
+      compatfactory: 2.0.9_typescript@4.9.5
       crosspath: 2.0.0
       magic-string: 0.27.0
       rollup: 3.24.0
-      ts-clone-node: 2.0.4_typescript@5.1.3
+      ts-clone-node: 2.0.4_typescript@4.9.5
       tslib: 2.5.3
-      typescript: 5.1.3
+      typescript: 4.9.5
     dev: false
 
   /rollup/3.24.0:
@@ -16771,14 +16771,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-clone-node/2.0.4_typescript@5.1.3:
+  /ts-clone-node/2.0.4_typescript@4.9.5:
     resolution: {integrity: sha512-eG6FAgmQsenhIJOIFhUcO6yyYejBKZIKcI3y21jiQmIOrth5pD6GElyPAyeihbPSyBs3u/9PVNXy+5I7jGy8jA==}
     engines: {node: '>=14.9.0'}
     peerDependencies:
       typescript: ^3.x || ^4.x
     dependencies:
-      compatfactory: 2.0.9_typescript@5.1.3
-      typescript: 5.1.3
+      compatfactory: 2.0.9_typescript@4.9.5
+      typescript: 4.9.5
     dev: false
 
   /ts-dedent/2.2.0:
@@ -17015,6 +17015,12 @@ packages:
     dependencies:
       typescript-compare: 0.0.2
     dev: true
+
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: false
 
   /typescript/5.1.3:
     resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,7 +164,7 @@ importers:
       '@guardian/eslint-plugin-source-react-components': 17.0.0
       '@guardian/libs': 15.1.0
       '@guardian/source-foundations': 12.0.0
-      '@guardian/source-react-components': 15.0.0
+      '@guardian/source-react-components': 15.0.1
       '@testing-library/dom': 9.3.1
       '@testing-library/jest-dom': 5.16.5
       '@testing-library/react': 14.0.0
@@ -313,7 +313,7 @@ importers:
       '@emotion/react': 11.11.1_react@18.2.0
       '@guardian/libs': 15.0.0_xfreuenalcno2zxheqz32kfzfe
       '@guardian/source-foundations': link:../source-foundations
-      '@guardian/source-react-components': link:../source-react-components
+      '@guardian/source-react-components': 15.0.0_gqwmkmfg6hyvlppc3upkalgkjm
       '@types/eslint': 8.4.6
       '@types/estree': 1.0.1
       eslint: 8.0.0
@@ -424,7 +424,7 @@ importers:
       '@emotion/react': 11.11.1
       '@guardian/libs': 15.0.0
       '@guardian/source-foundations': 12.0.0
-      '@guardian/source-react-components': 15.0.0
+      '@guardian/source-react-components': 15.0.1
       '@types/react': 18.2.11
       react: 18.2.0
       tslib: 2.5.3
@@ -4744,6 +4744,26 @@ packages:
         optional: true
     dependencies:
       mini-svg-data-uri: 1.4.4
+      tslib: 2.5.3
+      typescript: 5.1.3
+    dev: true
+
+  /@guardian/source-react-components/15.0.0_gqwmkmfg6hyvlppc3upkalgkjm:
+    resolution: {integrity: sha512-bSEGjF6p0a6lGnHskjQPLYbyvQ+ldZoIPn/49GABIkNVkyTzfAzcx7u8WF+tVHBc576c7u1Sm/FT21303+7k1w==}
+    deprecated: Due to an issue with TS 5.1 and our build process this version is deprecated
+    peerDependencies:
+      '@emotion/react': ^11.11.1
+      '@guardian/source-foundations': ^12.0.0
+      react: ^18.2.0
+      tslib: ^2.5.3
+      typescript: ~5.1.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@emotion/react': 11.11.1_react@18.2.0
+      '@guardian/source-foundations': link:libs/@guardian/source-foundations
+      react: 18.2.0
       tslib: 2.5.3
       typescript: 5.1.3
     dev: true

--- a/tools/nx-plugins/npm-package/package.json
+++ b/tools/nx-plugins/npm-package/package.json
@@ -14,7 +14,7 @@
 		"sort-package-json": "1.57.0",
 		"tslib": "2.5.3",
 		"type-fest": "3.3.0",
-		"typescript": "5.1.3",
+		"typescript": "4.9.5",
 		"write-pkg": "5.1.0"
 	},
 	"executors": "./executors.json"


### PR DESCRIPTION
## What are you changing?

- rolling back `npm-package` to use TS 4.9.5.
- releasing patch versions of packages that previously contained the triple directive bug described below

## Why?

We're rolling back the version of TypeScript exclusively for the @csnx/npm-package tool, as the rollup-plugin-ts does not support TypeScript 5.0 or 5.1

This is a pragmatic decision that enables our libraries to work with the latest version of TypeScript, but not a stable position we can maintain for long…
