### PR TITLE
Deprecate `@guardian/libs`'s `ArticlePillar` in favour of `Pillar`.

### DIFF
--- a/.changeset/hip-walls-pretend.md
+++ b/.changeset/hip-walls-pretend.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Deprecate `ArticlePillar` in favour of `Pillar`. `ArticlePillar` will be removed entirely in a future major release.

--- a/libs/@guardian/libs/src/deprecated-exports.ts
+++ b/libs/@guardian/libs/src/deprecated-exports.ts
@@ -1,0 +1,10 @@
+/**
+ * DEPRECATED EXPORTS
+ *
+ * To be removed from the public interface in the next major version.
+ */
+
+import { Pillar } from './format/Pillar';
+
+/** @deprecated Use `Pillar` instead. */
+export const ArticlePillar = Pillar;

--- a/libs/@guardian/libs/src/format/ArticleTheme.ts
+++ b/libs/@guardian/libs/src/format/ArticleTheme.ts
@@ -1,4 +1,4 @@
-import type { ArticlePillar } from './ArticlePillar';
 import type { ArticleSpecial } from './ArticleSpecial';
+import type { Pillar } from './Pillar';
 
-export type ArticleTheme = ArticlePillar | ArticleSpecial;
+export type ArticleTheme = Pillar | ArticleSpecial;

--- a/libs/@guardian/libs/src/format/Pillar.ts
+++ b/libs/@guardian/libs/src/format/Pillar.ts
@@ -1,4 +1,4 @@
-export enum ArticlePillar {
+export enum Pillar {
 	News = 0,
 	Opinion = 1,
 	Sport = 2,

--- a/libs/@guardian/libs/src/format/format.test.ts
+++ b/libs/@guardian/libs/src/format/format.test.ts
@@ -1,7 +1,7 @@
 import { ArticleDesign } from './ArticleDesign';
 import { ArticleDisplay } from './ArticleDisplay';
-import { ArticlePillar } from './ArticlePillar';
 import { ArticleSpecial } from './ArticleSpecial';
+import { Pillar } from './Pillar';
 
 it('Design enum contains Article', () => {
 	expect(ArticleDesign.Standard).toBeDefined();
@@ -12,7 +12,7 @@ it('Display enum contains Standard', () => {
 });
 
 it('Pillar enum contains News', () => {
-	expect(ArticlePillar.News).toBe(0);
+	expect(Pillar.News).toBe(0);
 });
 
 it('Special enum contains SpecialReport', () => {

--- a/libs/@guardian/libs/src/index.test.ts
+++ b/libs/@guardian/libs/src/index.test.ts
@@ -8,6 +8,7 @@ describe('The package', () => {
 			'ArticleElementRole',
 			'ArticlePillar',
 			'ArticleSpecial',
+			'Pillar',
 			'countries',
 			'debug',
 			'getCookie',

--- a/libs/@guardian/libs/src/index.ts
+++ b/libs/@guardian/libs/src/index.ts
@@ -1,5 +1,7 @@
 /* istanbul ignore file */
 
+export * from './deprecated-exports';
+
 export { ArticleElementRole } from './ArticleElementRole/ArticleElementRole';
 
 export { getCookie } from './cookies/getCookie';
@@ -17,9 +19,9 @@ export { timeAgo } from './datetime/timeAgo';
 export { ArticleDesign } from './format/ArticleDesign';
 export { ArticleDisplay } from './format/ArticleDisplay';
 export type { ArticleFormat } from './format/ArticleFormat';
-export { ArticlePillar } from './format/ArticlePillar';
 export { ArticleSpecial } from './format/ArticleSpecial';
 export type { ArticleTheme } from './format/ArticleTheme';
+export { Pillar } from './format/Pillar';
 
 export { isBoolean } from './isBoolean/isBoolean';
 export { isNonNullable } from './isNonNullable/isNonNullable';


### PR DESCRIPTION
## What are you changing?

- Deprecate `@guardian/libs`'s `ArticlePillar` in favour of `Pillar`

_Co-authored with @joecowton1, supersedes #679._

## Why?

In DCR (one of the two primary consumers of `ArticleFormat`, along with AR) we support several categories of pages that aren't articles: fronts, the all newsletters page etc.. These pages still have a concept of pillar, to use in the nav and footer for example, and need to make use of this `Pillar` type. Therefore we'd like to rename it to reflect its wider usage.

For more context see the following:

- https://github.com/guardian/dotcom-rendering/issues/7562
- https://github.com/guardian/dotcom-rendering/pull/7587#discussion_r1194931855
- https://github.com/guardian/dotcom-rendering/pull/7967
