### PR TITLE
Update Accordion styles

### DIFF
--- a/libs/@guardian/source-react-components/src/accordion/styles.ts
+++ b/libs/@guardian/source-react-components/src/accordion/styles.ts
@@ -30,7 +30,7 @@ const buttonStyles = css`
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	padding: ${remSpace[2]} 0 ${remSpace[6]} 0;
+	padding: ${remSpace[1]} 0 ${remSpace[5]} 0;
 	cursor: pointer;
 `;
 
@@ -76,6 +76,7 @@ const expandedBodyStyles = css`
 	transition: max-height ${transitions.medium};
 	overflow: hidden;
 	height: auto;
+	padding-bottom: ${remSpace[5]};
 `;
 
 export const expandedBody = css`


### PR DESCRIPTION
## What are you changing?

- updating the Accordion styles

## Why?

- Akemi flagged these were incorrect

### Before
<img width="645" alt="Screenshot 2023-07-31 at 11 13 42" src="https://github.com/guardian/csnx/assets/77005274/3b7a4852-ecae-4af6-9627-53d43a279b9f">

### After
<img width="645" alt="Screenshot 2023-07-31 at 11 13 05" src="https://github.com/guardian/csnx/assets/77005274/a70646c8-0e2c-4c52-a0e5-ba45f0fcb29a">
