### PR TITLE
Fix `getMeasures` so it return actual values

### DIFF
--- a/.changeset/wise-wolves-sing.md
+++ b/.changeset/wise-wolves-sing.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': patch
+---
+
+PerformanceMeasure objects cannot be destructured…

--- a/libs/@guardian/libs/src/performance/@types/measure.ts
+++ b/libs/@guardian/libs/src/performance/@types/measure.ts
@@ -20,6 +20,11 @@ export type Detail = {
 	action?: string;
 };
 
-export interface GuardianMeasure extends PerformanceMeasure {
+export interface GuardianMeasure {
+	name: string;
+	duration: number;
+	startTime: number;
+	entryType: 'measure';
 	detail: Detail;
+	toJson(): string;
 }

--- a/libs/@guardian/libs/src/performance/getMeasures.ts
+++ b/libs/@guardian/libs/src/performance/getMeasures.ts
@@ -11,12 +11,21 @@ export const getMeasures = (
 ): readonly GuardianMeasure[] =>
 	// https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType#browser_compatibility
 	'getEntriesByType' in window.performance
-		? window.performance.getEntriesByType('measure').flatMap((measure) => {
-				const detail = deserialise(measure.name);
-				return measure instanceof PerformanceMeasure &&
-					detail &&
-					teams.includes(detail.team)
-					? { ...measure, detail }
-					: [];
-		  })
+		? window.performance
+				.getEntriesByType('measure')
+				.flatMap(({ entryType, name, duration, startTime }) => {
+					const detail = deserialise(name);
+					return entryType === 'measure' &&
+						detail &&
+						teams.includes(detail.team)
+						? {
+								name,
+								detail,
+								duration,
+								entryType,
+								startTime,
+								toJson: () => JSON.stringify(this),
+						  }
+						: [];
+				})
 		: [];


### PR DESCRIPTION
## What are you changing?

- destructure `PerformanceMeasure` parts explicitely in `@guardian/libs`

## Why?

- turns out spreading a PerformanceMeasure returns an empty object…
- we are currently recording only `null`s for all performance measures
- follow-up on #760 & #766 

## Screenshots

**Before** 

<img width="503" alt="image" src="https://github.com/guardian/csnx/assets/76776/7e51326b-f9b4-4bf4-8518-d87c24fe2a7a">

**After**

<img width="748" alt="image" src="https://github.com/guardian/csnx/assets/76776/91c737d8-d0c3-4473-a087-0fdeb4fc9ed5">
