### PR TITLE
Release `@guardian/identity-auth` 1.0

### DIFF
--- a/.changeset/odd-rice-check.md
+++ b/.changeset/odd-rice-check.md
@@ -1,0 +1,5 @@
+---
+'@guardian/identity-auth': major
+---
+
+Release `@guardian/identity-auth` 1.0. We're using this package in PROD and has multiple consumers so we should expect it to be stable now.


### PR DESCRIPTION
## What are you changing?

Release @guardian/identity-auth 1.0

## Why?

As per the semver spec https://semver.org/#spec-item-4

> Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.

- We're consuming this package in DCR, Frontend, and Commercial so the Public API should remain the same now if we want to avoid having to make downstream changes.
- Its being used in PROD (albeit only in a 2% test) so we would hope its fairly stable at this point.
- `^0.5.0` only matches up until the next minor version due to the aforementioned https://semver.org/#spec-item-4 whereas `^1.5.0` will match all minor versions after `1.5.0` till `2.0.0`  which allows consumers to specify this package as a peer dependency without getting breaking changes every minor update.
