### PR TITLE
Add 'key' and 'length' methods to Storage

### DIFF
--- a/libs/@guardian/libs/src/storage/README.md
+++ b/libs/@guardian/libs/src/storage/README.md
@@ -14,19 +14,19 @@ import { storage } from '@guardian/libs';
 
 Has a few advantages over the native API:
 
--   fails gracefully if storage is not available
--   you can save and retrieve any JSONable data
--   stored items can expire
+- fails gracefully if storage is not available
+- you can save and retrieve any JSONable data
+- stored items can expire
 
 _n.b. the examples below use `storage.local`, but all methods are available for both `storage.local` and `storage.session`._
 
 ## Methods
 
--   [`get(key)`](#getkey)
--   [`set(key, value, expires?)`](#setkey-value-expires)
--   [`remove(key)`](#removekey)
--   [`clear()`](#clear)
--   [`isAvailable()`](#isavailable)
+- [`get(key)`](#getkey)
+- [`set(key, value, expires?)`](#setkey-value-expires)
+- [`remove(key)`](#removekey)
+- [`clear()`](#clear)
+- [`isAvailable()`](#isavailable)
 
 ## `get(key)`
 
@@ -74,18 +74,18 @@ Optional expiry date for this item.
 
 ```js
 storage.local.set('my-item', {
-    prop1: 'abc',
-    prop2: 123,
+	prop1: 'abc',
+	prop2: 123,
 });
 
 storage.local.set(
-    'my-expiring-item',
-    {
-        prop1: 'abc',
-        prop2: 123,
-    },
-    // expires 24 hours from now
-    Date.now() + 60 * 60 * 24 * 1000,
+	'my-expiring-item',
+	{
+		prop1: 'abc',
+		prop2: 123,
+	},
+	// expires 24 hours from now
+	Date.now() + 60 * 60 * 24 * 1000,
 );
 ```
 
@@ -117,6 +117,32 @@ Removes all items from storage.
 
 ```js
 storage.local.clear();
+```
+
+## `key(index: number)`
+
+Returns: `string[] | null`
+
+Get the name of the key at `index` in the storage object. Returns `null` if index
+is out of range or storage is unavailable.
+
+### Example
+
+```js
+storage.local.key(1);
+```
+
+## `length()`
+
+Returns `number | null`
+
+Get the number of items in the storage object. Returns `null` if storage is
+unavailable.
+
+### Example
+
+```js
+storage.local.length();
 ```
 
 ## `isAvailable()`

--- a/libs/@guardian/libs/src/storage/storage.test.ts
+++ b/libs/@guardian/libs/src/storage/storage.test.ts
@@ -131,4 +131,44 @@ describe.each([
 		implementation.setRaw('raw item', '🦁');
 		expect(native.getItem('raw item')).toBe('🦁');
 	});
+
+	it(`gets keys in storage by index`, async () => {
+		expect(implementation.key(0)).toEqual(null);
+
+		native.setItem('item 1', 'some val');
+		native.setItem('item 2', 'some other val');
+		/**
+		 * The underlying native API doesn't guarantee order across different environments,
+		 * so we can't know for sure which key we will retrieve.
+		 */
+		expect(['item 1', 'item 2']).toContain(implementation.key(0));
+
+		native.removeItem('item 1');
+		expect(implementation.key(0)).toEqual('item 2');
+
+		setSpy.mockImplementation(functionThatThrowsAnError);
+		getSpy.mockImplementation(functionThatThrowsAnError);
+
+		// re-import now we've disabled native storage API
+		const { storage } = await import('./storage');
+		expect(storage[name].key(0)).toBeNull();
+	});
+
+	it(`returns the number of items in storage`, async () => {
+		expect(implementation.length()).toEqual(0);
+
+		native.setItem('item 1', 'some val');
+		native.setItem('item 2', 'some other val');
+		expect(implementation.length()).toEqual(2);
+
+		native.removeItem('item 1');
+		expect(implementation.length()).toEqual(1);
+
+		setSpy.mockImplementation(functionThatThrowsAnError);
+		getSpy.mockImplementation(functionThatThrowsAnError);
+
+		// re-import now we've disabled native storage API
+		const { storage } = await import('./storage');
+		expect(storage[name].length()).toEqual(null);
+	});
 });

--- a/libs/@guardian/libs/src/storage/storage.ts
+++ b/libs/@guardian/libs/src/storage/storage.ts
@@ -98,6 +98,32 @@ class StorageFactory {
 	setRaw(key: string, value: string): void {
 		return this.#storage?.setItem(key, value);
 	}
+
+	/**
+	 * Get key by index.
+	 * @returns the name of the key at that index (`string`), or `null` (if
+	 *      index is out of range of if storage is unavailable) - if the index
+	 *      is out of range, or if storage is not available.
+	 *
+	 * Wrapper for the `key` method on the native `Storage` object, with
+	 * additional check for availability of storage. Note that the _order_ of
+	 * keys in storage is dependent on user-agent implementation, and so you
+	 * should not assume that keys will be stored in any particular order (e.g.
+	 * order of insertion).
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Storage/key
+	 */
+	key(index: number): string | null {
+		return this.#storage?.key(index) ?? null;
+	}
+
+	/**
+	 * Get the number of items in storage.
+	 * @returns the number of items in storage, or `null` if storage is
+	 * 	not available.
+	 */
+	length(): number | null {
+		return this.#storage?.length ?? null;
+	}
 }
 
 /**


### PR DESCRIPTION
## What are you changing?

Add wrappers for the built-in `key` method and `length` property on `Storage` objects.

## Why?

These can be useful for extracting the keys from storage, especially given that we (presumably by design?) don't provide direct access to the whole storage object via this API.

Adding `key` and `length` to the API allows users of the library to use these methods with the same extra checks that they get for other methods that wrap built-in functionality in this lib.

In light of the discussion below, I thought it was best to revise this PR to add wrappers around these built-in methods, rather than adding a new abstraction. I thought it best to add these changes on top of the original branch, but happy to rewrite the history to remove the first two commits (which add code which is then removed in the third commit) if desired.

## Original PR description

```
## What are you changing?

Adds a method to return all keys of the storage object in `lib/storage`, by iterating over them.

## Why?

This is not a built-in method on the Storage objects, but provides an abstraction over the built-in `key` method. The `key` method doesn't have that much use outside of getting all the keys, and it has a potential gotcha insofar as the order of keys isn't reliable across user-agents (but `.key()` gets keys by index).

If we aren't happy with adding this new method, could we perhaps consider giving access to the built-in `key` method on the Storage class in this library, to allow users of the library to create their own `keys`-style implementation on top of it?


```