### PR TITLE
Adjust checkbox and radio button label alignment to account for line height reduction

### DIFF
--- a/libs/@guardian/source-react-components/src/checkbox/styles.ts
+++ b/libs/@guardian/source-react-components/src/checkbox/styles.ts
@@ -125,6 +125,11 @@ export const labelText = (
 
 export const labelTextWithSupportingText = css`
 	${textSans.medium()};
+	margin-top: 1px;
+	/* If label text is empty, add additional spacing to align supporting text */
+	&:empty {
+		margin-top: 2px;
+	}
 `;
 
 export const supportingText = (

--- a/libs/@guardian/source-react-components/src/radio/styles.ts
+++ b/libs/@guardian/source-react-components/src/radio/styles.ts
@@ -120,6 +120,11 @@ export const labelText = (
 
 export const labelTextWithSupportingText = css`
 	${textSans.medium({ fontWeight: 'bold' })};
+	margin-top: 1px;
+	/* If label text is empty, add additional spacing to align supporting text */
+	&:empty {
+		margin-top: 2px;
+	}
 `;
 
 export const supportingText = (


### PR DESCRIPTION
## What are you changing?

Adds spacing to the top of the checkbox and radio button label containers.

## Why?

Due to the reduction in line height the label and supporting text were not centred and aligned with the checkbox or radio button controls.

## Images

<img width="196" alt="Screenshot 2023-07-31 at 11 57 41" src="https://github.com/guardian/csnx/assets/1166188/e6a6dbc9-8645-41fc-ba5c-9b5aeecdfde5">
<img width="221" alt="Screenshot 2023-07-31 at 11 58 17" src="https://github.com/guardian/csnx/assets/1166188/b6bfa4d7-9d90-4c8e-8036-afb81ea81e2a">
<img width="148" alt="Screenshot 2023-07-31 at 11 57 58" src="https://github.com/guardian/csnx/assets/1166188/d6982cb9-ce43-40b4-8d0d-c4dfd6915fda">
<img width="215" alt="Screenshot 2023-07-31 at 11 58 30" src="https://github.com/guardian/csnx/assets/1166188/39b9da87-9e2b-48be-ae61-291d6ae4be45">
