### PR TITLE
Use NX Cloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     types: [opened, labeled, synchronize]
 
 env:
+  # The `accessToken` in `nx.json` is a read-only token for use in dev.
+  # This overrides it with a read-write token so that CI run results are 
+  # remotely cached.
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, labeled, synchronize]
 
+env:
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -19,6 +22,8 @@ jobs:
           - task: build-storybooks
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       # enables use to use the cache in actions/setup-node
       - uses: pnpm/action-setup@v2.2.4
@@ -27,6 +32,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+
+      - uses: nrwl/nx-set-shas@v3
 
       - run: pnpm install --frozen-lockfile
 

--- a/nx.json
+++ b/nx.json
@@ -19,7 +19,7 @@
 	"tasksRunnerOptions": {
 		"default": {
 			"options": {
-				"accessToken": "OTdkYmFjMTYtNGFhNS00MjM2LTg0OGMtZmNhNGZiMmU2YTM5fHJlYWQtd3JpdGU=",
+				"accessToken": "ZDI5NGQyNWMtYzRiNS00YjM0LWJkNDItMWEzMGQ2NWMwNWJkfHJlYWQtb25seQ==",
 				"cacheableOperations": [
 					"build",
 					"lint",


### PR DESCRIPTION
## What are you changing?

- reintroducing NX Cloud as per recipe here: https://nx.dev/recipes/ci/monorepo-ci-github-actions
- the token in `nx.json` is read-only as recommended by NX: [nx.dev/nx-cloud/account/scenarios#security-scenarios](https://nx.dev/nx-cloud/account/scenarios#security-scenarios)

## Why?

- cloud caching improves both CI times and local dev experience
