### PR TITLE
Update ESLint in `@guardian/*` packages

### DIFF
--- a/.changeset/tender-experts-agree.md
+++ b/.changeset/tender-experts-agree.md
@@ -1,0 +1,8 @@
+---
+'@guardian/eslint-plugin-source-react-components': major
+'@guardian/eslint-plugin-source-foundations': major
+'@guardian/eslint-config-typescript': major
+'@guardian/eslint-config': major
+---
+
+Updates ESLint to latest version to fix security vulnerability in `word-wrap` dependency

--- a/libs/@guardian/eslint-config-typescript/package.json
+++ b/libs/@guardian/eslint-config-typescript/package.json
@@ -11,12 +11,12 @@
 		"eslint-plugin-import": "2.27.5"
 	},
 	"devDependencies": {
-		"eslint": "8.0.0",
+		"eslint": "8.47.0",
 		"tslib": "2.5.3",
 		"typescript": "5.1.3"
 	},
 	"peerDependencies": {
-		"eslint": "^8.0.0",
+		"eslint": "^8.47.0",
 		"tslib": "^2.5.3",
 		"typescript": "~5.1.3"
 	}

--- a/libs/@guardian/eslint-config/package.json
+++ b/libs/@guardian/eslint-config/package.json
@@ -9,11 +9,11 @@
 		"eslint-plugin-import": "2.27.5"
 	},
 	"devDependencies": {
-		"eslint": "8.0.0",
+		"eslint": "8.47.0",
 		"tslib": "^2.5.3"
 	},
 	"peerDependencies": {
-		"eslint": "^8.0.0",
+		"eslint": "^8.47.0",
 		"tslib": "^2.5.3"
 	}
 }

--- a/libs/@guardian/eslint-plugin-source-foundations/package.json
+++ b/libs/@guardian/eslint-plugin-source-foundations/package.json
@@ -10,16 +10,16 @@
 	"devDependencies": {
 		"@guardian/libs": "15.4.0",
 		"@guardian/source-foundations": "13.0.0",
-		"@types/eslint": "8.40.0",
+		"@types/eslint": "8.44.2",
 		"@types/estree": "1.0.1",
-		"eslint": "8.42.0",
+		"eslint": "8.47.0",
 		"tslib": "2.5.3",
 		"typescript": "5.1.3"
 	},
 	"peerDependencies": {
 		"@guardian/libs": "^15.4.0",
 		"@guardian/source-foundations": "^13.0.0",
-		"eslint": "^8.0.0",
+		"eslint": "^8.47.0",
 		"tslib": "^2.5.3",
 		"typescript": "~5.1.3"
 	},

--- a/libs/@guardian/eslint-plugin-source-react-components/package.json
+++ b/libs/@guardian/eslint-plugin-source-react-components/package.json
@@ -11,9 +11,9 @@
 		"@guardian/libs": "15.4.0",
 		"@guardian/source-foundations": "13.0.0",
 		"@guardian/source-react-components": "16.0.0",
-		"@types/eslint": "8.4.6",
+		"@types/eslint": "8.44.2",
 		"@types/estree": "1.0.1",
-		"eslint": "8.0.0",
+		"eslint": "8.47.0",
 		"react": "18.2.0",
 		"tslib": "2.5.3",
 		"typescript": "5.1.3"
@@ -21,7 +21,7 @@
 	"peerDependencies": {
 		"@guardian/libs": "^15.4.0",
 		"@guardian/source-react-components": "^16.0.0",
-		"eslint": "^8.0.0",
+		"eslint": "^8.47.0",
 		"react": "^18.2.0",
 		"tslib": "^2.5.3",
 		"typescript": "~5.1.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,17 +236,17 @@ importers:
 
   libs/@guardian/eslint-config:
     specifiers:
-      eslint: 8.0.0
+      eslint: 8.47.0
       eslint-config-prettier: 8.8.0
       eslint-plugin-eslint-comments: 3.2.0
       eslint-plugin-import: 2.27.5
       tslib: ^2.5.3
     dependencies:
-      eslint-config-prettier: 8.8.0_eslint@8.0.0
-      eslint-plugin-eslint-comments: 3.2.0_eslint@8.0.0
-      eslint-plugin-import: 2.27.5_eslint@8.0.0
+      eslint-config-prettier: 8.8.0_eslint@8.47.0
+      eslint-plugin-eslint-comments: 3.2.0_eslint@8.47.0
+      eslint-plugin-import: 2.27.5_eslint@8.47.0
     devDependencies:
-      eslint: 8.0.0
+      eslint: 8.47.0
       tslib: 2.5.3
 
   libs/@guardian/eslint-config-typescript:
@@ -254,19 +254,19 @@ importers:
       '@guardian/eslint-config': workspace:*
       '@typescript-eslint/eslint-plugin': 5.59.9
       '@typescript-eslint/parser': 5.59.9
-      eslint: 8.0.0
+      eslint: 8.47.0
       eslint-import-resolver-typescript: 3.5.5
       eslint-plugin-import: 2.27.5
       tslib: 2.5.3
       typescript: 5.1.3
     dependencies:
       '@guardian/eslint-config': link:../eslint-config
-      '@typescript-eslint/eslint-plugin': 5.59.9_boh3o56sb7hmlbdqxbwmbfxsfy
-      '@typescript-eslint/parser': 5.59.9_v5z4zaksc2au4w32gg6cwoxijq
-      eslint-import-resolver-typescript: 3.5.5_l7sipoxitax7d5cntgfkqrud5m
-      eslint-plugin-import: 2.27.5_b2g36tyw6tf65lpijn4gzhayyu
+      '@typescript-eslint/eslint-plugin': 5.59.9_nql3j3nidtdrbqt3h3uirgis54
+      '@typescript-eslint/parser': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
+      eslint-import-resolver-typescript: 3.5.5_nyqfszrigflegggbmd2qgiaohi
+      eslint-plugin-import: 2.27.5_2keaic6pr7ugmsizqcgisaagjy
     devDependencies:
-      eslint: 8.0.0
+      eslint: 8.47.0
       tslib: 2.5.3
       typescript: 5.1.3
 
@@ -274,24 +274,24 @@ importers:
     specifiers:
       '@guardian/libs': 15.4.0
       '@guardian/source-foundations': 13.0.0
-      '@types/eslint': 8.40.0
+      '@types/eslint': 8.44.2
       '@types/estree': 1.0.1
       '@typescript-eslint/eslint-plugin': 5.59.9
       '@typescript-eslint/parser': 5.59.9
-      eslint: 8.42.0
+      eslint: 8.47.0
       eslint-plugin-import: 2.27.5
       tslib: 2.5.3
       typescript: 5.1.3
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.59.9_3cembfv4vokiyn6g4ljynjc5d4
-      '@typescript-eslint/parser': 5.59.9_tizxnkcvjrb4cldxgwq5h3lj5u
-      eslint-plugin-import: 2.27.5_4sfevs3vpuvadhjdwbsynzgtpy
+      '@typescript-eslint/eslint-plugin': 5.59.9_nql3j3nidtdrbqt3h3uirgis54
+      '@typescript-eslint/parser': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
+      eslint-plugin-import: 2.27.5_uydhjpvr6vcjv2etsu73t4uhnu
     devDependencies:
       '@guardian/libs': 15.4.0_xfreuenalcno2zxheqz32kfzfe
       '@guardian/source-foundations': link:../source-foundations
-      '@types/eslint': 8.40.0
+      '@types/eslint': 8.44.2
       '@types/estree': 1.0.1
-      eslint: 8.42.0
+      eslint: 8.47.0
       tslib: 2.5.3
       typescript: 5.1.3
 
@@ -301,25 +301,25 @@ importers:
       '@guardian/libs': 15.4.0
       '@guardian/source-foundations': 13.0.0
       '@guardian/source-react-components': 16.0.0
-      '@types/eslint': 8.4.6
+      '@types/eslint': 8.44.2
       '@types/estree': 1.0.1
       '@typescript-eslint/eslint-plugin': 5.46.1
       '@typescript-eslint/parser': 5.59.9
-      eslint: 8.0.0
+      eslint: 8.47.0
       react: 18.2.0
       tslib: 2.5.3
       typescript: 5.1.3
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.46.1_boh3o56sb7hmlbdqxbwmbfxsfy
-      '@typescript-eslint/parser': 5.59.9_v5z4zaksc2au4w32gg6cwoxijq
+      '@typescript-eslint/eslint-plugin': 5.46.1_nql3j3nidtdrbqt3h3uirgis54
+      '@typescript-eslint/parser': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
     devDependencies:
       '@emotion/react': 11.11.1_react@18.2.0
       '@guardian/libs': 15.4.0_xfreuenalcno2zxheqz32kfzfe
       '@guardian/source-foundations': link:../source-foundations
       '@guardian/source-react-components': link:../source-react-components
-      '@types/eslint': 8.4.6
+      '@types/eslint': 8.44.2
       '@types/estree': 1.0.1
-      eslint: 8.0.0
+      eslint: 8.47.0
       react: 18.2.0
       tslib: 2.5.3
       typescript: 5.1.3
@@ -501,7 +501,6 @@ packages:
   /@aashutoshrathi/word-wrap/1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /@adobe/css-tools/4.2.0:
     resolution: {integrity: sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==}
@@ -2557,31 +2556,6 @@ packages:
     dev: true
     optional: true
 
-  /@eslint-community/eslint-utils/4.4.0_eslint@8.0.0:
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-    dependencies:
-      eslint: 8.0.0
-      eslint-visitor-keys: 3.4.1
-    dev: false
-
-  /@eslint-community/eslint-utils/4.4.0_eslint@8.42.0:
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-    dependencies:
-      eslint: 8.42.0
-      eslint-visitor-keys: 3.4.1
-
   /@eslint-community/eslint-utils/4.4.0_eslint@8.47.0:
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2592,8 +2566,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.47.0
-      eslint-visitor-keys: 3.4.1
-    dev: true
+      eslint-visitor-keys: 3.4.3
 
   /@eslint-community/regexpp/4.5.1:
     resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
@@ -2602,39 +2575,6 @@ packages:
   /@eslint-community/regexpp/4.6.2:
     resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
-
-  /@eslint/eslintrc/1.3.3:
-    resolution: {integrity: sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4
-      espree: 9.5.2
-      globals: 13.20.0
-      ignore: 5.2.4
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  /@eslint/eslintrc/2.0.3:
-    resolution: {integrity: sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4
-      espree: 9.5.2
-      globals: 13.20.0
-      ignore: 5.2.4
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
 
   /@eslint/eslintrc/2.1.2:
     resolution: {integrity: sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==}
@@ -2651,16 +2591,10 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@eslint/js/8.42.0:
-    resolution: {integrity: sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   /@eslint/js/8.47.0:
     resolution: {integrity: sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
 
   /@fal-works/esbuild-plugin-global-externals/2.1.2:
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
@@ -2839,16 +2773,6 @@ packages:
 
   /@humanwhocodes/config-array/0.11.10:
     resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
-    engines: {node: '>=10.10.0'}
-    dependencies:
-      '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  /@humanwhocodes/config-array/0.6.0:
-    resolution: {integrity: sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -5983,15 +5907,15 @@ packages:
       '@types/estree': 1.0.1
     dev: true
 
-  /@types/eslint/8.4.6:
-    resolution: {integrity: sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==}
-    dependencies:
-      '@types/estree': 1.0.1
-      '@types/json-schema': 7.0.11
-    dev: true
-
   /@types/eslint/8.40.0:
     resolution: {integrity: sha512-nbq2mvc/tBrK9zQQuItvjJl++GTN5j06DaPtp3hZCpngmG6Q3xoyEmd0TwZI0gAy/G1X0zhGBbr2imsGFdFV0g==}
+    dependencies:
+      '@types/estree': 1.0.1
+      '@types/json-schema': 7.0.12
+    dev: true
+
+  /@types/eslint/8.44.2:
+    resolution: {integrity: sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==}
     dependencies:
       '@types/estree': 1.0.1
       '@types/json-schema': 7.0.12
@@ -6089,10 +6013,6 @@ packages:
       '@types/node': 18.16.19
       '@types/tough-cookie': 4.0.2
       parse5: 7.1.2
-    dev: true
-
-  /@types/json-schema/7.0.11:
-    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
 
   /@types/json-schema/7.0.12:
@@ -6308,7 +6228,7 @@ packages:
     resolution: {integrity: sha512-uwqm0DUeg+2pff/8y9b22JJb+qWKOcG5aCn2yyT7hmLdK/M8+VECcK6QuNqdAR93IAqTmZeqK2nizTlQg5j+XA==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.46.1_boh3o56sb7hmlbdqxbwmbfxsfy:
+  /@typescript-eslint/eslint-plugin/5.46.1_nql3j3nidtdrbqt3h3uirgis54:
     resolution: {integrity: sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6321,12 +6241,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.9_v5z4zaksc2au4w32gg6cwoxijq
+      '@typescript-eslint/parser': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
       '@typescript-eslint/scope-manager': 5.46.1
-      '@typescript-eslint/type-utils': 5.46.1_v5z4zaksc2au4w32gg6cwoxijq
-      '@typescript-eslint/utils': 5.46.1_v5z4zaksc2au4w32gg6cwoxijq
+      '@typescript-eslint/type-utils': 5.46.1_xvfqhj2znzzcemdfwd7ahod35q
+      '@typescript-eslint/utils': 5.46.1_xvfqhj2znzzcemdfwd7ahod35q
       debug: 4.3.4
-      eslint: 8.0.0
+      eslint: 8.47.0
       ignore: 5.2.1
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
@@ -6337,7 +6257,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/eslint-plugin/5.59.9_3cembfv4vokiyn6g4ljynjc5d4:
+  /@typescript-eslint/eslint-plugin/5.59.9_nql3j3nidtdrbqt3h3uirgis54:
     resolution: {integrity: sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6351,42 +6271,12 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.9_tizxnkcvjrb4cldxgwq5h3lj5u
+      '@typescript-eslint/parser': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
       '@typescript-eslint/scope-manager': 5.59.9
-      '@typescript-eslint/type-utils': 5.59.9_tizxnkcvjrb4cldxgwq5h3lj5u
-      '@typescript-eslint/utils': 5.59.9_tizxnkcvjrb4cldxgwq5h3lj5u
+      '@typescript-eslint/type-utils': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
+      '@typescript-eslint/utils': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
       debug: 4.3.4
-      eslint: 8.42.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      semver: 7.5.4
-      tsutils: 3.21.0_typescript@5.1.3
-      typescript: 5.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@typescript-eslint/eslint-plugin/5.59.9_boh3o56sb7hmlbdqxbwmbfxsfy:
-    resolution: {integrity: sha512-4uQIBq1ffXd2YvF7MAvehWKW3zVv/w+mSfRAu+8cKbfj3nwzyqJLNcZJpQ/WZ1HLbJDiowwmQ6NO+63nCA+fqA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.9_v5z4zaksc2au4w32gg6cwoxijq
-      '@typescript-eslint/scope-manager': 5.59.9
-      '@typescript-eslint/type-utils': 5.59.9_v5z4zaksc2au4w32gg6cwoxijq
-      '@typescript-eslint/utils': 5.59.9_v5z4zaksc2au4w32gg6cwoxijq
-      debug: 4.3.4
-      eslint: 8.0.0
+      eslint: 8.47.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
@@ -6427,7 +6317,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.59.9_tizxnkcvjrb4cldxgwq5h3lj5u:
+  /@typescript-eslint/parser/5.59.9_xvfqhj2znzzcemdfwd7ahod35q:
     resolution: {integrity: sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6443,29 +6333,7 @@ packages:
       '@typescript-eslint/types': 5.59.9
       '@typescript-eslint/typescript-estree': 5.59.9_typescript@5.1.3
       debug: 4.3.4
-      eslint: 8.42.0
-      typescript: 5.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@typescript-eslint/parser/5.59.9_v5z4zaksc2au4w32gg6cwoxijq:
-    resolution: {integrity: sha512-FsPkRvBtcLQ/eVK1ivDiNYBjn3TGJdXy2fhXX+rc7czWl4ARwnpArwbihSOHI2Peg9WbtGHrbThfBUkZZGTtvQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.59.9
-      '@typescript-eslint/types': 5.59.9
-      '@typescript-eslint/typescript-estree': 5.59.9_typescript@5.1.3
-      debug: 4.3.4
-      eslint: 8.0.0
+      eslint: 8.47.0
       typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
@@ -6533,7 +6401,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.46.1_v5z4zaksc2au4w32gg6cwoxijq:
+  /@typescript-eslint/type-utils/5.46.1_xvfqhj2znzzcemdfwd7ahod35q:
     resolution: {integrity: sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6546,16 +6414,16 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.46.1_typescript@5.1.3
-      '@typescript-eslint/utils': 5.46.1_v5z4zaksc2au4w32gg6cwoxijq
+      '@typescript-eslint/utils': 5.46.1_xvfqhj2znzzcemdfwd7ahod35q
       debug: 4.3.4
-      eslint: 8.0.0
+      eslint: 8.47.0
       tsutils: 3.21.0_typescript@5.1.3
       typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/type-utils/5.59.9_tizxnkcvjrb4cldxgwq5h3lj5u:
+  /@typescript-eslint/type-utils/5.59.9_xvfqhj2znzzcemdfwd7ahod35q:
     resolution: {integrity: sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6568,31 +6436,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.59.9_typescript@5.1.3
-      '@typescript-eslint/utils': 5.59.9_tizxnkcvjrb4cldxgwq5h3lj5u
+      '@typescript-eslint/utils': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
       debug: 4.3.4
-      eslint: 8.42.0
-      tsutils: 3.21.0_typescript@5.1.3
-      typescript: 5.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@typescript-eslint/type-utils/5.59.9_v5z4zaksc2au4w32gg6cwoxijq:
-    resolution: {integrity: sha512-ksEsT0/mEHg9e3qZu98AlSrONAQtrSTljL3ow9CGej8eRo7pe+yaC/mvTjptp23Xo/xIf2mLZKC6KPv4Sji26Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.9_typescript@5.1.3
-      '@typescript-eslint/utils': 5.59.9_v5z4zaksc2au4w32gg6cwoxijq
-      debug: 4.3.4
-      eslint: 8.0.0
+      eslint: 8.47.0
       tsutils: 3.21.0_typescript@5.1.3
       typescript: 5.1.3
     transitivePeerDependencies:
@@ -6773,7 +6619,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.46.1_v5z4zaksc2au4w32gg6cwoxijq:
+  /@typescript-eslint/utils/5.46.1_xvfqhj2znzzcemdfwd7ahod35q:
     resolution: {integrity: sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6787,9 +6633,9 @@ packages:
       '@typescript-eslint/scope-manager': 5.46.1
       '@typescript-eslint/types': 5.46.1
       '@typescript-eslint/typescript-estree': 5.46.1_typescript@5.1.3
-      eslint: 8.0.0
+      eslint: 8.47.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.0.0
+      eslint-utils: 3.0.0_eslint@8.47.0
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -6819,7 +6665,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.59.9_tizxnkcvjrb4cldxgwq5h3lj5u:
+  /@typescript-eslint/utils/5.59.9_xvfqhj2znzzcemdfwd7ahod35q:
     resolution: {integrity: sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6828,36 +6674,13 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0_eslint@8.42.0
+      '@eslint-community/eslint-utils': 4.4.0_eslint@8.47.0
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.59.9
       '@typescript-eslint/types': 5.59.9
       '@typescript-eslint/typescript-estree': 5.59.9_typescript@5.1.3
-      eslint: 8.42.0
-      eslint-scope: 5.1.1
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: false
-
-  /@typescript-eslint/utils/5.59.9_v5z4zaksc2au4w32gg6cwoxijq:
-    resolution: {integrity: sha512-1PuMYsju/38I5Ggblaeb98TOoUvjhRvLpLa1DoTOFaLWqaXl/1iQ1eGurTXgBY58NUdtfTXKP5xBq7q9NDaLKg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0_eslint@8.0.0
-      '@types/json-schema': 7.0.12
-      '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 5.59.9
-      '@typescript-eslint/types': 5.59.9
-      '@typescript-eslint/typescript-estree': 5.59.9_typescript@5.1.3
-      eslint: 8.0.0
+      eslint: 8.47.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -7163,13 +6986,6 @@ packages:
     dependencies:
       acorn: 8.10.0
 
-  /acorn-jsx/5.3.2_acorn@8.8.2:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      acorn: 8.8.2
-
   /acorn-walk/7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
@@ -7196,11 +7012,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
-
-  /acorn/8.8.2:
-    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   /address/1.2.2:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
@@ -9198,7 +9009,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-prettier/8.8.0_eslint@8.0.0:
+  /eslint-config-prettier/8.8.0_eslint@8.47.0:
     resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
     hasBin: true
     peerDependencies:
@@ -9207,7 +9018,7 @@ packages:
       eslint:
         optional: true
     dependencies:
-      eslint: 8.0.0
+      eslint: 8.47.0
     dev: false
 
   /eslint-import-resolver-node/0.3.7:
@@ -9219,7 +9030,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-import-resolver-typescript/3.5.5_l7sipoxitax7d5cntgfkqrud5m:
+  /eslint-import-resolver-typescript/3.5.5_nyqfszrigflegggbmd2qgiaohi:
     resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -9231,9 +9042,9 @@ packages:
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.14.1
-      eslint: 8.0.0
-      eslint-module-utils: 2.8.0_b2g36tyw6tf65lpijn4gzhayyu
-      eslint-plugin-import: 2.27.5_b2g36tyw6tf65lpijn4gzhayyu
+      eslint: 8.47.0
+      eslint-module-utils: 2.8.0_2keaic6pr7ugmsizqcgisaagjy
+      eslint-plugin-import: 2.27.5_2keaic6pr7ugmsizqcgisaagjy
       get-tsconfig: 4.6.0
       globby: 13.1.4
       is-core-module: 2.12.0
@@ -9246,7 +9057,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils/2.8.0_2nwx77ryss4nbbyv7dgzy7wjum:
+  /eslint-module-utils/2.8.0_2keaic6pr7ugmsizqcgisaagjy:
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9267,16 +9078,45 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.9_v5z4zaksc2au4w32gg6cwoxijq
+      '@typescript-eslint/parser': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
       debug: 3.2.7
-      eslint: 8.0.0
+      eslint: 8.47.0
+      eslint-import-resolver-typescript: 3.5.5_nyqfszrigflegggbmd2qgiaohi
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /eslint-module-utils/2.8.0_5lccbnofh5otaxx4vkqn7qplny:
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
+      debug: 3.2.7
+      eslint: 8.47.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5_l7sipoxitax7d5cntgfkqrud5m
+      eslint-import-resolver-typescript: 3.5.5_nyqfszrigflegggbmd2qgiaohi
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-module-utils/2.8.0_b2g36tyw6tf65lpijn4gzhayyu:
+  /eslint-module-utils/2.8.0_ndnbhux42t3fninesk53luagbm:
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9297,15 +9137,15 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.9_v5z4zaksc2au4w32gg6cwoxijq
+      '@typescript-eslint/parser': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
       debug: 3.2.7
-      eslint: 8.0.0
-      eslint-import-resolver-typescript: 3.5.5_l7sipoxitax7d5cntgfkqrud5m
+      eslint: 8.47.0
+      eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-module-utils/2.8.0_s25xocu7x5kh3uqo67lvfry2mq:
+  /eslint-module-utils/2.8.0_o6cdr45zdsiercdndikis42xpm:
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9327,7 +9167,7 @@ packages:
         optional: true
     dependencies:
       debug: 3.2.7
-      eslint: 8.0.0
+      eslint: 8.47.0
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
       - supports-color
@@ -9362,49 +9202,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.8.0_z6h35y2edcwahhgxs7hcukw54e:
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.59.9_tizxnkcvjrb4cldxgwq5h3lj5u
-      debug: 3.2.7
-      eslint: 8.42.0
-      eslint-import-resolver-node: 0.3.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /eslint-plugin-eslint-comments/3.2.0_eslint@8.0.0:
-    resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
-    engines: {node: '>=6.5.0'}
-    peerDependencies:
-      eslint: '>=4.19.1'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-    dependencies:
-      escape-string-regexp: 1.0.5
-      eslint: 8.0.0
-      ignore: 5.2.1
-    dev: false
-
   /eslint-plugin-eslint-comments/3.2.0_eslint@8.47.0:
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
     engines: {node: '>=6.5.0'}
@@ -9417,9 +9214,8 @@ packages:
       escape-string-regexp: 1.0.5
       eslint: 8.47.0
       ignore: 5.2.1
-    dev: true
 
-  /eslint-plugin-import/2.27.5_4sfevs3vpuvadhjdwbsynzgtpy:
+  /eslint-plugin-import/2.27.5_2keaic6pr7ugmsizqcgisaagjy:
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9431,15 +9227,15 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.9_tizxnkcvjrb4cldxgwq5h3lj5u
+      '@typescript-eslint/parser': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.42.0
+      eslint: 8.47.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0_z6h35y2edcwahhgxs7hcukw54e
+      eslint-module-utils: 2.8.0_5lccbnofh5otaxx4vkqn7qplny
       has: 1.0.3
       is-core-module: 2.12.0
       is-glob: 4.0.3
@@ -9454,7 +9250,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-import/2.27.5_b2g36tyw6tf65lpijn4gzhayyu:
+  /eslint-plugin-import/2.27.5_eslint@8.47.0:
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9466,15 +9262,14 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.9_v5z4zaksc2au4w32gg6cwoxijq
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.0.0
+      eslint: 8.47.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0_2nwx77ryss4nbbyv7dgzy7wjum
+      eslint-module-utils: 2.8.0_o6cdr45zdsiercdndikis42xpm
       has: 1.0.3
       is-core-module: 2.12.0
       is-glob: 4.0.3
@@ -9489,7 +9284,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-import/2.27.5_eslint@8.0.0:
+  /eslint-plugin-import/2.27.5_uydhjpvr6vcjv2etsu73t4uhnu:
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9501,14 +9296,15 @@ packages:
       eslint:
         optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.59.9_xvfqhj2znzzcemdfwd7ahod35q
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.0.0
+      eslint: 8.47.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0_s25xocu7x5kh3uqo67lvfry2mq
+      eslint-module-utils: 2.8.0_ndnbhux42t3fninesk53luagbm
       has: 1.0.3
       is-core-module: 2.12.0
       is-glob: 4.0.3
@@ -9610,29 +9406,14 @@ packages:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
-  /eslint-scope/6.0.0:
-    resolution: {integrity: sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-
-  /eslint-scope/7.2.0:
-    resolution: {integrity: sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-
   /eslint-scope/7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-    dev: true
 
-  /eslint-utils/3.0.0_eslint@8.0.0:
+  /eslint-utils/3.0.0_eslint@8.47.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
@@ -9641,20 +9422,19 @@ packages:
       eslint:
         optional: true
     dependencies:
-      eslint: 8.0.0
+      eslint: 8.47.0
       eslint-visitor-keys: 2.1.0
+    dev: false
 
   /eslint-visitor-keys/2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
-
-  /eslint-visitor-keys/3.3.0:
-    resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
 
   /eslint-visitor-keys/3.4.1:
     resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
 
   /eslint-visitor-keys/3.4.2:
     resolution: {integrity: sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==}
@@ -9664,99 +9444,6 @@ packages:
   /eslint-visitor-keys/3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
-
-  /eslint/8.0.0:
-    resolution: {integrity: sha512-03spzPzMAO4pElm44m60Nj08nYonPGQXmw6Ceai/S4QK82IgwWO1EXx1s9namKzVlbVu3Jf81hb+N+8+v21/HQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@eslint/eslintrc': 1.3.3
-      '@humanwhocodes/config-array': 0.6.0
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
-      doctrine: 3.0.0
-      enquirer: 2.3.6
-      escape-string-regexp: 4.0.0
-      eslint-scope: 6.0.0
-      eslint-utils: 3.0.0_eslint@8.0.0
-      eslint-visitor-keys: 3.3.0
-      espree: 9.4.0
-      esquery: 1.4.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      functional-red-black-tree: 1.0.1
-      glob-parent: 6.0.2
-      globals: 13.17.0
-      ignore: 4.0.6
-      import-fresh: 3.3.0
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.1
-      progress: 2.0.3
-      regexpp: 3.2.0
-      semver: 7.5.4
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      text-table: 0.2.0
-      v8-compile-cache: 2.3.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /eslint/8.42.0:
-    resolution: {integrity: sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0_eslint@8.42.0
-      '@eslint-community/regexpp': 4.5.1
-      '@eslint/eslintrc': 2.0.3
-      '@eslint/js': 8.42.0
-      '@humanwhocodes/config-array': 0.11.10
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.0
-      eslint-visitor-keys: 3.4.1
-      espree: 9.5.2
-      esquery: 1.5.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.20.0
-      graphemer: 1.4.0
-      ignore: 5.2.4
-      import-fresh: 3.3.0
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.1
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
 
   /eslint/8.47.0:
     resolution: {integrity: sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==}
@@ -9802,28 +9489,11 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /esm/3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
     engines: {node: '>=6'}
     dev: true
-
-  /espree/9.4.0:
-    resolution: {integrity: sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      acorn: 8.8.2
-      acorn-jsx: 5.3.2_acorn@8.8.2
-      eslint-visitor-keys: 3.4.1
-
-  /espree/9.5.2:
-    resolution: {integrity: sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      acorn: 8.10.0
-      acorn-jsx: 5.3.2_acorn@8.10.0
-      eslint-visitor-keys: 3.4.1
 
   /espree/9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -9832,18 +9502,11 @@ packages:
       acorn: 8.10.0
       acorn-jsx: 5.3.2_acorn@8.10.0
       eslint-visitor-keys: 3.4.3
-    dev: true
 
   /esprima/4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-
-  /esquery/1.4.0:
-    resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
-    engines: {node: '>=0.10'}
-    dependencies:
-      estraverse: 5.3.0
 
   /esquery/1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
@@ -10390,9 +10053,6 @@ packages:
       es-abstract: 1.21.2
       functions-have-names: 1.2.3
 
-  /functional-red-black-tree/1.0.1:
-    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
-
   /functions-have-names/1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
@@ -10547,24 +10207,11 @@ packages:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
 
-  /globals/13.17.0:
-    resolution: {integrity: sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==}
-    engines: {node: '>=8'}
-    dependencies:
-      type-fest: 0.20.2
-
-  /globals/13.20.0:
-    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      type-fest: 0.20.2
-
   /globals/13.21.0:
     resolution: {integrity: sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
-    dev: true
 
   /globalthis/1.0.3:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
@@ -10899,10 +10546,6 @@ packages:
 
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  /ignore/4.0.6:
-    resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
-    engines: {node: '>= 4'}
 
   /ignore/5.2.1:
     resolution: {integrity: sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==}
@@ -13027,17 +12670,6 @@ packages:
     resolution: {integrity: sha512-X5JoLOYxvfvNRI0Vo8xBT0UgJdiU9snPYOGgQUTk5ZnPYgX3xGW/yt7xdePeg9yM0eCuP5SeYQTLfF4bp0GFuw==}
     dev: true
 
-  /optionator/0.9.1:
-    resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      deep-is: 0.1.4
-      fast-levenshtein: 2.0.6
-      levn: 0.4.1
-      prelude-ls: 1.2.1
-      type-check: 0.4.0
-      word-wrap: 1.2.3
-
   /optionator/0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -13048,7 +12680,6 @@ packages:
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
-    dev: true
 
   /ora/5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
@@ -13502,6 +13133,7 @@ packages:
   /progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+    dev: true
 
   /promise-polyfill/8.2.3:
     resolution: {integrity: sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==}
@@ -13933,6 +13565,7 @@ packages:
   /regexpp/3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
+    dev: false
 
   /regexpu-core/5.3.2:
     resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
@@ -15727,10 +15360,6 @@ packages:
   /wolfy87-eventemitter/5.2.9:
     resolution: {integrity: sha512-P+6vtWyuDw+MB01X7UeF8TaHBvbCovf4HPEMF/SV7BdDc1SMTiBy13SRD71lQh4ExFTG1d/WNzDGDCyOKSMblw==}
     dev: true
-
-  /word-wrap/1.2.3:
-    resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
-    engines: {node: '>=0.10.0'}
 
   /wordwrap/1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}


### PR DESCRIPTION
## What are you changing?

This matches the update to the root workspace version (#782) and updates all `@guardian/*` packages to `8.47.0`.

## Why?

Older versions of ESLint rely on a vulnerable version of the `word-wrap` package. This ensures we're not publishing packages that include security vulnerabilities and allows individual projects to update to a non-vulnerable version.

There is a mismatch between the minor versions of the `eslint` and `@types/eslint` packages, but this was deemed to be acceptable as this is already the case and fixing a vulnerability takes precedence.
