### PR TITLE
Fix `CODEOWNERS` Paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,21 +4,21 @@
 
 * @guardian/client-side-infra
 
-.changeset/* @guardian/client-side-infra @guardian/dotcom-platform @guardian/commercial-dev @guardian/source @guardian/identity
+/.changeset/ @guardian/client-side-infra @guardian/dotcom-platform @guardian/commercial-dev @guardian/source @guardian/identity
 
-libs/@guardian/atoms-rendering/* @guardian/dotcom-platform @guardian/commercial-dev @guardian/client-side-infra
+/libs/@guardian/atoms-rendering/ @guardian/dotcom-platform @guardian/commercial-dev @guardian/client-side-infra
 
-libs/@guardian/source-foundations/* @guardian/source
-libs/@guardian/source-react-components/* @guardian/source
-libs/@guardian/source-react-components-development-kitchen/* @guardian/source
-libs/@guardian/eslint-plugin-source-foundations/* @guardian/source
-libs/@guardian/eslint-plugin-source-react-components/* @guardian/source
+/libs/@guardian/source-foundations/ @guardian/source
+/libs/@guardian/source-react-components/ @guardian/source
+/libs/@guardian/source-react-components-development-kitchen/ @guardian/source
+/libs/@guardian/eslint-plugin-source-foundations/ @guardian/source
+/libs/@guardian/eslint-plugin-source-react-components/ @guardian/source
 
-libs/@guardian/tsconfig/* @guardian/client-side-infra
-libs/@guardian/prettier/* @guardian/client-side-infra
-libs/@guardian/eslint-config/* @guardian/client-side-infra
-libs/@guardian/eslint-config-typescript/* @guardian/client-side-infra
-libs/@guardian/browserlist-config/*  @guardian/client-side-infra @guardian/dotcom-platform
-libs/@guardian/libs/* @guardian/client-side-infra @guardian/apps-rendering @guardian/dotcom-platform
+/libs/@guardian/tsconfig/ @guardian/client-side-infra
+/libs/@guardian/prettier/ @guardian/client-side-infra
+/libs/@guardian/eslint-config/ @guardian/client-side-infra
+/libs/@guardian/eslint-config-typescript/ @guardian/client-side-infra
+/libs/@guardian/browserlist-config/  @guardian/client-side-infra @guardian/dotcom-platform
+/libs/@guardian/libs/ @guardian/client-side-infra @guardian/apps-rendering @guardian/dotcom-platform
 
-libs/@guardian/identity-auth/* @guardian/identity
+/libs/@guardian/identity-auth/ @guardian/identity


### PR DESCRIPTION
## What are you changing?

Made two changes to the entries in the `CODEOWNERS` file:

1. Removed the trailing `*`s
2. Added leading `/`s

Without 1) the entry only applies to files in the directory specified, not any of its subdirectories. Without 2) the entry matches any path that includes the path specified, not just the one from the root.

Based on the documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

## How to test

Using the `identity-auth` library as a test case, we can compare the `OAuth.ts` file on this branch vs `main`:

- `main`: https://github.com/guardian/csnx/blob/6755e7e97dc1ad34149094632cbbda152c94da65/libs/%40guardian/identity-auth/src/%40types/OAuth.ts
- branch: https://github.com/guardian/csnx/blob/fix-codeowners-paths/libs/%40guardian/identity-auth/src/%40types/OAuth.ts

If you hover over the lock icon, on `main` it should tell you the owner is CS Infra, whereas on the branch it should tell you the owner is Identity.

![lock](https://github.com/guardian/csnx/assets/53781962/455e78ab-b7bb-4020-bcbe-9784d0cb028d)

This change in behaviour is a result of 1) above. On `main` Identity only owns the contents of `identity-auth`; the subdirectories (which include this file) fall back to CS Infra as the default. However, on the branch Identity also owns the subdirectories.

I don't have an example to test 2) as I'm not aware of it causing any issues so far.
