### PR TITLE
Remove `axios` in favour of native `fetch`

### DIFF
--- a/libs/@guardian/source-react-components/package.json
+++ b/libs/@guardian/source-react-components/package.json
@@ -18,7 +18,6 @@
 		"@types/mkdirp": "1.0.2",
 		"@types/prettier": "2.7.2",
 		"@types/react": "18.2.11",
-		"axios": "0.27.2",
 		"dotenv": "16.0.3",
 		"mkdirp": "1.0.4",
 		"prettier": "2.8.8",

--- a/libs/@guardian/source-react-components/scripts/create-icons/get-svgs-from-figma.ts
+++ b/libs/@guardian/source-react-components/scripts/create-icons/get-svgs-from-figma.ts
@@ -35,8 +35,7 @@ const figmaApi = async <T>(url: string): Promise<T> => {
 		`https://api.figma.com/v1/${url}`,
 		FIGMA_API_OPTIONS,
 	);
-	const data = await response.json();
-	return data;
+	return response.json();
 };
 
 export const getIconsFromFigma = async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,7 +389,6 @@ importers:
       '@types/mkdirp': 1.0.2
       '@types/prettier': 2.7.2
       '@types/react': 18.2.11
-      axios: 0.27.2
       dotenv: 16.0.3
       mkdirp: 1.0.4
       prettier: 2.8.8
@@ -409,7 +408,6 @@ importers:
       '@types/mkdirp': 1.0.2
       '@types/prettier': 2.7.2
       '@types/react': 18.2.11
-      axios: 0.27.2
       dotenv: 16.0.3
       mkdirp: 1.0.4
       prettier: 2.8.8
@@ -9106,15 +9104,6 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /axios/0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-    dependencies:
-      follow-redirects: 1.15.1
-      form-data: 4.0.0
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
   /axios/1.1.3:
     resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
     dependencies:
@@ -11981,16 +11970,6 @@ packages:
   /flow-parser/0.207.0:
     resolution: {integrity: sha512-s90OlXqzWj1xc4yUtqD1Gr8pGVx0/5rk9gsqPrOYF1kBAPMH4opkmzdWgQ8aNe3Pckqtwr8DlYGbfE2GnW+zsg==}
     engines: {node: '>=0.4.0'}
-    dev: true
-
-  /follow-redirects/1.15.1:
-    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
     dev: true
 
   /follow-redirects/1.15.2:


### PR DESCRIPTION
## What are you changing?

- Removes `axios` from the `source-react-components` package and replaces usage with native `fetch`.

## Why?

- As we're now using Node 18 which supports native `fetch` there's no need to rely upon an external dependency for data fetching, particularly as our needs are fairly minimal.
- Native `fetch` is also faster: execution time for the `create-icons` script has been reduced from 90 seconds to 26 seconds on average.

```bash
time pnpm --filter @guardian/source-react-components create-icons
```

| Run | `axios` | `fetch` |
| --- | --- | --- |
| 1 | 1m32.532s |   0m27.927s |
| 2 | 1m31.135s | 0m26.212s |
| 3 | 1m29.709s | 0m25.295s |
 