### PR TITLE
Handle performance measures in older browsers

### DIFF
--- a/.changeset/funny-readers-march.md
+++ b/.changeset/funny-readers-march.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': patch
+---
+
+Handle browser which do not support the `measureOptions` parameter to window.performance.measure() API

--- a/libs/@guardian/libs/src/performance/@types/measure.ts
+++ b/libs/@guardian/libs/src/performance/@types/measure.ts
@@ -14,10 +14,12 @@ declare global {
 	}
 }
 
+export type Detail = {
+	team: TeamName;
+	name: string;
+	action?: string;
+};
+
 export interface GuardianMeasure extends PerformanceMeasure {
-	detail: {
-		team: TeamName;
-		name: string;
-		action?: string;
-	};
+	detail: Detail;
 }

--- a/libs/@guardian/libs/src/performance/serialise.ts
+++ b/libs/@guardian/libs/src/performance/serialise.ts
@@ -1,8 +1,17 @@
 import { isNonNullable } from '../isNonNullable/isNonNullable';
-import type { TeamName } from '../logger/@types/logger';
+import { isString } from '../isString/isString';
+import { isTeam } from '../logger/teamStyles';
+import type { Detail } from './@types/measure';
 
 /** Serialisation is an implementation detail */
 const SEPARATOR = ':';
 
-export const serialise = (team: TeamName, name: string, action?: string) =>
+export const serialise = ({ team, name, action }: Detail) =>
 	[team, name, action].filter(isNonNullable).join(SEPARATOR);
+
+export const deserialise = (id: string): Detail | undefined => {
+	const [team, name, action] = id.split(SEPARATOR);
+	return isString(team) && isTeam(team) && isString(name)
+		? { team, name, action }
+		: undefined;
+};


### PR DESCRIPTION
## What are you changing?

- handle errors in older browsers when passing a [`measureOptions`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure#measureoptions) to `window.performance.measure`

## Why?

Some browsers do not support the `measureOptions` parameter to `window.performance.measure()` API introduced in #729, causing the method to throw an error. [According to MDN](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure#browser_compatibility):

- Chrome below 78 (October 2019)
- Edge below 79 (January 2020)
- Firefox below 103 (May 2022)
- Opera below 65 or 56 (November 2019)
- Safari below 14.1 or 14.5 (April 2021)

Currently addressed by a [hot fix in DCR](https://github.com/guardian/dotcom-rendering/pull/8445).

## Does it work?

Tested in Safari 13.1 using BrowserStack

<img width="1445" alt="image" src="https://github.com/guardian/csnx/assets/76776/59b61daa-4581-4181-b22e-80b06465a501">
