### PR TITLE
Handle browser lack of performance API support for `getMeasures`

### DIFF
--- a/.changeset/small-icons-drop.md
+++ b/.changeset/small-icons-drop.md
@@ -1,0 +1,6 @@
+---
+'@guardian/libs': patch
+---
+
+Handle browsers which do not support the
+[`performance.getEntriesByType` API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType#browser_compatibility).

--- a/libs/@guardian/libs/src/performance/getMeasures.ts
+++ b/libs/@guardian/libs/src/performance/getMeasures.ts
@@ -9,7 +9,8 @@ import { deserialise } from './serialise';
 export const getMeasures = (
 	teams: readonly TeamName[],
 ): readonly GuardianMeasure[] =>
-	window.performance.getEntriesByType('measure').flatMap((measure) => {
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType#browser_compatibility
+	window.performance.getEntriesByType?.('measure').flatMap((measure) => {
 		const detail = deserialise(measure.name);
 		return measure instanceof PerformanceMeasure &&
 			detail &&


### PR DESCRIPTION
## What are you changing?

- Guard against missing `performance.getEntriesByType` method

## Why?

- [Some browsers may not have `performance.getEntriesByType()` API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType#browser_compatibility)
- Follow-up on #773 
