### PR TITLE
Handle browser lack of performance API support for `getMeasures` (bis)

### DIFF
--- a/.changeset/breezy-jokes-reflect.md
+++ b/.changeset/breezy-jokes-reflect.md
@@ -1,0 +1,7 @@
+---
+'@guardian/libs': patch
+---
+
+Handle browsers which do not support the
+[`performance.getEntriesByType` API](https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType#browser_compatibility),
+for real this time…

--- a/libs/@guardian/libs/src/performance/getMeasures.test.ts
+++ b/libs/@guardian/libs/src/performance/getMeasures.test.ts
@@ -1,0 +1,7 @@
+import { getMeasures } from './getMeasures';
+
+describe('getMeasures', () => {
+	it('returns an empty array when no measures are present', () => {
+		expect(getMeasures(['dotcom'])).toEqual([]);
+	});
+});

--- a/libs/@guardian/libs/src/performance/getMeasures.ts
+++ b/libs/@guardian/libs/src/performance/getMeasures.ts
@@ -9,12 +9,14 @@ import { deserialise } from './serialise';
 export const getMeasures = (
 	teams: readonly TeamName[],
 ): readonly GuardianMeasure[] =>
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType#browser_compatibility
-	window.performance.getEntriesByType?.('measure').flatMap((measure) => {
-		const detail = deserialise(measure.name);
-		return measure instanceof PerformanceMeasure &&
-			detail &&
-			teams.includes(detail.team)
-			? { ...measure, detail }
-			: [];
-	});
+	// https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType#browser_compatibility
+	'getEntriesByType' in window.performance
+		? window.performance.getEntriesByType('measure').flatMap((measure) => {
+				const detail = deserialise(measure.name);
+				return measure instanceof PerformanceMeasure &&
+					detail &&
+					teams.includes(detail.team)
+					? { ...measure, detail }
+					: [];
+		  })
+		: [];


### PR DESCRIPTION
## What are you changing?

- Actually handle `getMeasures` in unsupported browsers

## Why?

- #775 did not do the trick
