### PR TITLE
Add a new `@guardian/identity-auth-frontend` library which takes care of setting up `@guardian/identity-auth` for DCR, Frontend, and Commerci

### DIFF
--- a/.changeset/fuzzy-falcons-build.md
+++ b/.changeset/fuzzy-falcons-build.md
@@ -1,0 +1,5 @@
+---
+'@guardian/identity-auth-frontend': minor
+---
+
+Add a new @guardian/identity-auth-frontend library which takes care of setting up `@guardian/identity-auth` for DCR, Frontend, and Commercial

--- a/.changeset/fuzzy-falcons-build.md
+++ b/.changeset/fuzzy-falcons-build.md
@@ -1,5 +1,0 @@
----
-'@guardian/identity-auth-frontend': minor
----
-
-Add a new @guardian/identity-auth-frontend library which takes care of setting up `@guardian/identity-auth` for DCR, Frontend, and Commercial

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,5 +20,6 @@
 /libs/@guardian/eslint-config-typescript/ @guardian/client-side-infra
 /libs/@guardian/browserlist-config/  @guardian/client-side-infra @guardian/dotcom-platform
 /libs/@guardian/libs/ @guardian/client-side-infra @guardian/apps-rendering @guardian/dotcom-platform
+/libs/@guardian/identity-auth-frontend/ @guardian/dotcom-platform @guardian/commercial-dev
 
 /libs/@guardian/identity-auth/ @guardian/identity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,6 @@
 /libs/@guardian/eslint-config-typescript/ @guardian/client-side-infra
 /libs/@guardian/browserlist-config/  @guardian/client-side-infra @guardian/dotcom-platform
 /libs/@guardian/libs/ @guardian/client-side-infra @guardian/apps-rendering @guardian/dotcom-platform
-/libs/@guardian/identity-auth-frontend/ @guardian/dotcom-platform @guardian/commercial-dev
+/libs/@guardian/identity-auth-frontend/ @guardian/dotcom-platform @guardian/commercial-dev @guardian/identity
 
 /libs/@guardian/identity-auth/ @guardian/identity

--- a/@types/window.d.ts
+++ b/@types/window.d.ts
@@ -2,6 +2,7 @@ import type { TeamSubscription } from '../libs/@guardian/libs/src/logger/@types/
 import type { Switches } from '../libs/@guardian/libs/src/switches/@types/Switches';
 import type { google } from '../libs/@guardian/atoms-rendering/src/ima';
 import type { ImaManager } from '../libs/@guardian/atoms-rendering/src/YoutubeAtomPlayer';
+import type { FrontendIdentityAuth } from '../libs/@guardian/identity-auth-frontend/src';
 
 declare global {
 	interface Window {
@@ -15,6 +16,8 @@ declare global {
 				page?: {
 					isPreview: boolean;
 				};
+				stage?: string;
+				isDev?: boolean;
 				switches?: Switches;
 			};
 			/**
@@ -39,6 +42,7 @@ declare global {
 				viewId: string;
 				pageViewId: string;
 			};
+			identityAuth?: FrontendIdentityAuth;
 		};
 		/**
 		 * Here we want to type the google object that will be added to window.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The following packages live in `libs/@guardian/*` and are published to NPM:
 - [@guardian/eslint-plugin-source-foundations](libs/@guardian/eslint-plugin-source-foundations)
 - [@guardian/eslint-plugin-source-react-components](libs/@guardian/eslint-plugin-source-react-components)
 - [@guardian/identity-auth](libs/@guardian/identity-auth)
+- [@guardian/identity-auth-frontend](libs/@guardian/identity-auth-frontend)
 - [@guardian/libs](libs/@guardian/libs)
 - [@guardian/prettier](libs/@guardian/prettier)
 - [@guardian/source-foundations](libs/@guardian/source-foundations)

--- a/libs/@guardian/identity-auth-frontend/.eslintrc.json
+++ b/libs/@guardian/identity-auth-frontend/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+	"extends": ["../../../.eslintrc.js"],
+	"ignorePatterns": ["!**/*", "node_modules"],
+	"overrides": [
+		{
+			"files": ["*.ts"],
+			"parserOptions": {
+				"project": ["libs/@guardian/identity-auth-frontend/tsconfig.json"]
+			},
+			"rules": {}
+		},
+		{
+			"files": ["*.test.ts"],
+			"rules": {
+				"@typescript-eslint/no-unsafe-call": "off",
+				"@typescript-eslint/no-unsafe-assignment": "off"
+			}
+		}
+	]
+}

--- a/libs/@guardian/identity-auth-frontend/CHANGELOG.md
+++ b/libs/@guardian/identity-auth-frontend/CHANGELOG.md
@@ -1,1 +1,7 @@
 # @guardian/identity-auth-frontend
+
+## 0.1.0
+
+### Minor Changes
+
+- 81cfb45: Add a new @guardian/identity-auth-frontend library which takes care of setting up `@guardian/identity-auth` for DCR, Frontend, and Commercial

--- a/libs/@guardian/identity-auth-frontend/CHANGELOG.md
+++ b/libs/@guardian/identity-auth-frontend/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @guardian/identity-auth-frontend

--- a/libs/@guardian/identity-auth-frontend/README.MD
+++ b/libs/@guardian/identity-auth-frontend/README.MD
@@ -1,6 +1,6 @@
 # IdentityAuthFrontend
 
-A wrapper around [@guardian/identity-auth](../identity-auth/README.md) which manages creating and configuring a IdentityAuth singleton to be used primarily on [www.theguardian.com](www.theguardian.com) by DCR, Frontend, and Commercial.
+A wrapper around [@guardian/identity-auth](../identity-auth/README.md) which manages creating and configuring a IdentityAuth singleton to be used solely on [www.theguardian.com](www.theguardian.com) by DCR, Frontend, and Commercial.
 
 ## Usage
 

--- a/libs/@guardian/identity-auth-frontend/README.MD
+++ b/libs/@guardian/identity-auth-frontend/README.MD
@@ -1,0 +1,21 @@
+# IdentityAuthFrontend
+
+A wrapper around [@guardian/identity-auth](../identity-auth/README.md) which manages creating and configuring a IdentityAuth singleton to be used primarily on [www.theguardian.com](www.theguardian.com) by DCR, Frontend, and Commercial.
+
+## Usage
+
+```js
+import { getIdentityAuth } from '@guardian/identity-auth-frontend';
+
+const identityAuth = getIdentityAuth();
+
+// Check if the user is logged in and return the current auth state
+const authState = await identityAuth.isSignedInWithAuthState();
+
+authState.isAuthenticated; // true or false
+authState?.accessToken; // the user's access token object
+authState?.idToken; // the user's id token object
+
+// or boolean only
+const isLoggedIn = await identityAuth.isSignedIn();
+```

--- a/libs/@guardian/identity-auth-frontend/jest.config.ts
+++ b/libs/@guardian/identity-auth-frontend/jest.config.ts
@@ -1,0 +1,8 @@
+/* eslint-disable import/no-default-export -- that's what jest likes */
+export default {
+	displayName: '@guardian/identity-auth-frontend',
+	preset: '../../../jest.preset.js',
+	testEnvironment: 'jest-environment-jsdom',
+	moduleFileExtensions: ['ts', 'js'],
+	coverageDirectory: '../../../coverage/libs/@guardian/identity-auth-frontend',
+};

--- a/libs/@guardian/identity-auth-frontend/jest.e2e.setup.js
+++ b/libs/@guardian/identity-auth-frontend/jest.e2e.setup.js
@@ -1,0 +1,6 @@
+// Mock `./src/index` with whatever `package.json` points at in dist.
+// This means we can run the unit tests against `dist` instead.
+
+const dist = require('../../../dist/libs/@guardian/identity-auth-frontend');
+
+jest.mock('./src/index', () => dist);

--- a/libs/@guardian/identity-auth-frontend/package.json
+++ b/libs/@guardian/identity-auth-frontend/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@guardian/identity-auth-frontend",
+	"version": "0.1.0",
+	"private": false,
+	"description": "",
+	"license": "Apache-2.0",
+	"sideEffects": false,
+	"devDependencies": {
+		"@guardian/identity-auth": "0.4.0",
+		"jest-fetch-mock": "3.0.3",
+		"tslib": "2.5.3",
+		"typescript": "5.1.3"
+	},
+	"peerDependencies": {
+		"@guardian/identity-auth": "^0.4.0",
+		"tslib": "^2.5.3",
+		"typescript": "~5.1.3"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/libs/@guardian/identity-auth-frontend/project.json
+++ b/libs/@guardian/identity-auth-frontend/project.json
@@ -1,0 +1,55 @@
+{
+	"name": "@guardian/identity-auth-frontend",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "libs/@guardian/identity-auth-frontend/src",
+	"projectType": "library",
+	"targets": {
+		"build": {
+			"executor": "@csnx/npm-package:build",
+			"outputs": ["{options.outputPath}"],
+			"options": {
+				"entry": "libs/@guardian/identity-auth-frontend/src/index.ts",
+				"tsConfig": "libs/@guardian/identity-auth-frontend/tsconfig.json",
+				"packageJson": "libs/@guardian/identity-auth-frontend/package.json",
+				"outputPath": "dist/libs/@guardian/identity-auth-frontend",
+				"assets": ["libs/@guardian/identity-auth-frontend/*.md"]
+			}
+		},
+		"lint": {
+			"executor": "@csnx/eslint:check",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": ["libs/@guardian/identity-auth-frontend/**/*.ts"]
+			}
+		},
+		"fix": {
+			"executor": "@csnx/eslint:fix",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": ["libs/@guardian/identity-auth-frontend/**/*.ts"]
+			}
+		},
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": [
+				"{workspaceRoot}/coverage/libs/@guardian/identity-auth-frontend"
+			],
+			"options": {
+				"jestConfig": "libs/@guardian/identity-auth-frontend/jest.config.ts",
+				"passWithNoTests": true
+			}
+		},
+		"e2e": {
+			"executor": "@nx/jest:jest",
+			"outputs": [
+				"{workspaceRoot}/coverage/libs/@guardian/identity-auth-frontend"
+			],
+			"options": {
+				"jestConfig": "libs/@guardian/identity-auth-frontend/jest.config.ts",
+				"passWithNoTests": true,
+				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
+			}
+		}
+	},
+	"tags": []
+}

--- a/libs/@guardian/identity-auth-frontend/src/__tests__/index.test.ts
+++ b/libs/@guardian/identity-auth-frontend/src/__tests__/index.test.ts
@@ -1,0 +1,20 @@
+import { getIdentityAuth } from '../index';
+
+jest.mock('@guardian/identity-auth');
+
+describe('IdentityAuthFrontend', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should return access and id token default claims', () => {
+		window.guardian = {
+			config: { isDev: true, stage: 'CODE' },
+		};
+
+		const auth = getIdentityAuth();
+		const auth2 = getIdentityAuth();
+
+		expect(auth).toStrictEqual(auth2);
+	});
+});

--- a/libs/@guardian/identity-auth-frontend/src/index.ts
+++ b/libs/@guardian/identity-auth-frontend/src/index.ts
@@ -9,6 +9,7 @@ const isStage = guard(stages);
 type FrontendIdTokenClaims = CustomClaims & {
 	email: string;
 	braze_uuid: string;
+	google_tag_id: string;
 };
 
 export type FrontendIdentityAuth = IdentityAuth<never, FrontendIdTokenClaims>;

--- a/libs/@guardian/identity-auth-frontend/src/index.ts
+++ b/libs/@guardian/identity-auth-frontend/src/index.ts
@@ -37,8 +37,9 @@ const getRedirectUri = (stage: Stage) => {
 };
 
 export const getIdentityAuth = () => {
-	if (!window.guardian)
+	if (!window.guardian) {
 		throw new Error('window.guardian has not yet been initialized');
+	}
 
 	const {
 		isDev = false,

--- a/libs/@guardian/identity-auth-frontend/src/index.ts
+++ b/libs/@guardian/identity-auth-frontend/src/index.ts
@@ -16,11 +16,27 @@ export type FrontendIdentityAuth = IdentityAuth<never, FrontendIdTokenClaims>;
 const getStage = (isDev: boolean, stage: string) =>
 	isDev || !isStage(stage) ? 'DEV' : stage;
 
+/**
+ * Decide Issuer URL based on Stage.
+ *
+ * NOTE: These values are specifically are solely for use on www.theguardian.com
+ *
+ * @param stage
+ * @returns issuer URL
+ */
 const getIssuer = (stage: Stage) =>
 	stage === 'PROD'
 		? 'https://profile.theguardian.com/oauth2/aus3xgj525jYQRowl417'
 		: 'https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7';
 
+/**
+ * Decide Client ID based on Stage.
+ *
+ * NOTE: These values are specifically are solely for use on www.theguardian.com
+ *
+ * @param stage
+ * @returns Client ID
+ */
 const getClientId = (stage: Stage) =>
 	stage === 'PROD' ? '0oa79m1fmgzrtaHc1417' : '0oa53x6k5wGYXOGzm0x7';
 

--- a/libs/@guardian/identity-auth-frontend/src/index.ts
+++ b/libs/@guardian/identity-auth-frontend/src/index.ts
@@ -1,5 +1,10 @@
 import { IdentityAuth } from '@guardian/identity-auth';
 import type { CustomClaims } from '@guardian/identity-auth';
+import { guard } from '@guardian/identity-auth/cjs/@types/guard';
+
+const stages = ['PROD', 'CODE', 'DEV'] as const;
+type Stage = (typeof stages)[number];
+const isStage = guard(stages);
 
 type FrontendIdTokenClaims = CustomClaims & {
 	email: string;
@@ -8,17 +13,18 @@ type FrontendIdTokenClaims = CustomClaims & {
 
 export type FrontendIdentityAuth = IdentityAuth<never, FrontendIdTokenClaims>;
 
-const getStage = (isDev: boolean, stage: string) => (isDev ? 'DEV' : stage);
+const getStage = (isDev: boolean, stage: string) =>
+	isDev || !isStage(stage) ? 'DEV' : stage;
 
-const getIssuer = (stage: string) =>
+const getIssuer = (stage: Stage) =>
 	stage === 'PROD'
 		? 'https://profile.theguardian.com/oauth2/aus3xgj525jYQRowl417'
 		: 'https://profile.code.dev-theguardian.com/oauth2/aus3v9gla95Toj0EE0x7';
 
-const getClientId = (stage: string) =>
+const getClientId = (stage: Stage) =>
 	stage === 'PROD' ? '0oa79m1fmgzrtaHc1417' : '0oa53x6k5wGYXOGzm0x7';
 
-const getRedirectUri = (stage: string) => {
+const getRedirectUri = (stage: Stage) => {
 	switch (stage) {
 		case 'PROD':
 			return 'https://www.theguardian.com/';
@@ -31,36 +37,37 @@ const getRedirectUri = (stage: string) => {
 };
 
 export const getIdentityAuth = () => {
-	const { guardian } = window;
-	const { config } = guardian ?? {};
-	const { isDev, stage } = guardian?.config ?? {};
-
-	if (!guardian || !config || !isDev || !stage) {
+	if (!window.guardian)
 		throw new Error('window.guardian has not yet been initialized');
-	}
 
+	const {
+		isDev = false,
+		stage = 'PROD',
+		switches,
+	} = window.guardian.config ?? {};
 	const stageOrDev = getStage(isDev, stage);
 
-	if (!guardian.identityAuth) {
-		guardian.identityAuth = new IdentityAuth<never, FrontendIdTokenClaims>({
-			issuer: getIssuer(stageOrDev),
-			clientId: getClientId(stageOrDev),
-			redirectUri: getRedirectUri(stageOrDev),
-			idCookieSessionRefresh: config.switches?.idCookieRefresh ?? false,
-			scopes: [
-				'openid', // required for open id connect, returns an id token
-				'profile', // populates the id token with basic profile information
-				'email', // populates the id token with the user's email address
-				'guardian.discussion-api.private-profile.read.self', // allows the access token to be used to make requests to the discussion api to read the user's profile
-				'guardian.discussion-api.update.secure', // allows the access token to be used to make requests to the discussion api to post comments, upvote etc
-				'guardian.identity-api.newsletters.read.self', // allows the access token to be used to make requests to the identity api to read the user's newsletter subscriptions
-				'guardian.identity-api.newsletters.update.self', // allows the access token to be used to make requests to the identity api to update the user's newsletter subscriptions
-				'guardian.identity-api.user.username.create.self.secure', // allows the access token to set the user's username
-				'guardian.members-data-api.read.self', // allows the access token to be used to make requests to the members data api to read the user's membership status
-				'id_token.profile.theguardian', // populates the id token with application specific profile information
-			],
-		});
-	}
+	window.guardian.identityAuth ||= new IdentityAuth<
+		never,
+		FrontendIdTokenClaims
+	>({
+		issuer: getIssuer(stageOrDev),
+		clientId: getClientId(stageOrDev),
+		redirectUri: getRedirectUri(stageOrDev),
+		idCookieSessionRefresh: switches?.idCookieRefresh ?? false,
+		scopes: [
+			'openid', // required for open id connect, returns an id token
+			'profile', // populates the id token with basic profile information
+			'email', // populates the id token with the user's email address
+			'guardian.discussion-api.private-profile.read.self', // allows the access token to be used to make requests to the discussion api to read the user's profile
+			'guardian.discussion-api.update.secure', // allows the access token to be used to make requests to the discussion api to post comments, upvote etc
+			'guardian.identity-api.newsletters.read.self', // allows the access token to be used to make requests to the identity api to read the user's newsletter subscriptions
+			'guardian.identity-api.newsletters.update.self', // allows the access token to be used to make requests to the identity api to update the user's newsletter subscriptions
+			'guardian.identity-api.user.username.create.self.secure', // allows the access token to set the user's username
+			'guardian.members-data-api.read.self', // allows the access token to be used to make requests to the members data api to read the user's membership status
+			'id_token.profile.theguardian', // populates the id token with application specific profile information
+		],
+	});
 
-	return guardian.identityAuth;
+	return window.guardian.identityAuth;
 };

--- a/libs/@guardian/identity-auth-frontend/tsconfig.json
+++ b/libs/@guardian/identity-auth-frontend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"files": ["../../../@types/window.d.ts"],
+	"include": ["."],
+	"references": [
+		{
+			"path": "./tsconfig.spec.json"
+		}
+	]
+}

--- a/libs/@guardian/identity-auth-frontend/tsconfig.spec.json
+++ b/libs/@guardian/identity-auth-frontend/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"module": "commonjs",
+		"types": ["jest", "node"]
+	},
+	"include": ["jest.config.ts", "**/*.test.ts", "**/*.d.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,18 @@ importers:
       tslib: 2.5.3
       typescript: 5.1.3
 
+  libs/@guardian/identity-auth-frontend:
+    specifiers:
+      '@guardian/identity-auth': 0.4.0
+      jest-fetch-mock: 3.0.3
+      tslib: 2.5.3
+      typescript: 5.1.3
+    devDependencies:
+      '@guardian/identity-auth': 0.4.0_xfreuenalcno2zxheqz32kfzfe
+      jest-fetch-mock: 3.0.3
+      tslib: 2.5.3
+      typescript: 5.1.3
+
   libs/@guardian/libs:
     specifiers:
       '@types/wcag-contrast': 3.0.0
@@ -2616,6 +2628,20 @@ packages:
       tslib: 2.6.1
       typescript: 5.1.3
       web-vitals: 3.3.2
+    dev: true
+
+  /@guardian/identity-auth/0.4.0_xfreuenalcno2zxheqz32kfzfe:
+    resolution: {integrity: sha512-+lXmoMhrACvibKYBIwKQ15zyWGiGKC+mOg8831R8ilwF3vwXuXnzCLy1EpLTlSfDf72IOAuGyX4gDOqdQP8R/w==}
+    peerDependencies:
+      '@guardian/libs': ^15.0.0
+      tslib: ^2.5.3
+      typescript: ~5.1.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      tslib: 2.5.3
+      typescript: 5.1.3
     dev: true
 
   /@guardian/libs/10.1.1_tslib@2.6.1:


### PR DESCRIPTION
## What are you changing?

Creates a `@guardian/identity-auth-frontend` library which acts as a wrapper around `@guardian/identity-auth` to ensure only a single instance of IdentityAuth is created and that all clients trying to access it use the same settings.

## Why?

- Somewhat ensures that Frontend, DCR, and Commercial all initialize `IdentityAuth` the same way. As they all need to share the same token it would be problematic if one application requested different/less scopes than another application.
- Ensures only 1 instance of IdentityAuth is created per page view. Multiple instances of `IdentityAuth` could potentially try and refresh tokens at the same time as eachother and use up our Okta API requests quota.
- Makes sure that no application is blocked by another. Commercial shouldn't have to wait for DCR/Frontend to initialize to be able to check signed in status.