### PR TITLE
feat(performance): add getMeasures method

### DIFF
--- a/.changeset/honest-mice-hammer.md
+++ b/.changeset/honest-mice-hammer.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+New API to retrieve `PerformanceMeasure` created with `startPerformanceMeasure`.

--- a/libs/@guardian/libs/src/performance/@types/measure.ts
+++ b/libs/@guardian/libs/src/performance/@types/measure.ts
@@ -1,3 +1,5 @@
+import type { TeamName } from '../../logger/@types/logger';
+
 declare global {
 	interface Performance {
 		/**
@@ -12,4 +14,10 @@ declare global {
 	}
 }
 
-export type {};
+export interface GuardianMeasure extends PerformanceMeasure {
+	detail: {
+		team: TeamName;
+		name: string;
+		action?: string;
+	};
+}

--- a/libs/@guardian/libs/src/performance/README.md
+++ b/libs/@guardian/libs/src/performance/README.md
@@ -50,3 +50,16 @@ Type: `string | undefined`<br>
 
 Optional action performed as part of a task.
 Used for labelling `PerformanceMeasure`.
+
+### `getMeasures(teams)`
+
+Returns: `GuardianMeasure[]`
+
+Retrieve `PerformanceMeasure` generated with `startPerformanceMeasure`.
+The type is narrowed to `GuardianMeasure` which contains relevant details
+
+#### `teams`
+
+Type:`TeamName[]`
+
+Name of teams to get the measures for

--- a/libs/@guardian/libs/src/performance/getMeasures.ts
+++ b/libs/@guardian/libs/src/performance/getMeasures.ts
@@ -1,0 +1,28 @@
+import { isObject } from '../isObject/isObject';
+import { isString } from '../isString/isString';
+import type { TeamName } from '../logger/@types/logger';
+import { isTeam } from '../logger/teamStyles';
+import type { GuardianMeasure } from './@types/measure';
+
+const isGuardianMeasure = (
+	measure: PerformanceEntry,
+): measure is GuardianMeasure =>
+	measure instanceof PerformanceMeasure &&
+	isObject(measure.detail) &&
+	isString(measure.detail.team) &&
+	isTeam(measure.detail.team) &&
+	typeof measure.detail.name === 'string' &&
+	(measure.detail.action === undefined ||
+		typeof measure.detail.action === 'string');
+
+/**
+ * Retrieve `PerformanceMeasure` generated with `startPerformanceMeasure`.
+ * The type is narrowed to `GuardianMeasure` which contains relevant details
+ */
+export const getMeasures = (
+	teams: readonly TeamName[],
+): readonly GuardianMeasure[] =>
+	window.performance
+		.getEntriesByType('measure')
+		.filter(isGuardianMeasure)
+		.filter((measure) => teams.includes(measure.detail.team));

--- a/libs/@guardian/libs/src/performance/startPerformanceMeasure.ts
+++ b/libs/@guardian/libs/src/performance/startPerformanceMeasure.ts
@@ -31,6 +31,11 @@ export const startPerformanceMeasure = (
 
 	const options = {
 		start: performance.now(),
+		detail: {
+			team,
+			name,
+			action,
+		},
 	} satisfies PerformanceMeasureOptions;
 
 	const endPerformanceMeasure = () => {


### PR DESCRIPTION
## What are you changing?

- Retrieve `PerformanceMeasure` generated with `startPerformanceMeasure`. Returns a narrowed `GuardianMeasure` which contains relevant details

## Why?

- We want to start picking these measures up in https://github.com/guardian/commercial/pull/967
