### PR TITLE
Identity Auth | Set up `AutoRenewService` and update type definitions for `IdentityAuthState`

### DIFF
--- a/.changeset/clever-swans-bathe.md
+++ b/.changeset/clever-swans-bathe.md
@@ -1,0 +1,6 @@
+---
+'@guardian/identity-auth': minor
+---
+
+- Add `AutoRenewService` for automatically renewing tokens before they expire
+- Update type definitions for `IdentityAuthState`

--- a/libs/@guardian/identity-auth/README.md
+++ b/libs/@guardian/identity-auth/README.md
@@ -16,6 +16,7 @@ Browsers will need to support the following features or polyfill them:
   - [`crypto.subtle.importKey`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey)
   - [`crypto.subtle.verify`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/verify)
 - [`TextEncoder`](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder)
+- [`Page Visibility API`](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API)
 
 ## Usage
 
@@ -55,11 +56,26 @@ This is what replaces the `SC_GU_U` cookie that is used in the legacy identity p
 import type { IdentityAuthOptions } from '@guardian/identity-auth';
 import { IdentityAuth } from '@guardian/identity-auth';
 
+/**
+ * Defines the options that are required to configure the IdentityAuth
+ * Ask the Identity team for the values to use for your app.
+ *
+ * https://developer.okta.com/docs/reference/api/oidc/
+ *
+ * @param clientId - The client ID of your app
+ * @param issuer - The issuer of the tokens
+ * @param scopes - The scopes that your app requires
+ * @param redirectUri - The redirect URI of your app
+ * @param autoRenew - Whether to automatically renew the tokens, defaults to `true`
+ * @param renewGracePeriod - The time in seconds before the access token expires to renew the token, defaults to 60 seconds
+ */
 const config: IdentityAuthOptions = {
 	issuer: 'https://profile.theguardian.com/oauth2/SERVER_ID',
 	clientId: 'example-client-id',
 	redirectUri: 'https://theguardian.com',
 	scopes: ['openid', 'profile'], // and any other scopes you need
+	autoRenew: true, // optional, defaults to true
+	renewGracePeriod: 60, // optional, defaults to 60 seconds
 };
 
 const identityAuth = new IdentityAuth(config);
@@ -69,20 +85,23 @@ const identityAuth = new IdentityAuth(config);
 
 `IdentityAuth` exposes the following:
 
-- [`isSignedInWithAuthState`](#isSignedInWithAuthState)
-- [`isSignedIn`](#isSignedIn)
-- [`authStateManager`](#authStateManager)
-  - [`getAuthState`](#getAuthState)
+- [`isSignedInWithAuthState`](#issignedinwithauthstate)
+- [`isSignedIn`](#issignedin)
+- [`authStateManager`](#authstatemanager)
+  - [`getAuthState`](#getauthstate)
   - [`subscribe`](#subscribe)
   - [`unsubscribe`](#unsubscribe)
-- [`tokenManager`](#tokenManager)
+- [`tokenManager`](#tokenmanager)
   - [`clear`](#clear)
-  - [`getTokens`](#getTokens)
-  - [`getTokensSync`](#getTokensSync)
-  - [`setTokens`](#setTokens)
+  - [`getTokens`](#gettokens)
+  - [`getTokensSync`](#gettokenssync)
+  - [`renew`](#renew)
+  - [`setTokens`](#settokens)
 - [`token`](#token)
-  - [`getWithoutPrompt`](#getWithoutPrompt)
-  - [`verifyToken`](#verifyToken)
+  - [`getWithoutPrompt`](#getwithoutprompt)
+  - [`verifyToken`](#verifytoken)
+- [`autoRenew`](#autorenew)
+  - [`start`](#start)
 
 #### `isSignedInWithAuthState`
 
@@ -238,6 +257,16 @@ tokens.accessToken; // the user's access token
 tokens.idToken; // the user's id token
 ```
 
+#### `renew`
+
+Attempts to renew the tokens, regardless of whether they are expired or not
+
+Returns tokens or `undefined`.
+
+```ts
+const renewedTokens = await identityAuth.tokenManager.renew();
+```
+
 #### `setTokens`
 
 Sets the tokens in local storage, very unlikely you'll need to manually use this unless you're manually retrieving tokens using the `token` class.
@@ -320,6 +349,14 @@ try {
 	// handle other errors
 }
 ```
+
+### `autoRenew`
+
+The `autoRenew` object is an instance of `AutoRenew`, which manages the automatic renewal of tokens based on the expiry time of the tokens and the `autoRenew` options (`autoRenew` and `renewGracePeriod`).
+
+#### `start`
+
+Starts the automatic renewal of tokens, will automatically be started, no need to call, but exposed for use in other internal classes.
 
 ## Types
 

--- a/libs/@guardian/identity-auth/src/@types/OAuth.ts
+++ b/libs/@guardian/identity-auth/src/@types/OAuth.ts
@@ -17,6 +17,27 @@ export interface IdentityAuthOptions {
 }
 
 /**
+ * Defines the state of the IdentityAuth instance when not authenticated.
+ */
+export type IdentityAuthStateNotAuthenticated = {
+	accessToken: undefined;
+	idToken: undefined;
+	isAuthenticated: false;
+};
+
+/**
+ * Defines the state of the IdentityAuth instance when authenticated.
+ */
+export type IdentityAuthStateAuthenticated<
+	AC extends CustomClaims = CustomClaims,
+	IC extends CustomClaims = CustomClaims,
+> = {
+	accessToken: AccessToken<AC>;
+	idToken: IDToken<IC>;
+	isAuthenticated: true;
+};
+
+/**
  * Defines the state of the IdentityAuth instance.
  *
  * `isAuthenticated` - `true` when access and id token are present, `false` otherwise
@@ -26,11 +47,7 @@ export interface IdentityAuthOptions {
 export type IdentityAuthState<
 	AC extends CustomClaims = CustomClaims,
 	IC extends CustomClaims = CustomClaims,
-> = {
-	accessToken?: AccessToken<AC>;
-	idToken?: IDToken<IC>;
-	isAuthenticated: boolean;
-};
+> = IdentityAuthStateNotAuthenticated | IdentityAuthStateAuthenticated<AC, IC>;
 
 /**
  * Parameter required for the OAuth2 authorization code flow, /authorize endpoint

--- a/libs/@guardian/identity-auth/src/@types/OAuth.ts
+++ b/libs/@guardian/identity-auth/src/@types/OAuth.ts
@@ -5,6 +5,13 @@ import type { AccessToken, CustomClaims, IDToken } from './Token';
  * Ask the Identity team for the values to use for your app.
  *
  * https://developer.okta.com/docs/reference/api/oidc/
+ *
+ * @param clientId - The client ID of your app
+ * @param issuer - The issuer of the tokens
+ * @param scopes - The scopes that your app requires
+ * @param redirectUri - The redirect URI of your app
+ * @param autoRenew - Whether to automatically renew the tokens, defaults to `true`
+ * @param renewGracePeriod - The time in seconds before the access token expires to renew the token, defaults to 60 seconds
  */
 export interface IdentityAuthOptions {
 	clientId: string;
@@ -14,6 +21,8 @@ export interface IdentityAuthOptions {
 		| 'thegulocal'}.com/oauth2/${string}`;
 	scopes: ['openid', 'profile', ...string[]];
 	redirectUri: string;
+	autoRenew?: boolean;
+	renewGracePeriod?: number;
 }
 
 /**

--- a/libs/@guardian/identity-auth/src/__tests__/autoRenew.test.ts
+++ b/libs/@guardian/identity-auth/src/__tests__/autoRenew.test.ts
@@ -1,0 +1,215 @@
+/* eslint-disable @typescript-eslint/unbound-method -- jest mocks */
+
+import type { IdentityAuthOptions } from '../@types/OAuth';
+import { AuthStateManager } from '../authState';
+import { AutoRenewService } from '../autoRenew';
+import { Emitter } from '../emitter';
+import { Token } from '../token';
+import { TokenManager } from '../tokenManager';
+
+jest.useFakeTimers();
+
+jest.mock('../authState');
+jest.mock('../token');
+jest.mock('../tokenManager');
+
+const setVisibilityState = (value: DocumentVisibilityState = 'visible') => {
+	Object.defineProperty(document, 'visibilityState', {
+		writable: true,
+		configurable: true,
+		value,
+	});
+	Object.defineProperty(document, 'hidden', {
+		configurable: true,
+		get: function () {
+			return value === 'hidden';
+		},
+	});
+};
+
+describe('IdentityAuth#AutoRenewService', () => {
+	let token: Token;
+	let tokenManager: TokenManager;
+	let emitter: Emitter;
+	let authStateManager: AuthStateManager;
+
+	const options: IdentityAuthOptions = {
+		clientId: 'test',
+		issuer: 'https://profile.theguardian.com/oauth2/test',
+		redirectUri: 'test',
+		scopes: ['openid', 'profile', 'test'],
+	};
+
+	beforeEach(() => {
+		token = new (Token as jest.MockedClass<typeof Token>)(options, {
+			authorizeUrl: 'https://profile.theguardian.com/oauth2/test/v1/authorize',
+			tokenUrl: 'https://profile.theguardian.com/oauth2/test/v1/token',
+			keysUrl: 'https://profile.theguardian.com/oauth2/test/v1/keys',
+		});
+		emitter = new Emitter();
+		tokenManager = new (TokenManager as jest.MockedClass<typeof TokenManager>)(
+			emitter,
+			token,
+		);
+		authStateManager = new AuthStateManager(emitter, tokenManager);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+
+		setVisibilityState();
+	});
+
+	it('should start the auto renew service', () => {
+		const autoRenewService = new AutoRenewService(
+			{
+				...options,
+				autoRenew: true,
+				renewGracePeriod: 60,
+			},
+			emitter,
+			authStateManager,
+		);
+
+		authStateManager.getAuthState = jest.fn().mockReturnValue({
+			isAuthenticated: false,
+		});
+
+		autoRenewService.start();
+
+		expect(autoRenewService.started).toBe(true);
+	});
+
+	it('should not start the auto renew service if autoRenew is false', () => {
+		const autoRenewService = new AutoRenewService(
+			{
+				...options,
+				autoRenew: false,
+				renewGracePeriod: 60,
+			},
+			emitter,
+			authStateManager,
+		);
+
+		autoRenewService.start();
+
+		expect(autoRenewService.started).toBe(false);
+	});
+
+	it('should emit a renew event when the token should be renewed', () => {
+		const autoRenewService = new AutoRenewService(
+			{
+				...options,
+				autoRenew: true,
+				renewGracePeriod: 60,
+			},
+			emitter,
+			authStateManager,
+		);
+
+		authStateManager.getAuthState = jest.fn().mockReturnValue({
+			accessToken: {
+				expiresAt: 0,
+			},
+			isAuthenticated: true,
+		});
+
+		emitter.emit = jest.fn();
+
+		autoRenewService.start();
+
+		jest.runAllTimers();
+
+		expect(authStateManager.getAuthState).toHaveBeenCalledTimes(1);
+
+		expect(emitter.emit).toHaveBeenCalledTimes(1);
+		expect(emitter.emit).toHaveBeenCalledWith('renew');
+	});
+
+	it('should handle visibility change within grace period of renewal', () => {
+		const mockAddEventListener = jest.spyOn(document, 'addEventListener');
+
+		setVisibilityState('hidden');
+
+		const autoRenewService = new AutoRenewService(
+			{
+				...options,
+				autoRenew: true,
+				renewGracePeriod: 60,
+			},
+			emitter,
+			authStateManager,
+		);
+
+		authStateManager.getAuthState = jest.fn().mockReturnValue({
+			accessToken: {
+				expiresAt: 0,
+			},
+			isAuthenticated: true,
+		});
+
+		emitter.emit = jest.fn();
+
+		autoRenewService.start();
+
+		jest.runAllTimers();
+
+		expect(authStateManager.getAuthState).toHaveBeenCalledTimes(1);
+
+		expect(emitter.emit).toHaveBeenCalledTimes(0);
+		expect(mockAddEventListener).toHaveBeenCalledTimes(1);
+
+		setVisibilityState('visible');
+		document.dispatchEvent(new Event('visibilitychange'));
+
+		expect(authStateManager.getAuthState).toHaveBeenCalledTimes(2);
+		expect(emitter.emit).toHaveBeenCalledTimes(1);
+	});
+
+	it('should handle visibility change outside grace period of renewal but has GU_U cookie', () => {
+		document.cookie = 'GU_U=value;';
+
+		const mockAddEventListener = jest.spyOn(document, 'addEventListener');
+
+		setVisibilityState('hidden');
+
+		const autoRenewService = new AutoRenewService(
+			{
+				...options,
+				autoRenew: true,
+				renewGracePeriod: 60,
+			},
+			emitter,
+			authStateManager,
+		);
+
+		authStateManager.getAuthState = jest
+			.fn()
+			.mockReturnValueOnce({
+				accessToken: {
+					expiresAt: 0,
+				},
+				isAuthenticated: true,
+			})
+			.mockReturnValueOnce({
+				isAuthenticated: false,
+			});
+
+		emitter.emit = jest.fn();
+
+		autoRenewService.start();
+
+		jest.runAllTimers();
+
+		expect(authStateManager.getAuthState).toHaveBeenCalledTimes(1);
+
+		expect(emitter.emit).toHaveBeenCalledTimes(0);
+		expect(mockAddEventListener).toHaveBeenCalledTimes(1);
+
+		setVisibilityState('visible');
+		document.dispatchEvent(new Event('visibilitychange'));
+
+		expect(authStateManager.getAuthState).toHaveBeenCalledTimes(2);
+		expect(emitter.emit).toHaveBeenCalledTimes(1);
+	});
+});

--- a/libs/@guardian/identity-auth/src/__tests__/identityAuth.test.ts
+++ b/libs/@guardian/identity-auth/src/__tests__/identityAuth.test.ts
@@ -17,6 +17,7 @@ describe('IdentityAuth', () => {
 			issuer: 'https://profile.theguardian.com/oauth2/test',
 			redirectUri: 'test',
 			scopes: ['openid', 'profile', 'test'],
+			autoRenew: false,
 		});
 
 		const accessToken: AccessToken = {
@@ -100,6 +101,7 @@ describe('IdentityAuth', () => {
 				issuer: 'https://profile.theguardian.com/oauth2/test',
 				redirectUri: 'test',
 				scopes: ['openid', 'profile', 'test'],
+				autoRenew: false,
 			},
 		);
 

--- a/libs/@guardian/identity-auth/src/__tests__/tokenManager.test.ts
+++ b/libs/@guardian/identity-auth/src/__tests__/tokenManager.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/unbound-method -- jest mocks */
 import { storage } from '@guardian/libs';
 import type { AccessToken, IDToken } from '../@types/Token';
 import { Emitter } from '../emitter';
@@ -141,7 +142,30 @@ describe('IdentityAuth#TokenManager', () => {
 			idToken,
 		});
 
-		// eslint-disable-next-line @typescript-eslint/unbound-method -- jest mock
 		expect(token.getWithoutPrompt).toHaveBeenCalledTimes(1);
+	});
+
+	it('should renew the tokens if renew is called', async () => {
+		jest.spyOn(token, 'getWithoutPrompt').mockImplementation(() =>
+			Promise.resolve({
+				state: 'state',
+				tokens: {
+					accessToken,
+					idToken,
+				},
+			}),
+		);
+
+		tokenManager.setTokens = jest.fn();
+
+		const tokens = await tokenManager.renew();
+
+		expect(tokens).toEqual({
+			accessToken,
+			idToken,
+		});
+
+		expect(token.getWithoutPrompt).toHaveBeenCalledTimes(1);
+		expect(tokenManager.setTokens).toHaveBeenCalledTimes(1);
 	});
 });

--- a/libs/@guardian/identity-auth/src/authState.ts
+++ b/libs/@guardian/identity-auth/src/authState.ts
@@ -11,13 +11,20 @@ export class AuthStateManager<
 	AC extends CustomClaims = CustomClaims,
 	IC extends CustomClaims = CustomClaims,
 > {
-	#authState: IdentityAuthState<AC, IC> | undefined = undefined;
+	#authState: IdentityAuthState<AC, IC>;
 	#emitter: Emitter;
 	#tokenManager: TokenManager<AC, IC>;
 
 	constructor(emitter: Emitter, tokenManager: TokenManager<AC, IC>) {
 		this.#emitter = emitter;
 		this.#tokenManager = tokenManager;
+
+		// set default auth state, will be updated if there are existing tokens in storage
+		this.#authState = {
+			accessToken: undefined,
+			idToken: undefined,
+			isAuthenticated: false,
+		};
 
 		// on init, check if there are existing tokens in storage, and if so, update the auth state
 		this.#updateAuthState();
@@ -57,6 +64,8 @@ export class AuthStateManager<
 		} else {
 			// if there are no tokens, set the auth state to false
 			this.#authState = {
+				accessToken: undefined,
+				idToken: undefined,
 				isAuthenticated: false,
 			};
 		}
@@ -70,7 +79,7 @@ export class AuthStateManager<
 	 * @description Returns the current auth state
 	 * @returns IdentityAuthState
 	 */
-	public getAuthState(): IdentityAuthState<AC, IC> | undefined {
+	public getAuthState(): IdentityAuthState<AC, IC> {
 		return this.#authState;
 	}
 

--- a/libs/@guardian/identity-auth/src/autoRenew.ts
+++ b/libs/@guardian/identity-auth/src/autoRenew.ts
@@ -1,0 +1,146 @@
+import { getCookie } from '@guardian/libs';
+import type { IdentityAuthOptions, IdentityAuthState } from './@types/OAuth';
+import type { AuthStateManager } from './authState';
+import type { Emitter } from './emitter';
+
+/**
+ * @class AutoRenewService
+ * @description Managing the auto renewal of tokens, if enabled
+ */
+export class AutoRenewService {
+	#options: Required<IdentityAuthOptions>;
+	#emitter: Emitter;
+	#authStateManager: AuthStateManager;
+	started = false;
+
+	#renewAtTimeoutId: number | undefined;
+
+	constructor(
+		options: Required<IdentityAuthOptions>,
+		emitter: Emitter,
+		authStateManager: AuthStateManager,
+	) {
+		this.#options = options;
+		this.#emitter = emitter;
+		this.#authStateManager = authStateManager;
+
+		// if there is a storage event, clear the timeout, and start a new one
+		this.#emitter.on('storage', () => {
+			this.#clearRenewAtTimeout();
+			this.#handleAuthStateChange();
+		});
+	}
+
+	/**
+	 * @name clearRenewAtTimeout
+	 * @description Clears the timeout for renewing the access token, if it exists
+	 */
+	#clearRenewAtTimeout() {
+		if (this.#renewAtTimeoutId !== undefined) {
+			window.clearTimeout(this.#renewAtTimeoutId);
+			this.#renewAtTimeoutId = undefined;
+		}
+	}
+
+	/**
+	 * @name setRenewAtTimeout
+	 * @description Sets the timeout for renewing the access token based on the expiry time and the grace period
+	 * @param expiresAt The time at which the access token expires
+	 * @returns The timeout id
+	 */
+	#setRenewAtTimeout(expiresAt: number) {
+		// get the time now
+		const now = Date.now();
+
+		// calculate the time at which the access token should be renewed
+		const renewAt = (expiresAt - this.#options.renewGracePeriod) * 1000;
+
+		// calculate the timeout duration
+		const timeout = renewAt - now;
+
+		// set the timeout
+		this.#renewAtTimeoutId = window.setTimeout(() => {
+			// if the document is hidden, then we need to wait for the visibility change event before renewing the token
+			if (window.document.visibilityState === 'hidden') {
+				// if the document is hidden, then wait for the visibility change event
+				window.document.addEventListener(
+					'visibilitychange',
+					() => {
+						if (window.document.visibilityState === 'visible') {
+							// now that the document is visible, we first check if any other tabs have renewed the token already
+							const authState = this.#authStateManager.getAuthState();
+
+							// if the user is authenticated, but there is less than the grace period left on the token, then we should renew it
+							if (
+								authState.isAuthenticated &&
+								authState.accessToken.expiresAt -
+									this.#options.renewGracePeriod <
+									Math.floor(Date.now() / 1000)
+							) {
+								// if the token has not been renewed, emit the renew event
+								this.#emitter.emit('renew');
+							}
+
+							// if the authState is not authenticated, and there is a GU_U cookie, then the token has not been renewed and we can renew it
+							if (
+								!authState.isAuthenticated &&
+								!!getCookie({ name: 'GU_U', shouldMemoize: true })
+							) {
+								// if the token has not been renewed, emit the renew event
+								this.#emitter.emit('renew');
+							}
+						}
+					},
+					{
+						once: true, // only listen for the event once
+					},
+				);
+			} else {
+				// if the document is not hidden, then we can renew the token
+				// emit the renew event, which will trigger the renew method in the token manager
+				this.#emitter.emit('renew');
+			}
+
+			// clear the timeout id once the timeout has been triggered
+			this.#renewAtTimeoutId = undefined;
+		}, timeout);
+	}
+
+	/**
+	 * @name handleAuthStateChange
+	 * @description Listens for changes to the auth state and sets the timeout for renewing the access token if required
+	 * @param state - The IdentityAuthState
+	 */
+	#handleAuthStateChange(state?: IdentityAuthState) {
+		// clear the timeout if it exists
+		this.#clearRenewAtTimeout();
+
+		// if the state was not passed in, get the state from the auth state manager
+		const authState: IdentityAuthState =
+			state ?? this.#authStateManager.getAuthState();
+
+		// if the user is authenticated, set the timeout for renewing the access token
+		if (authState.isAuthenticated) {
+			this.#setRenewAtTimeout(authState.accessToken.expiresAt);
+		}
+	}
+
+	/**
+	 * @name start
+	 * @description Starts the auto renewal service if autoRenew is enabled
+	 */
+	start() {
+		if (this.#options.autoRenew && !this.started) {
+			// set the started flag to true
+			this.started = true;
+
+			// listen for auth state changes
+			this.#emitter.on('authStateChange', (state: IdentityAuthState) =>
+				this.#handleAuthStateChange(state),
+			);
+
+			// handle the auth state change on start
+			this.#handleAuthStateChange();
+		}
+	}
+}

--- a/libs/@guardian/identity-auth/src/emitter.ts
+++ b/libs/@guardian/identity-auth/src/emitter.ts
@@ -6,7 +6,12 @@ type Event = {
 	ctx?: unknown;
 };
 
-export type EventName = 'added' | 'removed' | 'storage' | 'authStateChange';
+export type EventName =
+	| 'added'
+	| 'authStateChange'
+	| 'removed'
+	| 'renew'
+	| 'storage';
 
 /**
  * @class Emitter

--- a/libs/@guardian/identity-auth/src/identityAuth.ts
+++ b/libs/@guardian/identity-auth/src/identityAuth.ts
@@ -74,17 +74,15 @@ export class IdentityAuth<
 			if (getCookie({ name: 'GU_SO', shouldMemoize: true })) {
 				this.tokenManager.clear();
 				return {
+					accessToken: undefined,
+					idToken: undefined,
 					isAuthenticated: false,
 				};
 			}
 
 			// if user tokens already exist, they are signed in
 			const authState = this.authStateManager.getAuthState();
-			if (
-				authState?.isAuthenticated &&
-				authState.accessToken &&
-				authState.idToken
-			) {
+			if (authState.isAuthenticated) {
 				// validate the id token and access token to make sure auth state is still valid
 				await this.token.verifyToken(authState.idToken, authState.accessToken);
 
@@ -100,15 +98,19 @@ export class IdentityAuth<
 				const tokens = await this.tokenManager.getTokens({
 					refreshIfRequired: true,
 				});
-				return {
-					accessToken: tokens?.accessToken,
-					idToken: tokens?.idToken,
-					isAuthenticated: true,
-				};
+				if (tokens) {
+					return {
+						accessToken: tokens.accessToken,
+						idToken: tokens.idToken,
+						isAuthenticated: true,
+					};
+				}
 			}
 
 			// if the user doesn't have tokens or a GU_U cookie, they are not signed in
 			return {
+				accessToken: undefined,
+				idToken: undefined,
 				isAuthenticated: false,
 			};
 		} catch (error) {
@@ -116,6 +118,8 @@ export class IdentityAuth<
 			if (error instanceof OAuthError && error.error === 'login_required') {
 				// so return isAuthenticated: false
 				return {
+					accessToken: undefined,
+					idToken: undefined,
 					isAuthenticated: false,
 				};
 			}

--- a/libs/@guardian/identity-auth/src/index.ts
+++ b/libs/@guardian/identity-auth/src/index.ts
@@ -1,4 +1,9 @@
-import type { IdentityAuthOptions, IdentityAuthState } from './@types/OAuth';
+import type {
+	IdentityAuthOptions,
+	IdentityAuthState,
+	IdentityAuthStateAuthenticated,
+	IdentityAuthStateNotAuthenticated,
+} from './@types/OAuth';
 import type {
 	AccessToken,
 	AccessTokenClaims,
@@ -10,7 +15,12 @@ import type {
 import { IdentityAuth } from './identityAuth';
 
 export { IdentityAuth };
-export type { IdentityAuthOptions, IdentityAuthState };
+export type {
+	IdentityAuthOptions,
+	IdentityAuthState,
+	IdentityAuthStateAuthenticated,
+	IdentityAuthStateNotAuthenticated,
+};
 export type {
 	AccessToken,
 	AccessTokenClaims,

--- a/libs/@guardian/identity-auth/src/token.ts
+++ b/libs/@guardian/identity-auth/src/token.ts
@@ -522,7 +522,7 @@ export const addPostMessageListener = (
 
 	// return the promise, clearing the timeout and removing the event listener when the promise resolves
 	return msgReceivedOrTimeout.finally(() => {
-		clearTimeout(timeoutId);
+		window.clearTimeout(timeoutId);
 		window.removeEventListener('message', responseHandler);
 	});
 };

--- a/libs/@guardian/identity-auth/src/tokenManager.ts
+++ b/libs/@guardian/identity-auth/src/tokenManager.ts
@@ -37,6 +37,10 @@ export class TokenManager<
 				this.#emitStorage();
 			}
 		});
+
+		this.#emitter.on('renew', async () => {
+			await this.renew();
+		});
 	}
 
 	/**
@@ -171,5 +175,16 @@ export class TokenManager<
 		this.#storage.remove(this.#idTokenKey);
 		this.#emitRemoved('accessToken');
 		this.#emitRemoved('idToken');
+	}
+
+	/**
+	 * @name renew
+	 * @description Attempts to renew the tokens, regardless of whether they are expired or not
+	 * @returns Promise<Tokens | undefined> - The tokens if they exist
+	 */
+	public async renew(): Promise<Tokens<AC, IC> | undefined> {
+		const tokenResponse = await this.#token.getWithoutPrompt();
+		this.setTokens(tokenResponse.tokens);
+		return tokenResponse.tokens;
 	}
 }


### PR DESCRIPTION
## What does this change?

- Adds an `autoRenew` service which will automatically renew/refresh tokens silently before they expire
  - This is enabled through the `autoRenew` flag in the `IdentityAuthOptions` config object, this defaults to `true`
  - The time when it's renewed is controlled through the `renewGracePeriod` option, which defaults to `60` seconds before the tokens expire
- Updates the type definitions for `IdentityAuthState` to explicitly define the `IdentityAuthStateNotAuthenticated` and `IdentityAuthStateAuthenticated` states, which are now also exported

### `AutoRenew` service

The auto renew service is required as if a user stays on a page longer than the time it takes for a token to expire, then when a user attempts to take an authenticated action, it would behave as if the user is not logged in, e.g. posting a comment.

We can mitigate this edge case through the auto renew service, which will automatically refresh the token in the background before it expires should the user still be on the page.

We also use the Page Visibility API, so that tokens are only ever renewed on the active tab, rather than all renewing at the same time on multiple different hidden/background tabs. The refreshed tokens will migrate to the other tabs through local storage anyway.

The main reason for this is to limit the number of refresh calls that we make to Okta, without the visiblity API, if a user had 5 tabs open or in a hidden tab, then when the token would expire, it would make 5 separate API calls to Okta in order to renew.
The Page Visibility API limits this to 1 call on an open tab, or when a user comes back to a hidden/background tab.

This is difficult to automatically test, but through manual testing was done to make sure this behaviour worked as expected.

## Note

While this is a breaking change regarding the type definitions, we're making this a `minor` bump, as we don't want to release `1.0.0` until we're ready to release the migration piece on DCR.