### PR TITLE
Add gu to performance measure names

### DIFF
--- a/.changeset/khaki-apricots-mix.md
+++ b/.changeset/khaki-apricots-mix.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Add gu prefix to performance measure name

--- a/libs/@guardian/libs/src/performance/serialise.ts
+++ b/libs/@guardian/libs/src/performance/serialise.ts
@@ -5,4 +5,4 @@ import type { TeamName } from '../logger/@types/logger';
 const SEPARATOR = ':';
 
 export const serialise = (team: TeamName, name: string, action?: string) =>
-	[team, name, action].filter(isNonNullable).join(SEPARATOR);
+	['gu', team, name, action].filter(isNonNullable).join(SEPARATOR);


### PR DESCRIPTION
## What are you changing?

Add the prefix 'gu' to performance measures recorded by libs.

## Why?

It will make it easier to group all of the metrics we care about without having to know the individual team names.
