### PR TITLE
Actually export `getMeasures`

### DIFF
--- a/.changeset/angry-needles-own.md
+++ b/.changeset/angry-needles-own.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Actually export new `getMeasures` method

--- a/libs/@guardian/libs/src/index.test.ts
+++ b/libs/@guardian/libs/src/index.test.ts
@@ -14,6 +14,7 @@ describe('The package', () => {
 			'getCookie',
 			'getCountryByCountryCode',
 			'getLocale',
+			'getMeasures',
 			'getSwitches',
 			'isBoolean',
 			'isNonNullable',

--- a/libs/@guardian/libs/src/index.ts
+++ b/libs/@guardian/libs/src/index.ts
@@ -40,6 +40,7 @@ export { log } from './logger/log';
 export type { TeamName } from './logger/@types/logger';
 
 export { startPerformanceMeasure } from './performance/startPerformanceMeasure';
+export { getMeasures } from './performance/getMeasures';
 
 export type {
 	OphanABEvent,

--- a/libs/@guardian/libs/src/performance/getMeasures.ts
+++ b/libs/@guardian/libs/src/performance/getMeasures.ts
@@ -11,9 +11,8 @@ const isGuardianMeasure = (
 	isObject(measure.detail) &&
 	isString(measure.detail.team) &&
 	isTeam(measure.detail.team) &&
-	typeof measure.detail.name === 'string' &&
-	(measure.detail.action === undefined ||
-		typeof measure.detail.action === 'string');
+	isString(measure.detail.name) &&
+	(isString(measure.detail.action) || measure.detail.action === undefined);
 
 /**
  * Retrieve `PerformanceMeasure` generated with `startPerformanceMeasure`.


### PR DESCRIPTION
## What are you changing?

- fix(getMeasures): export method
- refactor(getMeasures): use more libs

## Why?

- forgot to export them in #760 
