### PR TITLE
feat: add collection of INP metrics to core-web-vitals

### DIFF
--- a/.changeset/dull-olives-applaud.md
+++ b/.changeset/dull-olives-applaud.md
@@ -1,0 +1,5 @@
+---
+'@guardian/core-web-vitals': minor
+---
+
+Adds collection of INP data in core-web-vitals

--- a/.changeset/serious-yaks-pull.md
+++ b/.changeset/serious-yaks-pull.md
@@ -1,0 +1,5 @@
+---
+'@guardian/core-web-vitals': minor
+---
+
+Updated deprecated ReportHandler with ReportCallback in core-web-vitals

--- a/libs/@guardian/core-web-vitals/src/@types/CoreWebVitalsPayload.ts
+++ b/libs/@guardian/core-web-vitals/src/@types/CoreWebVitalsPayload.ts
@@ -6,4 +6,5 @@ export type CoreWebVitalsPayload = {
 	lcp: null | number;
 	fcp: null | number;
 	ttfb: null | number;
+	inp: null | number;
 };

--- a/libs/@guardian/core-web-vitals/src/index.test.ts
+++ b/libs/@guardian/core-web-vitals/src/index.test.ts
@@ -12,40 +12,47 @@ const defaultCoreWebVitalsPayload: CoreWebVitalsPayload = {
 	lcp: 150,
 	ttfb: 9.99,
 	cls: 0.01,
+	inp: 180.3,
 };
 
 const browserId = defaultCoreWebVitalsPayload.browser_id;
 const pageViewId = defaultCoreWebVitalsPayload.page_view_id;
 
 jest.mock('web-vitals', () => ({
-	getTTFB: (onReport: ReportHandler) => {
+	onTTFB: (onReport: ReportHandler) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.ttfb,
 			name: 'TTFB',
 		} as Metric);
 	},
-	getFCP: (onReport: ReportHandler) => {
+	onFCP: (onReport: ReportHandler) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.fcp,
 			name: 'FCP',
 		} as Metric);
 	},
-	getCLS: (onReport: ReportHandler) => {
+	onCLS: (onReport: ReportHandler) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.cls,
 			name: 'CLS',
 		} as Metric);
 	},
-	getFID: (onReport: ReportHandler) => {
+	onFID: (onReport: ReportHandler) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.fid,
 			name: 'FID',
 		} as Metric);
 	},
-	getLCP: (onReport: ReportHandler) => {
+	onLCP: (onReport: ReportHandler) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.lcp,
 			name: 'LCP',
+		} as Metric);
+	},
+	onINP: (onReport: ReportHandler) => {
+		onReport({
+			value: defaultCoreWebVitalsPayload.inp,
+			name: 'INP',
 		} as Metric);
 	},
 }));
@@ -114,6 +121,7 @@ describe('coreWebVitals', () => {
 			lcp: null,
 			ttfb: null,
 			cls: null,
+			inp: null,
 		});
 	});
 

--- a/libs/@guardian/core-web-vitals/src/index.ts
+++ b/libs/@guardian/core-web-vitals/src/index.ts
@@ -1,6 +1,6 @@
 import type { TeamName } from '@guardian/libs';
 import { log } from '@guardian/libs';
-import type { ReportCallback } from 'web-vitals';
+import { type ReportCallback } from 'web-vitals';
 import type { CoreWebVitalsPayload } from './@types/CoreWebVitalsPayload';
 import { roundWithDecimals } from './roundWithDecimals';
 
@@ -17,6 +17,7 @@ const coreWebVitalsPayload: CoreWebVitalsPayload = {
 	lcp: null,
 	fcp: null,
 	ttfb: null,
+	inp: null,
 };
 
 const teamsForLogging: Set<TeamName> = new Set();
@@ -71,6 +72,9 @@ const onReport: ReportCallback = (metric) => {
 			// Browser support: Chromium, Firefox, Safari, Internet Explorer
 			coreWebVitalsPayload.ttfb = roundWithDecimals(metric.value);
 			break;
+		case 'INP':
+			coreWebVitalsPayload.inp = roundWithDecimals(metric.value);
+			break;
 	}
 };
 
@@ -87,13 +91,14 @@ const listener = (e: Event): void => {
 
 const getCoreWebVitals = async (): Promise<void> => {
 	const webVitals = await import('web-vitals');
-	const { onCLS, onFCP, onFID, onLCP, onTTFB } = webVitals;
+	const { onCLS, onFCP, onFID, onLCP, onTTFB, onINP } = webVitals;
 
 	onCLS(onReport, { reportAllChanges: false });
 	onFID(onReport);
 	onLCP(onReport);
 	onFCP(onReport);
 	onTTFB(onReport);
+	onINP(onReport);
 
 	// Report all available metrics when the page is unloaded or in background.
 	addEventListener('visibilitychange', listener);

--- a/libs/@guardian/core-web-vitals/src/index.ts
+++ b/libs/@guardian/core-web-vitals/src/index.ts
@@ -87,13 +87,13 @@ const listener = (e: Event): void => {
 
 const getCoreWebVitals = async (): Promise<void> => {
 	const webVitals = await import('web-vitals');
-	const { getCLS, getFCP, getFID, getLCP, getTTFB } = webVitals;
+	const { onCLS, onFCP, onFID, onLCP, onTTFB } = webVitals;
 
-	getCLS(onReport, { reportAllChanges: false });
-	getFID(onReport);
-	getLCP(onReport);
-	getFCP(onReport);
-	getTTFB(onReport);
+	onCLS(onReport, { reportAllChanges: false });
+	onFID(onReport);
+	onLCP(onReport);
+	onFCP(onReport);
+	onTTFB(onReport);
 
 	// Report all available metrics when the page is unloaded or in background.
 	addEventListener('visibilitychange', listener);

--- a/libs/@guardian/core-web-vitals/src/index.ts
+++ b/libs/@guardian/core-web-vitals/src/index.ts
@@ -1,6 +1,6 @@
 import type { TeamName } from '@guardian/libs';
 import { log } from '@guardian/libs';
-import type { ReportHandler } from 'web-vitals';
+import type { ReportCallback } from 'web-vitals';
 import type { CoreWebVitalsPayload } from './@types/CoreWebVitalsPayload';
 import { roundWithDecimals } from './roundWithDecimals';
 
@@ -49,7 +49,7 @@ const sendData = (): void => {
 	}
 };
 
-const onReport: ReportHandler = (metric) => {
+const onReport: ReportCallback = (metric) => {
 	switch (metric.name) {
 		case 'FCP':
 			// Browser support: Chromium, Firefox, Safari Technology Preview


### PR DESCRIPTION
## What are you changing?

- Replacing the deprecated `ReportHandler` with `ReportCallback`
- Replacing the deprecated `getX` with `onX`
- Adds collection of [INP data](https://web.dev/inp/)

## Why?

`INP` is being used more widely and being reported in tools like Google Search Console (we've recently seen some warnings) and becoming [the replacement for FID in the future](https://web.dev/inp-cwv/). 

Let's get reporting on it so we can respond to it sooner rather than later.

---

## Filesize

I am not 100% sure of how we would know how much filesize this might add to the lib, but given the [source file is quite small](https://github.com/GoogleChrome/web-vitals/blob/3806160ffbc93c3c4abf210a167b81228172b31c/src/onINP.ts) - we should be OK. We will also be notified on the filesize diff when bumping the consumers version.

This isn't a great way to check filesize as I'd rather know at this point that there's an issue to avoid going through the release cycle to receive the feedback. Again though, it _feels_ OK, and if not, we can decide what to do at that point.

Maybe worth thinking about how we add feedback about filesize to libs that will inevitably end up in the browser at this point in the delivery pipeline.


