### PR TITLE
Identity Auth | Change token storage/verification, and refactor certain methods

### DIFF
--- a/.changeset/olive-seals-give.md
+++ b/.changeset/olive-seals-give.md
@@ -1,0 +1,8 @@
+---
+'@guardian/identity-auth': minor
+---
+
+- Add `decodeTokens` method to `Token` class
+- Refactor library so that we only store required values in l `verifyTokens`ocal storage, and now derive other values from decoding the token
+- Rename `verifyToken` method to `verifyTokens` in `Token` class to better reflect functionality
+- Use access token to verify timestamps, instead of id tokens

--- a/.changeset/olive-seals-give.md
+++ b/.changeset/olive-seals-give.md
@@ -3,6 +3,6 @@
 ---
 
 - Add `decodeTokens` method to `Token` class
-- Refactor library so that we only store required values in l `verifyTokens`ocal storage, and now derive other values from decoding the token
+- Refactor library so that we only store required values in `verifyTokens` local storage, and now derive other values from decoding the token
 - Rename `verifyToken` method to `verifyTokens` in `Token` class to better reflect functionality
 - Use access token to verify timestamps, instead of id tokens

--- a/libs/@guardian/identity-auth/src/@types/Token.ts
+++ b/libs/@guardian/identity-auth/src/@types/Token.ts
@@ -121,6 +121,11 @@ export type AccessToken<T extends CustomClaims = CustomClaims> =
 	};
 
 /**
+ * The access token storage object, containing the access token.
+ */
+export type AccessTokenStorage = Pick<AccessToken, 'accessToken'>;
+
+/**
  * The ID token object.
  */
 export type IDToken<T extends CustomClaims = CustomClaims> = AbstractToken & {
@@ -130,6 +135,11 @@ export type IDToken<T extends CustomClaims = CustomClaims> = AbstractToken & {
 	clientId: string;
 	nonce: string;
 };
+
+/**
+ * The ID token storage object, containing the ID token and nonce.
+ */
+export type IDTokenStorage = Pick<IDToken, 'idToken' | 'nonce'>;
 
 /**
  * The tokens object, containing the access token and ID token.

--- a/libs/@guardian/identity-auth/src/__tests__/tokenManager.test.ts
+++ b/libs/@guardian/identity-auth/src/__tests__/tokenManager.test.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/unbound-method -- jest mocks */
 import { storage } from '@guardian/libs';
-import type { AccessToken, IDToken } from '../@types/Token';
+import type {
+	AccessToken,
+	AccessTokenStorage,
+	IDToken,
+	IDTokenStorage,
+} from '../@types/Token';
 import { Emitter } from '../emitter';
 import { Token } from '../token';
 import { TokenManager } from '../tokenManager';
@@ -40,6 +45,10 @@ describe('IdentityAuth#TokenManager', () => {
 		tokenType: 'tokenType',
 	};
 
+	const accessTokenStorage: AccessTokenStorage = {
+		accessToken: 'accessToken',
+	};
+
 	const idToken: IDToken = {
 		claims: {
 			amr: ['amr'],
@@ -66,6 +75,11 @@ describe('IdentityAuth#TokenManager', () => {
 		idToken: 'idToken',
 		issuer: 'issuer',
 		scopes: ['scp'],
+		nonce: 'nonce',
+	};
+
+	const idTokenStorage: IDTokenStorage = {
+		idToken: 'idToken',
 		nonce: 'nonce',
 	};
 
@@ -105,12 +119,12 @@ describe('IdentityAuth#TokenManager', () => {
 		expect(mockedSetLocal).toHaveBeenCalledTimes(2);
 		expect(mockedSetLocal).toHaveBeenCalledWith(
 			'gu.access_token',
-			accessToken,
+			accessTokenStorage,
 			new Date(accessToken.expiresAt * 1000),
 		);
 		expect(mockedSetLocal).toHaveBeenCalledWith(
 			'gu.id_token',
-			idToken,
+			idTokenStorage,
 			new Date(idToken.expiresAt * 1000),
 		);
 	});

--- a/libs/@guardian/identity-auth/src/identityAuth.ts
+++ b/libs/@guardian/identity-auth/src/identityAuth.ts
@@ -99,7 +99,7 @@ export class IdentityAuth<
 			const authState = this.authStateManager.getAuthState();
 			if (authState.isAuthenticated) {
 				// validate the id token and access token to make sure auth state is still valid
-				await this.token.verifyToken(authState.idToken, authState.accessToken);
+				await this.token.verifyTokens(authState.idToken, authState.accessToken);
 
 				// if the id token is valid, return the auth state
 				return authState;

--- a/libs/@guardian/identity-auth/src/token.ts
+++ b/libs/@guardian/identity-auth/src/token.ts
@@ -283,7 +283,7 @@ const decodeTokens = <
 	const accessToken: AccessToken<AC> = {
 		accessToken: accessTokenRaw,
 		claims: accessTokenPayload,
-		expiresAt: accessTokenPayload.exp - accessTokenPayload.iat + now, // adjusting expiresAt to be in local (machine) time, to account for clock skew, // adjusted to local (machine) time, to account for clock skew
+		expiresAt: accessTokenPayload.exp - accessTokenPayload.iat + now, // adjusting expiresAt to be in local (machine) time, to account for clock skew
 		clockSkew: accessTokenClockSkew,
 		tokenType: 'Bearer',
 		scopes: accessTokenPayload.scp,

--- a/libs/@guardian/identity-auth/src/tokenManager.ts
+++ b/libs/@guardian/identity-auth/src/tokenManager.ts
@@ -161,7 +161,7 @@ export class TokenManager<
 	 * @name getTokens
 	 * @description Gets the tokens from storage asynchronously, can refresh tokens if required and verify them
 	 *
-	 * @param verifyTokens - If true, will verify the token before returning (default: true)
+	 * @param verifyTokens - If true, will verify the tokens before returning (default: true)
 	 * @param refreshIfRequired - If true, will refresh the tokens if they are expired (default: false)
 	 * @returns Promise<Tokens | undefined> - The tokens if they exist
 	 */


### PR DESCRIPTION
## What are you changing?

- We now only store the raw access token string under `gu.access_token`, and the raw id token string + nonce user
`gu.id_token` rather than the entire decoded token.
  - This is because it was possible to modify what was in local storage (e.g. a token's claims), verify the tokens, and use the modified values in your application, which can be a security issue.
  - By only storing the minimum information in local storage we can eliminate this risk, and instead
generate what is required when the tokens are decoded from local storage.
  - To facilitate this we added a public `decodeTokens` method to the `Token` class.
- We also rename `verifyToken` to `verifyTokens` as that better describes what is happening, i.e verifying both the access and id tokens.
- We also use access token timestamps to validate expiry instead of id tokens
  - This is because the ID token in Okta is only valid for 1 hour with no way to change this, whereas the access token can be valid anywhere from 5 minutes to 24 hours, so we use the access token as the source of truth for the expiry timestamp

This is technically a breaking change, but since we're still in pre-release (i.e v0) this will bump the minor version rather than releasing a v1.
