### PR TITLE
Only publish ES modules in compiled `@guardian` packages

### DIFF
--- a/.changeset/chilly-bags-drive.md
+++ b/.changeset/chilly-bags-drive.md
@@ -1,0 +1,20 @@
+---
+'@guardian/source-react-components-development-kitchen': major
+'@guardian/eslint-plugin-source-react-components': major
+'@guardian/eslint-plugin-source-foundations': major
+'@guardian/source-react-components': major
+'@guardian/source-foundations': major
+'@guardian/atoms-rendering': major
+'@guardian/core-web-vitals': major
+'@guardian/identity-auth': minor
+'@guardian/ab-react': major
+'@guardian/ab-core': major
+'@guardian/libs': major
+---
+
+- removes CommonJS exports
+- requires Node >= 16 (if you're using it with Node)
+
+Since [`@guardian/*` packages should be transpiled by consumers](https://github.com/guardian/recommendations/blob/main/npm-packages.md#using-guardian-npm-packages), and all current versions of Node support ES modules, this _shouldn't_ cause any issues.
+
+See [Sindre Sorhus' guide to consuming ESM modules](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) if it does.

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ test: env
 	$(call log,"Running unit tests")
 	@corepack pnpm nx run-many --target=test --skip-nx-cache=$(SKIP_NX_CACHE)
 
+# verfies that built packages are ready to publish
+.PHONY: verify
+verify: env
+	$(call log,"Verifying packages")
+	@corepack pnpm nx run-many --target=verify --skip-nx-cache=$(SKIP_NX_CACHE)
+
 # runs the e2e tests for all projects
 .PHONY: e2e
 e2e: env
@@ -44,7 +50,7 @@ fix: install
 
 # makes sure absolutely everything is working
 .PHONY: validate
-validate: env clean lint test build e2e build-storybooks
+validate: env clean lint test build verify e2e build-storybooks
 
 ##################################### BUILD ####################################
 

--- a/libs/@guardian/ab-core/project.json
+++ b/libs/@guardian/ab-core/project.json
@@ -45,6 +45,12 @@
 				"passWithNoTests": true,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/ab-core"
+			}
 		}
 	},
 	"tags": []

--- a/libs/@guardian/ab-react/project.json
+++ b/libs/@guardian/ab-react/project.json
@@ -51,6 +51,12 @@
 				"passWithNoTests": true,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/ab-react"
+			}
 		}
 	},
 	"tags": []

--- a/libs/@guardian/atoms-rendering/project.json
+++ b/libs/@guardian/atoms-rendering/project.json
@@ -46,6 +46,12 @@
 				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
 			}
 		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/atoms-rendering"
+			}
+		},
 		"storybook": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/libs/@guardian/browserslist-config/project.json
+++ b/libs/@guardian/browserslist-config/project.json
@@ -26,6 +26,12 @@
 			"options": {
 				"jestConfig": "libs/@guardian/browserslist-config/jest.config.js"
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/browserslist-config"
+			}
 		}
 	},
 	"tags": []

--- a/libs/@guardian/core-web-vitals/project.json
+++ b/libs/@guardian/core-web-vitals/project.json
@@ -45,6 +45,12 @@
 				"passWithNoTests": true,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/core-web-vitals"
+			}
 		}
 	},
 	"tags": []

--- a/libs/@guardian/eslint-config-typescript/project.json
+++ b/libs/@guardian/eslint-config-typescript/project.json
@@ -24,6 +24,12 @@
 			"options": {
 				"jestConfig": "libs/@guardian/eslint-config-typescript/jest.config.js"
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/eslint-config-typescript"
+			}
 		}
 	},
 	"tags": []

--- a/libs/@guardian/eslint-config/project.json
+++ b/libs/@guardian/eslint-config/project.json
@@ -22,6 +22,12 @@
 			"options": {
 				"jestConfig": "libs/@guardian/eslint-config/jest.config.js"
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/eslint-config"
+			}
 		}
 	},
 	"tags": []

--- a/libs/@guardian/eslint-plugin-source-foundations/project.json
+++ b/libs/@guardian/eslint-plugin-source-foundations/project.json
@@ -53,6 +53,12 @@
 				"passWithNoTests": true,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/eslint-plugin-source-foundations"
+			}
 		}
 	},
 	"tags": []

--- a/libs/@guardian/eslint-plugin-source-react-components/project.json
+++ b/libs/@guardian/eslint-plugin-source-react-components/project.json
@@ -53,6 +53,12 @@
 				"passWithNoTests": true,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/eslint-plugin-source-react-components"
+			}
 		}
 	},
 	"tags": []

--- a/libs/@guardian/identity-auth/project.json
+++ b/libs/@guardian/identity-auth/project.json
@@ -45,6 +45,12 @@
 				"passWithNoTests": true,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/identity-auth"
+			}
 		}
 	},
 	"tags": []

--- a/libs/@guardian/libs/project.json
+++ b/libs/@guardian/libs/project.json
@@ -45,6 +45,12 @@
 				"passWithNoTests": true,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/libs"
+			}
 		}
 	},
 	"tags": []

--- a/libs/@guardian/prettier/project.json
+++ b/libs/@guardian/prettier/project.json
@@ -23,6 +23,12 @@
 			"options": {
 				"jestConfig": "libs/@guardian/prettier/jest.config.js"
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/prettier"
+			}
 		}
 	},
 	"tags": []

--- a/libs/@guardian/source-foundations/project.json
+++ b/libs/@guardian/source-foundations/project.json
@@ -46,6 +46,12 @@
 				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
 			}
 		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/source-foundations"
+			}
+		},
 		"storybook": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/libs/@guardian/source-react-components-development-kitchen/project.json
+++ b/libs/@guardian/source-react-components-development-kitchen/project.json
@@ -56,6 +56,12 @@
 				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
 			}
 		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/source-react-components-development-kitchen"
+			}
+		},
 		"storybook": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/libs/@guardian/source-react-components/project.json
+++ b/libs/@guardian/source-react-components/project.json
@@ -50,6 +50,12 @@
 				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
 			}
 		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/source-react-components"
+			}
+		},
 		"storybook": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/libs/@guardian/tsconfig/project.json
+++ b/libs/@guardian/tsconfig/project.json
@@ -22,6 +22,12 @@
 			"options": {
 				"jestConfig": "libs/@guardian/tsconfig/jest.config.js"
 			}
+		},
+		"verify": {
+			"executor": "@csnx/npm-package:verify",
+			"options": {
+				"outputPath": "dist/libs/@guardian/tsconfig"
+			}
 		}
 	},
 	"tags": []

--- a/nx.json
+++ b/nx.json
@@ -14,6 +14,9 @@
 		},
 		"e2e": {
 			"dependsOn": ["build", "^build"]
+		},
+		"verify": {
+			"dependsOn": ["build", "^build"]
 		}
 	},
 	"tasksRunnerOptions": {
@@ -25,7 +28,8 @@
 					"lint",
 					"test",
 					"e2e",
-					"build-storybook"
+					"build-storybook",
+					"verify"
 				]
 			},
 			"runner": "nx-cloud"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,10 +191,10 @@ importers:
       '@emotion/react': 11.11.1_tznpbkknyqq5lcv5sgrl332jvu
       '@guardian/ab-core': link:../ab-core
       '@guardian/commercial': 10.8.0_typescript@5.1.3
-      '@guardian/consent-management-platform': 13.6.1_uo3bjqllavv5kwoq2zqgzcz5h4
+      '@guardian/consent-management-platform': 13.6.1_@guardian+libs@15.4.0
       '@guardian/eslint-plugin-source-foundations': link:../eslint-plugin-source-foundations
       '@guardian/eslint-plugin-source-react-components': link:../eslint-plugin-source-react-components
-      '@guardian/libs': link:../libs
+      '@guardian/libs': 15.4.0_xfreuenalcno2zxheqz32kfzfe
       '@guardian/source-foundations': link:../source-foundations
       '@guardian/source-react-components': link:../source-react-components
       '@testing-library/dom': 9.3.1
@@ -287,7 +287,7 @@ importers:
       '@typescript-eslint/parser': 5.59.9_tizxnkcvjrb4cldxgwq5h3lj5u
       eslint-plugin-import: 2.27.5_4sfevs3vpuvadhjdwbsynzgtpy
     devDependencies:
-      '@guardian/libs': link:../libs
+      '@guardian/libs': 15.4.0_xfreuenalcno2zxheqz32kfzfe
       '@guardian/source-foundations': link:../source-foundations
       '@types/eslint': 8.40.0
       '@types/estree': 1.0.1
@@ -314,7 +314,7 @@ importers:
       '@typescript-eslint/parser': 5.59.9_v5z4zaksc2au4w32gg6cwoxijq
     devDependencies:
       '@emotion/react': 11.11.1_react@18.2.0
-      '@guardian/libs': link:../libs
+      '@guardian/libs': 15.4.0_xfreuenalcno2zxheqz32kfzfe
       '@guardian/source-foundations': link:../source-foundations
       '@guardian/source-react-components': link:../source-react-components
       '@types/eslint': 8.4.6
@@ -433,7 +433,7 @@ importers:
     devDependencies:
       '@babel/core': 7.22.9
       '@emotion/react': 11.11.1_j4swkgacdxrhexoapez3itylte
-      '@guardian/libs': link:../libs
+      '@guardian/libs': 15.4.0_xfreuenalcno2zxheqz32kfzfe
       '@guardian/source-foundations': link:../source-foundations
       '@guardian/source-react-components': link:../source-react-components
       '@types/react': 18.2.11
@@ -460,6 +460,7 @@ importers:
       '@rollup/plugin-node-resolve': 15.1.0
       cpy: 10.1.0
       execa: 7.1.1
+      publint: 0.2.0
       read-pkg: 8.0.0
       rollup: 3.24.0
       rollup-plugin-ts: 3.2.0
@@ -475,6 +476,7 @@ importers:
       '@rollup/plugin-node-resolve': 15.1.0_rollup@3.24.0
       cpy: 10.1.0
       execa: 7.1.1
+      publint: 0.2.0
       read-pkg: 8.0.0
       rollup: 3.24.0
       rollup-plugin-ts: 3.2.0_ollrytiw5favcwcsi5344oeg6e
@@ -2572,9 +2574,9 @@ packages:
     dependencies:
       '@changesets/cli': 2.26.2
       '@guardian/ab-core': 5.0.0_2fm6qdqvboq725wodu6qww5jhq
-      '@guardian/consent-management-platform': 13.6.1_@guardian+libs@15.2.0
-      '@guardian/core-web-vitals': 5.0.0_3mflpycv66vuqouhdlj477ddkq
-      '@guardian/libs': 15.2.0_2fm6qdqvboq725wodu6qww5jhq
+      '@guardian/consent-management-platform': 13.6.1_@guardian+libs@15.4.0
+      '@guardian/core-web-vitals': 5.0.0_fkwh3656kve324stdzzoqiq6vm
+      '@guardian/libs': 15.4.0_2fm6qdqvboq725wodu6qww5jhq
       '@guardian/source-foundations': 12.0.0_2fm6qdqvboq725wodu6qww5jhq
       '@guardian/support-dotcom-components': 1.0.7
       '@octokit/core': 4.2.1
@@ -2593,23 +2595,15 @@ packages:
       - typescript
     dev: true
 
-  /@guardian/consent-management-platform/13.6.1_@guardian+libs@15.2.0:
+  /@guardian/consent-management-platform/13.6.1_@guardian+libs@15.4.0:
     resolution: {integrity: sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==}
     peerDependencies:
       '@guardian/libs': ^15.0.0
     dependencies:
-      '@guardian/libs': 15.2.0_2fm6qdqvboq725wodu6qww5jhq
+      '@guardian/libs': 15.4.0_xfreuenalcno2zxheqz32kfzfe
     dev: true
 
-  /@guardian/consent-management-platform/13.6.1_uo3bjqllavv5kwoq2zqgzcz5h4:
-    resolution: {integrity: sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==}
-    peerDependencies:
-      '@guardian/libs': ^15.0.0
-    dependencies:
-      '@guardian/libs': link:libs/@guardian/libs
-    dev: true
-
-  /@guardian/core-web-vitals/5.0.0_3mflpycv66vuqouhdlj477ddkq:
+  /@guardian/core-web-vitals/5.0.0_fkwh3656kve324stdzzoqiq6vm:
     resolution: {integrity: sha512-Mq3v8Y/YJGs7p/8NWmYHFKdVqRThjDJSfpoo1zSb6DgpQ1Ko8RjvOa2Q9P9ABWfKJCaDp0kcGK3dk0AjDSi/Qw==}
     peerDependencies:
       '@guardian/libs': ^15.0.0
@@ -2620,7 +2614,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/libs': 15.2.0_2fm6qdqvboq725wodu6qww5jhq
+      '@guardian/libs': 15.4.0_2fm6qdqvboq725wodu6qww5jhq
       tslib: 2.6.1
       typescript: 5.1.3
       web-vitals: 3.3.2
@@ -2647,8 +2641,8 @@ packages:
       typescript: 5.1.3
     dev: true
 
-  /@guardian/libs/15.2.0_2fm6qdqvboq725wodu6qww5jhq:
-    resolution: {integrity: sha512-R/DRo1qrRDTs856Keh+lFW62x97QG/7cqz/IyDfg5YoPyZpgHtnNuNoVrhnGdjWE0ZdAXJIg8TGAm+n+/JFPvQ==}
+  /@guardian/libs/15.4.0_2fm6qdqvboq725wodu6qww5jhq:
+    resolution: {integrity: sha512-UnLLRnVNHhuBE8uRSx3b0rjpjovFK7lSbnfCZ5jZqabEutkZimkNdW4DX95y3QWDHJT/faHo3kV7heiXKbiO3g==}
     peerDependencies:
       tslib: ^2.5.3
       typescript: ~5.1.3
@@ -2657,6 +2651,19 @@ packages:
         optional: true
     dependencies:
       tslib: 2.6.1
+      typescript: 5.1.3
+    dev: true
+
+  /@guardian/libs/15.4.0_xfreuenalcno2zxheqz32kfzfe:
+    resolution: {integrity: sha512-UnLLRnVNHhuBE8uRSx3b0rjpjovFK7lSbnfCZ5jZqabEutkZimkNdW4DX95y3QWDHJT/faHo3kV7heiXKbiO3g==}
+    peerDependencies:
+      tslib: ^2.5.3
+      typescript: ~5.1.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      tslib: 2.5.3
       typescript: 5.1.3
     dev: true
 
@@ -10330,6 +10337,13 @@ packages:
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  /ignore-walk/5.0.1:
+    resolution: {integrity: sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      minimatch: 5.1.6
+    dev: false
+
   /ignore/4.0.6:
     resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
     engines: {node: '>= 4'}
@@ -12057,7 +12071,6 @@ packages:
   /mri/1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
-    dev: true
 
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -12184,6 +12197,29 @@ packages:
   /normalize-path/3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  /npm-bundled/2.0.1:
+    resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      npm-normalize-package-bin: 2.0.0
+    dev: false
+
+  /npm-normalize-package-bin/2.0.0:
+    resolution: {integrity: sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dev: false
+
+  /npm-packlist/5.1.3:
+    resolution: {integrity: sha512-263/0NGrn32YFYi4J533qzrQ/krmmrWwhKkzwTuM4f/07ug51odoaNjUexxO4vxlzURHcmYMH1QjvHjsNDKLVg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      glob: 8.1.0
+      ignore-walk: 5.0.1
+      npm-bundled: 2.0.1
+      npm-normalize-package-bin: 2.0.0
+    dev: false
 
   /npm-run-path/4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -12967,6 +13003,16 @@ packages:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
     dev: true
 
+  /publint/0.2.0:
+    resolution: {integrity: sha512-h8lxdjhQjpDw+A4BgY4sE7Z4CU3x5tCGGpERVdKGDQmWMtr1P7kvptJS2P10HhmNnS7Yeny37zfQE5+xRZ6nig==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      npm-packlist: 5.1.3
+      picocolors: 1.0.0
+      sade: 1.8.1
+    dev: false
+
   /pump/2.0.1:
     resolution: {integrity: sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==}
     dependencies:
@@ -13527,6 +13573,13 @@ packages:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
       tslib: 2.6.1
+
+  /sade/1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
+    dev: false
 
   /safe-buffer/5.1.1:
     resolution: {integrity: sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==}

--- a/tools/nx-plugins/npm-package/build/set-package-defaults.ts
+++ b/tools/nx-plugins/npm-package/build/set-package-defaults.ts
@@ -4,7 +4,6 @@ import sortPkgJson from 'sort-package-json';
 import type { JsonObject } from 'type-fest';
 import type * as WritePackage from 'write-pkg';
 import type { BuildExecutorOptions } from './schema';
-import type { Entries } from './index';
 
 /**
  * THIS IS KLUDGE #ES_NODE_MODULES
@@ -22,7 +21,7 @@ const esmModuleImport = new Function('specifier', 'return import(specifier)');
  */
 export const setPackageDefaults = async (
 	options: BuildExecutorOptions,
-	entries: Entries | undefined,
+	outputEntry?: string,
 ) => {
 	const { readPackage } = (await esmModuleImport(
 		'read-pkg',
@@ -52,6 +51,9 @@ export const setPackageDefaults = async (
 			type: 'git',
 			url: 'git+https://github.com/guardian/csnx.git',
 		},
+		engines: {
+			node: '>=16',
+		},
 	};
 
 	if (!pkg.private) {
@@ -60,9 +62,11 @@ export const setPackageDefaults = async (
 		};
 	}
 
-	if (entries) {
-		pkgDefaults.main = entries.cjs;
-		pkgDefaults.module = entries.esm;
+	if (outputEntry) {
+		pkgDefaults.type = 'module';
+		pkgDefaults.exports = {
+			'.': `./${outputEntry}`,
+		};
 	} else if (!pkg.main) {
 		throw new Error(
 			"You must add a 'main' field to your package.json, or pass an 'entry' option to the build executor",

--- a/tools/nx-plugins/npm-package/executors.json
+++ b/tools/nx-plugins/npm-package/executors.json
@@ -5,6 +5,11 @@
 			"implementation": "./build/index.ts",
 			"schema": "./build/schema.json",
 			"description": "Bundles source code into an NPM package for publishing."
+		},
+		"verify": {
+			"implementation": "./verify/index.ts",
+			"schema": "./verify/schema.json",
+			"description": "Verifies that a built package is ready to be published."
 		}
 	}
 }

--- a/tools/nx-plugins/npm-package/package.json
+++ b/tools/nx-plugins/npm-package/package.json
@@ -8,6 +8,7 @@
 		"@rollup/plugin-node-resolve": "15.1.0",
 		"cpy": "10.1.0",
 		"execa": "7.1.1",
+		"publint": "0.2.0",
 		"read-pkg": "8.0.0",
 		"rollup": "3.24.0",
 		"rollup-plugin-ts": "3.2.0",

--- a/tools/nx-plugins/npm-package/verify/index.ts
+++ b/tools/nx-plugins/npm-package/verify/index.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs/promises';
+import { logger } from '@nx/devkit';
+import type { publint as Publint } from 'publint';
+import type { formatMessage as FormatMessage } from 'publint/utils';
+import type { BuildExecutorOptions } from './schema';
+
+/**
+ * THIS IS KLUDGE #ES_NODE_MODULES
+ *
+ * lifted from https://github.com/nrwl/nx/pull/10414
+ *
+ * @TODO once Nx allows esm imports, it should be removed
+ */
+// eslint-disable-next-line @typescript-eslint/no-implied-eval -- this is a kludge
+const esmModuleImport = new Function('specifier', 'return import(specifier)');
+
+export default async function buildExecutor(
+	options: BuildExecutorOptions,
+): Promise<{ success: boolean }> {
+	try {
+		const { publint } = (await esmModuleImport('publint')) as {
+			publint: typeof Publint;
+		};
+		const { formatMessage } = (await esmModuleImport('publint/utils')) as {
+			formatMessage: typeof FormatMessage;
+		};
+
+		const pkg = JSON.parse(
+			await fs.readFile(`${options.outputPath}/package.json`, 'utf8'),
+		) as Record<string, unknown>;
+
+		const { messages } = await publint({
+			pkgDir: options.outputPath,
+			level: 'warning',
+			strict: true,
+		});
+
+		if (messages.length > 0) {
+			logger.log(`There are issues with the ${options.outputPath} package:`);
+
+			for (const message of messages) {
+				logger.error(formatMessage(message, pkg));
+			}
+
+			return { success: false };
+		}
+	} catch (error) {
+		logger.error(error);
+		return { success: false };
+	}
+
+	// logger.info(messages.join('\n'));
+
+	return { success: true };
+}

--- a/tools/nx-plugins/npm-package/verify/schema.d.ts
+++ b/tools/nx-plugins/npm-package/verify/schema.d.ts
@@ -1,0 +1,3 @@
+export interface BuildExecutorOptions {
+	outputPath: string;
+}

--- a/tools/nx-plugins/npm-package/verify/schema.json
+++ b/tools/nx-plugins/npm-package/verify/schema.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "http://json-schema.org/schema",
+	"type": "object",
+	"cli": "nx",
+	"properties": {
+		"outputPath": {
+			"type": "string",
+			"description": "The output path of the generated files."
+		}
+	},
+	"required": ["outputPath"]
+}


### PR DESCRIPTION
## What are you changing?

### For all packages
- makes Node 16 the minimum supported version for compiled packages (all Node 16 versions support ES modules)
- adds `@csnx/npm-package:verify` which runs [`publint`](https://publint.dev) against the built output
- releases new versions of affected packages

### For compiled packages

_i.e. for packages built from TS source code_

- removes CommonJS version
- sets `"type": "module"`
- removes `main` and `module` fields, using only `exports`

## Why?

Our current packages are [incorrectly configured](https://publint.dev/@guardian/libs@15.4.0). Fixing this is quite tricky, and publishing CommonJS and ESM together exposes us to the dual package hazard https://nodejs.org/api/packages.html#dual-package-hazard.

We only publish CommonJS because we needed to support old versions of Node. But all current Node versions support ES modules now.

Also, [`@guardian/*` packages are expected to be transpiled by consumers](https://github.com/guardian/recommendations/blob/main/npm-packages.md#using-guardian-npm-packages), so this _should_ not affect us.
