### PR TITLE
Explain how our line heights meet WCAG SC 1.4.12

### DIFF
--- a/libs/@guardian/source-foundations/src/typography/data.ts
+++ b/libs/@guardian/source-foundations/src/typography/data.ts
@@ -88,6 +88,19 @@ export const fonts = {
 		'GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif',
 } as const;
 
+/**
+ * @see https://theguardian.design/2a1e5182b/p/0578f1-typography-presets/b/4704a2
+ * @see https://www.figma.com/file/OqhZwB5nboFn33iHLYoc6d/%E2%97%90-Typography?type=design&node-id=384%3A3&t=mYsLeX87mBF2Uw8J-1
+ *
+ * Relative units ensure users can change their user-agent’s font size
+ * and having the line height grow accordingly.
+ *
+ * We meet the Web Consortium Accessibility Guidelines’
+ * success criterion for “Text Spacing” (1.4.12) as these values
+ * can be overridden by users.
+ *
+ * @see https://www.w3.org/WAI/WCAG21/Understanding/text-spacing
+ */
 export const lineHeights = {
 	tight: 1.15,
 	regular: 1.3,


### PR DESCRIPTION
## What are you changing?

- Add documentation around our line heights

## Why?

- I’ve been confused by [WCAG SC 1.4.2 “Text Spacing”](https://www.w3.org/WAI/WCAG21/Understanding/text-spacing) several times, but we’ve answered the question before
  - https://github.com/guardian/source/pull/1572
  - https://github.com/guardian/design-system-advocates/issues/1
  - https://chat.google.com/room/AAAAoMQI1jM/nW9v6tbEnYk
