### PR TITLE
Don't snapshot the YoutubeAtom no overlay story

### DIFF
--- a/libs/@guardian/atoms-rendering/src/YoutubeAtom.stories.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtom.stories.tsx
@@ -74,6 +74,10 @@ export const NoOverlay = (): JSX.Element => {
 	);
 };
 
+NoOverlay.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
 export const WithOverrideImage = (): JSX.Element => {
 	return (
 		<div style={containerStyle}>


### PR DESCRIPTION
## What are you changing?

Don't snapshot the YoutubeAtom 'no overlay' story as it is flaky when running as part of the collated csnx Storybook.

