### PR TITLE
Release `@guardian/identity-auth-frontend` v1.0

### DIFF
--- a/.changeset/healthy-sheep-sniff.md
+++ b/.changeset/healthy-sheep-sniff.md
@@ -1,0 +1,5 @@
+---
+'@guardian/identity-auth-frontend': major
+---
+
+Release `@guardian/identity-auth-frontend` v1.0.0

--- a/libs/@guardian/identity-auth-frontend/package.json
+++ b/libs/@guardian/identity-auth-frontend/package.json
@@ -6,13 +6,14 @@
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"devDependencies": {
-		"@guardian/identity-auth": "0.4.0",
+		"@guardian/identity-auth": "^1.0.0",
 		"jest-fetch-mock": "3.0.3",
 		"tslib": "2.5.3",
 		"typescript": "5.1.3"
 	},
 	"peerDependencies": {
-		"@guardian/identity-auth": "^0.4.0",
+		"@guardian/identity-auth": "^1.0.0",
+		"@guardian/libs": "^15.0.0",
 		"tslib": "^2.5.3",
 		"typescript": "~5.1.3"
 	},

--- a/libs/@guardian/identity-auth-frontend/src/index.ts
+++ b/libs/@guardian/identity-auth-frontend/src/index.ts
@@ -6,7 +6,7 @@ const stages = ['PROD', 'CODE', 'DEV'] as const;
 type Stage = (typeof stages)[number];
 const isStage = guard(stages);
 
-type FrontendIdTokenClaims = CustomClaims & {
+export type FrontendIdTokenClaims = CustomClaims & {
 	email: string;
 	braze_uuid: string;
 	google_tag_id: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,12 +338,12 @@ importers:
 
   libs/@guardian/identity-auth-frontend:
     specifiers:
-      '@guardian/identity-auth': 0.4.0
+      '@guardian/identity-auth': ^1.0.0
       jest-fetch-mock: 3.0.3
       tslib: 2.5.3
       typescript: 5.1.3
     devDependencies:
-      '@guardian/identity-auth': 0.4.0_xfreuenalcno2zxheqz32kfzfe
+      '@guardian/identity-auth': 1.0.0_xfreuenalcno2zxheqz32kfzfe
       jest-fetch-mock: 3.0.3
       tslib: 2.5.3
       typescript: 5.1.3
@@ -1941,13 +1941,6 @@ packages:
       regenerator-runtime: 0.13.11
     dev: true
 
-  /@babel/runtime/7.22.6:
-    resolution: {integrity: sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.13.11
-    dev: true
-
   /@babel/template/7.22.5:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
     engines: {node: '>=6.9.0'}
@@ -2728,7 +2721,7 @@ packages:
       fastdom: 1.0.11
       lodash-es: 4.17.21
       ophan-tracker-js: 1.4.0
-      prebid.js: github.com/guardian/prebid.js/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb_tslib@2.6.1
+      prebid.js: github.com/guardian/prebid.js/1d6bbdc64411fbe719489eb06bce72b66ac6a4f3_tslib@2.6.1
       process: 0.11.10
       raven-js: 3.27.2
       tslib: 2.6.1
@@ -2765,8 +2758,8 @@ packages:
       web-vitals: 3.3.2
     dev: true
 
-  /@guardian/identity-auth/0.4.0_xfreuenalcno2zxheqz32kfzfe:
-    resolution: {integrity: sha512-+lXmoMhrACvibKYBIwKQ15zyWGiGKC+mOg8831R8ilwF3vwXuXnzCLy1EpLTlSfDf72IOAuGyX4gDOqdQP8R/w==}
+  /@guardian/identity-auth/1.0.0_xfreuenalcno2zxheqz32kfzfe:
+    resolution: {integrity: sha512-JUkPai2Qnuq1quQ2rtvwWhLTtISqJBNe8XpxqbIr4jGaNWn5EL3kI1scAwq5PyNEg9135E7YXWTnjLNkm3ivoA==}
     peerDependencies:
       '@guardian/libs': ^15.0.0
       tslib: ^2.5.3
@@ -8348,11 +8341,6 @@ packages:
     resolution: {integrity: sha512-7a9a3D1k4UCVKnLhrgALyFcP7YCsLOQIxPd0dKjf/6GuPcgyiGP70ewWdCGrSK7evyhymi0qO4EqCmSJofDeYw==}
     dependencies:
       browserslist: 4.21.10
-    dev: true
-
-  /core-js-pure/3.31.1:
-    resolution: {integrity: sha512-w+C62kvWti0EPs4KPMCMVv9DriHSXfQOCQ94bGGBiEW5rrbtt/Rz8n5Krhfw9cpFyzXBjf3DB3QnPdEzGDY4Fw==}
-    requiresBuild: true
     dev: true
 
   /core-js-pure/3.32.0:
@@ -15056,7 +15044,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.16.19
-      acorn: 8.10.0
+      acorn: 8.8.1
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -15969,9 +15957,9 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  github.com/guardian/prebid.js/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb_tslib@2.6.1:
-    resolution: {tarball: https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb}
-    id: github.com/guardian/prebid.js/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb
+  github.com/guardian/prebid.js/1d6bbdc64411fbe719489eb06bce72b66ac6a4f3_tslib@2.6.1:
+    resolution: {tarball: https://codeload.github.com/guardian/prebid.js/tar.gz/1d6bbdc64411fbe719489eb06bce72b66ac6a4f3}
+    id: github.com/guardian/prebid.js/1d6bbdc64411fbe719489eb06bce72b66ac6a4f3
     name: prebid.js
     version: 7.26.0
     engines: {node: '>=8.9.0'}
@@ -15979,10 +15967,10 @@ packages:
       '@babel/core': 7.22.9
       '@babel/plugin-transform-runtime': 7.22.9_@babel+core@7.22.9
       '@babel/preset-env': 7.22.9_@babel+core@7.22.9
-      '@babel/runtime': 7.22.6
+      '@babel/runtime': 7.22.10
       '@guardian/libs': 10.1.1_tslib@2.6.1
       core-js: 3.31.1
-      core-js-pure: 3.31.1
+      core-js-pure: 3.32.0
       criteo-direct-rsa-validate: 1.1.0
       crypto-js: 3.3.0
       dlv: 1.1.3


### PR DESCRIPTION
## What are you changing?

Bumps `@guardian/identity-auth-frontend` to 1.0 and use \`@guardian/identity-auth\` 1.0

Also exports FrontendIdTokenClaims as a type

## Why?

- We're using a new major version of @guardian/identity-auth
- We've update the peer dep range for @guardian/identity-auth
