### PR TITLE
Extend youtube atom API for autopausing and text overlay

### DIFF
--- a/libs/@guardian/atoms-rendering/src/YoutubeAtom.stories.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtom.stories.tsx
@@ -290,6 +290,7 @@ export const Sticky = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				shouldPauseOutOfView={true}
 			/>
 			<div style={{ height: '1000px' }}></div>
 		</div>
@@ -441,5 +442,38 @@ export const MultipleStickyVideos = (): JSX.Element => {
 };
 
 MultipleStickyVideos.parameters = {
+	chromatic: { disableSnapshot: true },
+};
+
+export const PausesOffscreen = (): JSX.Element => {
+	return (
+		<div>
+			<div>Scroll down...</div>
+			<YoutubeAtom
+				elementId="xyz"
+				videoId="-ZCvZmYlQD8"
+				alt=""
+				role="inline"
+				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
+				consentState={consentStateCanTarget}
+				duration={252}
+				pillar={Pillar.Culture}
+				height={450}
+				width={800}
+				shouldStick={false}
+				isMainMedia={true}
+				title="Rayshard Brooks: US justice system treats us like 'animals'"
+				imaEnabled={false}
+				abTestParticipations={{}}
+				adTargeting={adTargeting}
+				shouldPauseOutOfView={true}
+			/>
+			<div style={{ height: '1000px' }}></div>
+			<p>It stopped playing!</p>
+		</div>
+	);
+};
+
+PausesOffscreen.parameters = {
 	chromatic: { disableSnapshot: true },
 };

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtom.stories.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtom.stories.tsx
@@ -223,6 +223,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
 				kicker="Breaking News"
+				showTextOverlay={true}
 			/>
 		</div>
 	);

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtom.stories.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtom.stories.tsx
@@ -1,4 +1,4 @@
-import { ArticlePillar } from '@guardian/libs';
+import { Pillar } from '@guardian/libs';
 import { useState } from 'react';
 import { consentStateCanTarget } from './fixtures/consentStateCanTarget';
 import { YoutubeAtom } from './YoutubeAtom';
@@ -43,7 +43,7 @@ export const NoConsent = (): JSX.Element => {
 				role="inline"
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 				duration={252}
-				pillar={ArticlePillar.Culture}
+				pillar={Pillar.Culture}
 				height={450}
 				width={800}
 				shouldStick={false}
@@ -67,7 +67,7 @@ export const NoOverlay = (): JSX.Element => {
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 				consentState={consentStateCanTarget}
 				duration={252}
-				pillar={ArticlePillar.Culture}
+				pillar={Pillar.Culture}
 				height={450}
 				width={800}
 				shouldStick={false}
@@ -97,7 +97,7 @@ export const WithOverrideImage = (): JSX.Element => {
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 				duration={252}
 				consentState={consentStateCanTarget}
-				pillar={ArticlePillar.News}
+				pillar={Pillar.News}
 				overrideImage={[
 					{
 						srcSet: [
@@ -129,7 +129,7 @@ export const WithPosterImage = (): JSX.Element => {
 				alt=""
 				role="inline"
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
-				pillar={ArticlePillar.Sport}
+				pillar={Pillar.Sport}
 				duration={252}
 				consentState={consentStateCanTarget}
 				posterImage={[
@@ -179,7 +179,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
 				role="inline"
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 				duration={252}
-				pillar={ArticlePillar.Opinion}
+				pillar={Pillar.Opinion}
 				videoCategory="live"
 				overrideImage={[
 					{
@@ -222,6 +222,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
 				imaEnabled={false}
 				abTestParticipations={{}}
 				adTargeting={adTargeting}
+				kicker="Breaking News"
 			/>
 		</div>
 	);
@@ -242,7 +243,7 @@ export const GiveConsent = (): JSX.Element => {
 					eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 					consentState={consented ? consentStateCanTarget : undefined}
 					duration={252}
-					pillar={ArticlePillar.News}
+					pillar={Pillar.News}
 					overrideImage={[
 						{
 							srcSet: [
@@ -280,7 +281,7 @@ export const Sticky = (): JSX.Element => {
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 				consentState={consentStateCanTarget}
 				duration={252}
-				pillar={ArticlePillar.Culture}
+				pillar={Pillar.Culture}
 				height={450}
 				width={800}
 				shouldStick={true}
@@ -308,7 +309,7 @@ export const StickyMainMedia = (): JSX.Element => {
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 				consentState={consentStateCanTarget}
 				duration={252}
-				pillar={ArticlePillar.Culture}
+				pillar={Pillar.Culture}
 				height={450}
 				width={800}
 				shouldStick={true}
@@ -339,7 +340,7 @@ export const DuplicateVideos = (): JSX.Element => {
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 				consentState={consentStateCanTarget}
 				duration={252}
-				pillar={ArticlePillar.Culture}
+				pillar={Pillar.Culture}
 				height={450}
 				width={800}
 				shouldStick={true}
@@ -356,7 +357,7 @@ export const DuplicateVideos = (): JSX.Element => {
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 				consentState={consentStateCanTarget}
 				duration={252}
-				pillar={ArticlePillar.Culture}
+				pillar={Pillar.Culture}
 				height={450}
 				width={800}
 				shouldStick={true}
@@ -389,7 +390,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 				consentState={consentStateCanTarget}
 				duration={252}
-				pillar={ArticlePillar.Culture}
+				pillar={Pillar.Culture}
 				height={450}
 				width={800}
 				shouldStick={true}
@@ -407,7 +408,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 				consentState={consentStateCanTarget}
 				duration={252}
-				pillar={ArticlePillar.Culture}
+				pillar={Pillar.Culture}
 				height={450}
 				width={800}
 				shouldStick={true}
@@ -425,7 +426,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
 				eventEmitters={[(e) => console.log(`analytics event ${e} called`)]}
 				consentState={consentStateCanTarget}
 				duration={252}
-				pillar={ArticlePillar.Culture}
+				pillar={Pillar.Culture}
 				height={450}
 				width={800}
 				shouldStick={true}

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtom.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtom.tsx
@@ -38,6 +38,7 @@ type Props = {
 	videoCategory?: VideoCategory;
 	kicker?: string;
 	shouldPauseOutOfView?: boolean;
+	showTextOverlay?: boolean;
 };
 
 export const YoutubeAtom = ({
@@ -63,6 +64,7 @@ export const YoutubeAtom = ({
 	kicker,
 	pillar,
 	shouldPauseOutOfView,
+	showTextOverlay,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -197,6 +199,7 @@ export const YoutubeAtom = ({
 						videoCategory={videoCategory}
 						kicker={kicker}
 						pillar={pillar}
+						showTextOverlay={showTextOverlay}
 					/>
 				)}
 				{showPlaceholder && <YoutubeAtomPlaceholder uniqueId={uniqueId} />}

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtom.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtom.tsx
@@ -37,6 +37,7 @@ type Props = {
 	abTestParticipations: Participations;
 	videoCategory?: VideoCategory;
 	kicker?: string;
+	shouldPauseOutOfView?: boolean;
 };
 
 export const YoutubeAtom = ({
@@ -61,6 +62,7 @@ export const YoutubeAtom = ({
 	videoCategory,
 	kicker,
 	pillar,
+	shouldPauseOutOfView,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -148,10 +150,11 @@ export const YoutubeAtom = ({
 			shouldStick={shouldStick}
 			isActive={isActive}
 			eventEmitters={eventEmitters}
-			setPauseVideo={() => setPauseVideo(true)}
+			setPauseVideo={setPauseVideo}
 			isMainMedia={isMainMedia}
 			isClosed={isClosed}
 			setIsClosed={setIsClosed}
+			shouldPauseOutOfView={shouldPauseOutOfView}
 		>
 			<MaintainAspectRatio height={height} width={width}>
 				{loadPlayer && consentState && adTargeting && (

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtom.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtom.tsx
@@ -63,8 +63,8 @@ export const YoutubeAtom = ({
 	videoCategory,
 	kicker,
 	pillar,
-	shouldPauseOutOfView,
-	showTextOverlay,
+	shouldPauseOutOfView = false,
+	showTextOverlay = false,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtom.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtom.tsx
@@ -36,6 +36,7 @@ type Props = {
 	imaEnabled: boolean;
 	abTestParticipations: Participations;
 	videoCategory?: VideoCategory;
+	kicker?: string;
 };
 
 export const YoutubeAtom = ({
@@ -58,6 +59,8 @@ export const YoutubeAtom = ({
 	imaEnabled,
 	abTestParticipations,
 	videoCategory,
+	kicker,
+	pillar,
 }: Props): JSX.Element => {
 	const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
 	const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -189,6 +192,8 @@ export const YoutubeAtom = ({
 						title={title}
 						onClick={() => setOverlayClicked(true)}
 						videoCategory={videoCategory}
+						kicker={kicker}
+						pillar={pillar}
 					/>
 				)}
 				{showPlaceholder && <YoutubeAtomPlaceholder uniqueId={uniqueId} />}

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtomOverlay.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtomOverlay.tsx
@@ -29,6 +29,7 @@ type Props = {
 	videoCategory?: VideoCategory;
 	kicker?: string;
 	pillar: ArticleTheme;
+	showTextOverlay?: boolean;
 };
 
 const overlayStyles = css`
@@ -179,6 +180,7 @@ export const YoutubeAtomOverlay = ({
 	videoCategory,
 	kicker,
 	pillar,
+	showTextOverlay,
 }: Props): JSX.Element => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = duration !== undefined && duration > 0;
@@ -221,10 +223,12 @@ export const YoutubeAtomOverlay = ({
 				</span>
 			</div>
 
-			<div css={headlineStyles}>
-				<div css={kickerStyles(pillar)}>{kicker}</div>
-				<div css={titleStyles}>{title}</div>
-			</div>
+			{showTextOverlay && (
+				<div css={headlineStyles}>
+					<div css={kickerStyles(pillar)}>{kicker}</div>
+					<div css={titleStyles}>{title}</div>
+				</div>
+			)}
 		</button>
 	);
 };

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtomOverlay.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtomOverlay.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import {
 	focusHalo,
+	headline,
 	palette,
 	space,
 	textSans,
@@ -9,7 +10,8 @@ import { SvgMediaControlsPlay } from '@guardian/source-react-components';
 import { formatTime } from './lib/formatTime';
 import { Picture } from './Picture';
 import type { ImageSource, RoleType } from './types';
-
+import { ArticleTheme } from '@guardian/libs';
+import { pillarPalette } from './lib/pillarPalette';
 export type VideoCategory = 'live' | 'documentary' | 'explainer';
 
 type Props = {
@@ -24,6 +26,8 @@ type Props = {
 	title?: string;
 	onClick: () => void;
 	videoCategory?: VideoCategory;
+	kicker?: string;
+	pillar: ArticleTheme;
 };
 
 const overlayStyles = css`
@@ -102,6 +106,31 @@ const pillStyles = css`
 	display: inline-flex;
 `;
 
+const headlineStyling = css`
+	position: absolute;
+	background: linear-gradient(
+		180deg,
+		rgba(0, 0, 0, 0) 0%,
+		rgba(0, 0, 0, 0.7) 25.04%
+	);
+	width: 100%;
+	bottom: 0;
+	color: #ffffff;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	text-align: start;
+	padding: 36px 8px 8px 8px;
+`;
+
+const kickerStyles = (pillar: ArticleTheme) => css`
+	color: ${pillarPalette[pillar][400]};
+	${headline.xxsmall({ fontWeight: 'bold' })};
+`;
+const titleStyles = css`
+	${headline.xxsmall({ fontWeight: 'medium' })};
+`;
+
 const pillItemStyles = css`
 	/* Target all but the first element, and add a border */
 	:nth-of-type(n + 2) {
@@ -142,6 +171,8 @@ export const YoutubeAtomOverlay = ({
 	title,
 	onClick,
 	videoCategory,
+	kicker,
+	pillar,
 }: Props): JSX.Element => {
 	const id = `youtube-overlay-${uniqueId}`;
 	const hasDuration = duration !== undefined && duration > 0;
@@ -182,6 +213,11 @@ export const YoutubeAtomOverlay = ({
 				<span css={svgStyles}>
 					<SvgMediaControlsPlay />
 				</span>
+			</div>
+
+			<div css={headlineStyling}>
+				<div css={kickerStyles(pillar)}>{kicker}</div>
+				<div css={titleStyles}>{title}</div>
 			</div>
 		</button>
 	);

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtomOverlay.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtomOverlay.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+	from,
 	focusHalo,
 	headline,
 	palette,
@@ -76,7 +77,7 @@ const svgStyles = css`
 		transition-duration: 300ms;
 	}
 `;
-const playButtonStyling = css`
+const playButtonStyles = css`
 	position: absolute;
 	top: 50%;
 	left: 50%;
@@ -106,31 +107,6 @@ const pillStyles = css`
 	display: inline-flex;
 `;
 
-const headlineStyling = css`
-	position: absolute;
-	background: linear-gradient(
-		180deg,
-		rgba(0, 0, 0, 0) 0%,
-		rgba(0, 0, 0, 0.7) 25.04%
-	);
-	width: 100%;
-	bottom: 0;
-	color: #ffffff;
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	text-align: start;
-	padding: 36px 8px 8px 8px;
-`;
-
-const kickerStyles = (pillar: ArticleTheme) => css`
-	color: ${pillarPalette[pillar][400]};
-	${headline.xxsmall({ fontWeight: 'bold' })};
-`;
-const titleStyles = css`
-	${headline.xxsmall({ fontWeight: 'medium' })};
-`;
-
 const pillItemStyles = css`
 	/* Target all but the first element, and add a border */
 	:nth-of-type(n + 2) {
@@ -156,6 +132,36 @@ const liveStyles = css`
 	}
 `;
 
+const headlineStyles = css`
+	position: absolute;
+	background: linear-gradient(
+		180deg,
+		rgba(0, 0, 0, 0) 0%,
+		rgba(0, 0, 0, 0.7) 25.04%
+	);
+	width: 100%;
+	bottom: 0;
+	color: #ffffff;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	text-align: start;
+	padding: 36px 8px 8px 8px;
+`;
+
+const kickerStyles = (pillar: ArticleTheme) => css`
+	color: ${pillarPalette[pillar][400]};
+	${headline.xxxsmall({ fontWeight: 'bold' })};
+	${from.tablet} {
+		${headline.xxsmall({ fontWeight: 'bold' })};
+	}
+`;
+const titleStyles = css`
+	${headline.xxxsmall({ fontWeight: 'medium' })};
+	${from.tablet} {
+		${headline.xxsmall({ fontWeight: 'medium' })};
+	}
+`;
 const capitalise = (str: string): string =>
 	str.charAt(0).toUpperCase() + str.slice(1);
 
@@ -209,13 +215,13 @@ export const YoutubeAtomOverlay = ({
 					)}
 				</div>
 			)}
-			<div className="overlay-play-button" css={playButtonStyling}>
+			<div className="overlay-play-button" css={playButtonStyles}>
 				<span css={svgStyles}>
 					<SvgMediaControlsPlay />
 				</span>
 			</div>
 
-			<div css={headlineStyling}>
+			<div css={headlineStyles}>
 				<div css={kickerStyles(pillar)}>{kicker}</div>
 				<div css={titleStyles}>{title}</div>
 			</div>

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtomOverlay.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtomOverlay.tsx
@@ -133,12 +133,12 @@ const liveStyles = css`
 	}
 `;
 
-const headlineStyles = css`
+const textOverlayStyles = css`
 	position: absolute;
 	background: linear-gradient(
 		180deg,
 		rgba(0, 0, 0, 0) 0%,
-		rgba(0, 0, 0, 0.7) 25.04%
+		rgba(0, 0, 0, 0.7) 25%
 	);
 	width: 100%;
 	bottom: 0;
@@ -147,7 +147,8 @@ const headlineStyles = css`
 	flex-direction: column;
 	align-items: flex-start;
 	text-align: start;
-	padding: 36px 8px 8px 8px;
+	padding: ${space[2]}px;
+	padding-top: ${space[9]}px;
 `;
 
 const kickerStyles = (pillar: ArticleTheme) => css`
@@ -224,7 +225,7 @@ export const YoutubeAtomOverlay = ({
 			</div>
 
 			{showTextOverlay && (
-				<div css={headlineStyles}>
+				<div css={textOverlayStyles}>
 					<div css={kickerStyles(pillar)}>{kicker}</div>
 					<div css={titleStyles}>{title}</div>
 				</div>

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtomPlayer.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtomPlayer.tsx
@@ -49,6 +49,7 @@ type Props = {
 	pauseVideo: boolean;
 	deactivateVideo: () => void;
 	abTestParticipations: Participations;
+	kicker?: string;
 };
 
 type CustomPlayEventDetail = { videoId: string };
@@ -365,6 +366,7 @@ export const YoutubeAtomPlayer = ({
 	pauseVideo,
 	deactivateVideo,
 	abTestParticipations,
+	kicker,
 }: Props): JSX.Element => {
 	/**
 	 * useRef for player and progressEvents

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtomSticky.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtomSticky.tsx
@@ -112,12 +112,13 @@ type Props = {
 	videoId: string;
 	eventEmitters: Array<(event: VideoEventKey) => void>;
 	shouldStick?: boolean;
-	setPauseVideo: () => void;
+	setPauseVideo: (state: boolean) => void;
 	isActive: boolean;
 	isMainMedia?: boolean;
 	children: JSX.Element;
 	isClosed: boolean;
 	setIsClosed: (state: boolean) => void;
+	shouldPauseOutOfView?: boolean;
 };
 
 const isMobile = detectMobile({ tablet: true });
@@ -133,6 +134,7 @@ export const YoutubeAtomSticky = ({
 	children,
 	isClosed,
 	setIsClosed,
+	shouldPauseOutOfView,
 }: Props): JSX.Element => {
 	const [isSticky, setIsSticky] = useState<boolean>(false);
 	const [stickEventSent, setStickEventSent] = useState<boolean>(false);
@@ -153,7 +155,7 @@ export const YoutubeAtomSticky = ({
 		// reset the sticky event sender
 		setStickEventSent(false);
 		// pause the video
-		setPauseVideo();
+		setPauseVideo(true);
 		// set isClosed so that player won't restick
 		setIsClosed(true);
 
@@ -199,6 +201,15 @@ export const YoutubeAtomSticky = ({
 	useEffect(() => {
 		if (shouldStick) setIsSticky(isActive && !isIntersecting && !isClosed);
 	}, [isIntersecting, isActive, shouldStick, isClosed]);
+
+	/**
+	 * useEffect for the pausing youtubeAtoms that are out of view
+	 */
+	useEffect(() => {
+		// Sticky-ness should take precedence over pausing
+		if (!shouldStick && shouldPauseOutOfView)
+			setPauseVideo(isActive && !isIntersecting && !isClosed);
+	}, [isIntersecting, shouldStick, isActive, shouldPauseOutOfView, isClosed]);
 
 	/**
 	 * useEffect for the stick events

--- a/libs/@guardian/atoms-rendering/src/YoutubeAtomSticky.tsx
+++ b/libs/@guardian/atoms-rendering/src/YoutubeAtomSticky.tsx
@@ -118,7 +118,7 @@ type Props = {
 	children: JSX.Element;
 	isClosed: boolean;
 	setIsClosed: (state: boolean) => void;
-	shouldPauseOutOfView?: boolean;
+	shouldPauseOutOfView: boolean;
 };
 
 const isMobile = detectMobile({ tablet: true });


### PR DESCRIPTION
## What are you changing?
Extends the YoutubeAtom API to include a showTextOverlay prop which renders the headline and kicker on a faded opacity overlay.  It also extends the API to allow autopausing when a playing video is swiped offscreen. 

## Why?
This is to help build the video container on DCR fronts.

As the youtube atom currently manages overlay hiding on click, this seemed like the most logical place to keep this text overlay too, so we can use the same functionality. There is an argument to say that we shouldn't couple container and atom too closely, however, it is reasonable that this overlay might want to be used outside of the video container. Also, there are plans to move this atom into the DCR repo (as it is only used in DCR) as which point the coupling becomes a little looser still. 

## Screenshots
<img width="799" alt="Screenshot 2023-07-27 at 09 47 59" src="https://github.com/guardian/csnx/assets/20416599/b1564f3b-17cd-492f-9936-d369faf21e78">


Example of the autopause is available in storybook