### PR TITLE
Helper to measure durations and create `PerformanceMeasure`s

### DIFF
--- a/.changeset/spicy-pugs-smell.md
+++ b/.changeset/spicy-pugs-smell.md
@@ -1,0 +1,6 @@
+---
+'@guardian/libs': minor
+---
+
+Add the `startPerformanceMeasure` helper, which has a unified API for measuring
+durations and producing `PerformanceMeasure`s.

--- a/libs/@guardian/libs/src/index.test.ts
+++ b/libs/@guardian/libs/src/index.test.ts
@@ -26,6 +26,7 @@ describe('The package', () => {
 			'removeCookie',
 			'setCookie',
 			'setSessionCookie',
+			'startPerformanceMeasure',
 			'storage',
 			'timeAgo',
 		]);

--- a/libs/@guardian/libs/src/index.ts
+++ b/libs/@guardian/libs/src/index.ts
@@ -39,6 +39,8 @@ export { debug } from './logger/debug';
 export { log } from './logger/log';
 export type { TeamName } from './logger/@types/logger';
 
+export { startPerformanceMeasure } from './performance/startPerformanceMeasure';
+
 export type {
 	OphanABEvent,
 	OphanABPayload,

--- a/libs/@guardian/libs/src/performance/@types/measure.ts
+++ b/libs/@guardian/libs/src/performance/@types/measure.ts
@@ -1,0 +1,15 @@
+declare global {
+	interface Performance {
+		/**
+		 * Firefox returned `undefined` before v101
+		 * @see https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark#browser_compatibility
+		 */
+		measure(
+			measureName: string,
+			startOrMeasureOptions?: string | PerformanceMeasureOptions,
+			endMark?: string,
+		): PerformanceMeasure | undefined;
+	}
+}
+
+export type {};

--- a/libs/@guardian/libs/src/performance/README.md
+++ b/libs/@guardian/libs/src/performance/README.md
@@ -1,0 +1,52 @@
+# `startPerformanceMeasure`
+
+Helper to measure the duration between two events.
+
+Once ended, measures are appended to the list of `PerformanceMeasure` and can be
+retrieved with `performance.getEntriesByType('measure')`
+
+### Example
+
+```js
+// my-file.js
+import { startPerformanceMeasure } from '@guardian/libs';
+
+const { endPerformanceMeasure } = startPerformanceMeasure('dotcom', 'fetch');
+// perform task
+await fetch('https://www.theguardian.com/uk.json');
+const duration = endPerformanceMeasure(); // duration of task in milliseconds
+```
+
+## Table of contents
+
+- [Methods](#methods)
+  - [`startPerformanceMeasure(team, name, action)`](#startperformancemeasureteam-name-action)
+
+## Methods
+
+### `startPerformanceMeasure(team, name, action)`
+
+Returns: `{ endPerformanceMeasure: () => number }`
+
+Start measuring a performance duration.
+
+#### `team`
+
+Type: `TeamName`<br>
+
+Name of the team interested in this log.
+Used for labelling `PerformanceMeasure`.
+
+#### `name`
+
+Type: `string`<br>
+
+The performed task’s name.
+Used for labelling `PerformanceMeasure`.
+
+#### `action`
+
+Type: `string | undefined`<br>
+
+Optional action performed as part of a task.
+Used for labelling `PerformanceMeasure`.

--- a/libs/@guardian/libs/src/performance/serialise.ts
+++ b/libs/@guardian/libs/src/performance/serialise.ts
@@ -1,0 +1,8 @@
+import { isNonNullable } from '../isNonNullable/isNonNullable';
+import type { TeamName } from '../logger/@types/logger';
+
+/** Serialisation is an implementation detail */
+const SEPARATOR = ':';
+
+export const serialise = (team: TeamName, name: string, action?: string) =>
+	[team, name, action].filter(isNonNullable).join(SEPARATOR);

--- a/libs/@guardian/libs/src/performance/startPerformanceMeasure.test.ts
+++ b/libs/@guardian/libs/src/performance/startPerformanceMeasure.test.ts
@@ -1,0 +1,12 @@
+import { startPerformanceMeasure } from './startPerformanceMeasure';
+
+describe('measure', () => {
+	it('can perform a measurement', () => {
+		const { endPerformanceMeasure } = startPerformanceMeasure(
+			'dotcom',
+			'Some Event',
+		);
+		const duration = endPerformanceMeasure();
+		expect(duration).toBe(-1);
+	});
+});

--- a/libs/@guardian/libs/src/performance/startPerformanceMeasure.ts
+++ b/libs/@guardian/libs/src/performance/startPerformanceMeasure.ts
@@ -1,0 +1,46 @@
+import type { TeamName } from '../logger/@types/logger';
+import type {} from './@types/measure';
+import { serialise } from './serialise';
+
+/** For browser which do not fully support the performance API */
+const fallback: ReturnType<typeof startPerformanceMeasure> = {
+	endPerformanceMeasure: () => -1,
+};
+
+/**
+ * Helper to measure the duration between two events.
+ *
+ * Once ended, measures are appended to the list of `PerformanceMeasure`
+ * and can be retrieved with `performance.getEntriesByType('measure')`
+ *
+ * @example
+ * const { endPerformanceMeasure } = startPerformanceMeasure('dotcom', 'fetch');
+ * await fetch('https://www.theguardian.com/uk.json');
+ * const duration = endPerformanceMeasure();
+ */
+export const startPerformanceMeasure = (
+	team: TeamName,
+	name: string,
+	action?: string,
+): { endPerformanceMeasure: () => number } => {
+	if (!('getEntriesByName' in window.performance)) {
+		return fallback;
+	}
+
+	const measureName = serialise(team, name, action);
+
+	const options = {
+		start: performance.now(),
+	} satisfies PerformanceMeasureOptions;
+
+	const endPerformanceMeasure = () => {
+		const { duration } = window.performance.measure(measureName, options) ??
+			window.performance.getEntriesByName(measureName, 'measure').at(-1) ?? {
+				duration: performance.now() - options.start,
+			};
+
+		return Math.ceil(duration);
+	};
+
+	return { endPerformanceMeasure };
+};


### PR DESCRIPTION
## What are you changing?

- Add a new method that can be user to measure durations.
- Using a curried function ensures the measurment can only be stopped afer it was started.

## Why?

- We rely on measurements for analysing performance and user metrics, so creating a single API can help teams with consistency.
- `PerformanceMeasure` contains all the information that `PerformanceMark` have, with an added duration. This API prevents potential bugs where two marks share the same name. 
