### PR TITLE
Log numbers from `performance` in `@guardian/libs`

### DIFF
--- a/.changeset/two-mails-cheat.md
+++ b/.changeset/two-mails-cheat.md
@@ -1,0 +1,6 @@
+---
+'@guardian/libs': minor
+---
+
+- add `perf` to `logger`
+- log measurement duration when calling `endPerformanceMeasure`

--- a/@types/window.d.ts
+++ b/@types/window.d.ts
@@ -1,4 +1,4 @@
-import type { SubscriptionStyle } from '../libs/@guardian/libs/src/logger/@types/logger';
+import type { ManageSubscription } from '../libs/@guardian/libs/src/logger/@types/logger';
 import type { Switches } from '../libs/@guardian/libs/src/switches/@types/Switches';
 import type { google } from '../libs/@guardian/atoms-rendering/src/ima';
 import type { ImaManager } from '../libs/@guardian/atoms-rendering/src/YoutubeAtomPlayer';
@@ -8,8 +8,8 @@ declare global {
 	interface Window {
 		guardian?: {
 			logger?: {
-				subscribeTo: SubscriptionStyle;
-				unsubscribeFrom: SubscriptionStyle;
+				subscribeTo: ManageSubscription;
+				unsubscribeFrom: ManageSubscription;
 				teams: () => string[];
 				subscriptions: () => string[];
 			};

--- a/@types/window.d.ts
+++ b/@types/window.d.ts
@@ -1,4 +1,4 @@
-import type { TeamSubscription } from '../libs/@guardian/libs/src/logger/@types/logger';
+import type { SubscriptionStyle } from '../libs/@guardian/libs/src/logger/@types/logger';
 import type { Switches } from '../libs/@guardian/libs/src/switches/@types/Switches';
 import type { google } from '../libs/@guardian/atoms-rendering/src/ima';
 import type { ImaManager } from '../libs/@guardian/atoms-rendering/src/YoutubeAtomPlayer';
@@ -8,9 +8,10 @@ declare global {
 	interface Window {
 		guardian?: {
 			logger?: {
-				subscribeTo: TeamSubscription;
-				unsubscribeFrom: TeamSubscription;
+				subscribeTo: SubscriptionStyle;
+				unsubscribeFrom: SubscriptionStyle;
 				teams: () => string[];
+				subscriptions: () => string[];
 			};
 			config?: {
 				page?: {

--- a/libs/@guardian/libs/README.md
+++ b/libs/@guardian/libs/README.md
@@ -66,6 +66,10 @@ Selectively log team-specific messages to the console.
 
 Types relating to Ophan.
 
+### [Performance](./src/performance)
+
+API over `window.performance` and hooks into the data warehouse.
+
 ### [`storage`](./src/storage)
 
 Robust API over `localStorage` and `sessionStorage`.

--- a/libs/@guardian/libs/scripts/generateSvg.logger.teams.ts
+++ b/libs/@guardian/libs/scripts/generateSvg.logger.teams.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
-import { commonStyle, teamStyles } from '../src/logger/teamStyles';
+import { commonStyle, subscriptionStyles } from '../src/logger/subscriptions';
 
 function generateSvg(): string {
-	const teams = Object.entries(teamStyles);
+	const teams = Object.entries(subscriptionStyles);
 
 	const padding = 10;
 	const lineHeight = 24;

--- a/libs/@guardian/libs/src/deprecated-exports.ts
+++ b/libs/@guardian/libs/src/deprecated-exports.ts
@@ -5,6 +5,10 @@
  */
 
 import { Pillar } from './format/Pillar';
+import { type Subscription } from './logger/@types/logger';
 
 /** @deprecated Use `Pillar` instead. */
 export const ArticlePillar = Pillar;
+
+/** @deprecated Use `Subscription` instead. */
+export type TeamName = Subscription;

--- a/libs/@guardian/libs/src/index.ts
+++ b/libs/@guardian/libs/src/index.ts
@@ -37,7 +37,7 @@ export { getLocale } from './locale/getLocale';
 
 export { debug } from './logger/debug';
 export { log } from './logger/log';
-export type { TeamName } from './logger/@types/logger';
+export type { Subscription } from './logger/@types/logger';
 
 export { startPerformanceMeasure } from './performance/startPerformanceMeasure';
 export { getMeasures } from './performance/getMeasures';

--- a/libs/@guardian/libs/src/logger/@types/logger.ts
+++ b/libs/@guardian/libs/src/logger/@types/logger.ts
@@ -1,7 +1,7 @@
-import type { commonStyle, teamStyles } from '../teamStyles';
+import type { commonStyle, subscriptionStyles } from '../subscriptions';
 
-export type Teams<K extends string> = Record<K, Record<string, string>>;
-export type LogCall = (team: TeamName, ...args: unknown[]) => void;
-export type TeamSubscription = (arg: TeamName) => void;
-export type TeamStyle = TeamName | keyof typeof commonStyle;
-export type TeamName = keyof typeof teamStyles;
+export type Subscriptions<K extends string> = Record<K, Record<string, string>>;
+export type LogCall = (subscription: Subscription, ...args: unknown[]) => void;
+export type SubscriptionStyle = (arg: Subscription) => void;
+export type LogStyle = Subscription | keyof typeof commonStyle;
+export type Subscription = keyof typeof subscriptionStyles;

--- a/libs/@guardian/libs/src/logger/@types/logger.ts
+++ b/libs/@guardian/libs/src/logger/@types/logger.ts
@@ -2,6 +2,6 @@ import type { commonStyle, subscriptionStyles } from '../subscriptions';
 
 export type Subscriptions<K extends string> = Record<K, Record<string, string>>;
 export type LogCall = (subscription: Subscription, ...args: unknown[]) => void;
-export type SubscriptionStyle = (arg: Subscription) => void;
+export type ManageSubscription = (arg: Subscription) => void;
 export type LogStyle = Subscription | keyof typeof commonStyle;
 export type Subscription = keyof typeof subscriptionStyles;

--- a/libs/@guardian/libs/src/logger/README.md
+++ b/libs/@guardian/libs/src/logger/README.md
@@ -1,6 +1,6 @@
 # `log`, `debug`
 
-Selectively log team-specific messages to the console.
+Selectively log subscription-specific messages to the console.
 
 ### Example
 
@@ -15,8 +15,8 @@ log('commercial', { 1: true, 2: false });
 Then in the browser console, you can do:
 
 ```js
-window.guardian.logger.teams();
-> ['commercial', 'cmp', 'dotcom'];
+window.guardian.logger.subscriptions();
+> ['commercial', 'cmp', 'dotcom', ...];
 
 window.guardian.logger.subscribeTo('commercial');
 window.guardian.logger.unsubscribeFrom('cmp');
@@ -24,31 +24,21 @@ window.guardian.logger.unsubscribeFrom('cmp');
 
 and see
 
-![example branded console output](/static/logger.svg)
-
-## Table of contents
-
--   [Methods](#methods)
-    -   [`log(team, args)`](#logteam-args)
-    -   [`debug(team, args)`](#debugteam-args)
--   [Browser globals](#browser-globals)
-    -   [`window.guardian.logger.subscribeTo(team)`](#windowguardianloggersubscribetoteam)
-    -   [`window.guardian.logger.unsubscribeFrom(team)`](#windowguardianloggerunsubscribefromteam)
-    -   [`window.guardian.logger.teams()`](#windowguardianloggerteams)
+![example branded console output](../../static/logger.svg)
 
 ## Methods
 
-### `log(team, args)`
+### `log(subscription, args)`
 
 Returns: `void`
 
-Logs a message to the console for a specific team.
+Logs a message to the console for a specific subscription.
 
-#### `team`
+#### `subscription`
 
 Type: `string`<br>
 
-Name of the team interested in this log.
+Name of the subscription interested in this log.
 
 #### `args`
 
@@ -62,7 +52,7 @@ The content to `console.log`.
 log('commercial', { 1: true, 2: false });
 ```
 
-### `debug(team, args)`
+### `debug(subscription, args)`
 
 Returns: `void`
 
@@ -70,23 +60,23 @@ Identical to [`log`][], but only runs in non-production environments (including 
 
 ## Browser globals
 
-### `window.guardian.logger.teams()`
+### `window.guardian.logger.subscriptions()`
 
 Returns: `Array`
 
-Get a list of available teams.
+Get a list of available subscriptions.
 
-### `window.guardian.logger.subscribeTo(team)`
-
-Returns: `void`
-
-Start receiving logs for a specific team.
-
-### `window.guardian.logger.unsubscribeFrom(team)`
+### `window.guardian.logger.subscribeTo(subscription)`
 
 Returns: `void`
 
-Stop receiving logs for a specific team.
+Start receiving logs for a specific subscription.
 
-[`log`]: #logteam-args
-[`debug`]: #debugteam-args
+### `window.guardian.logger.unsubscribeFrom(subscription)`
+
+Returns: `void`
+
+Stop receiving logs for a specific subscription.
+
+[`log`]: #logsubscription-args
+[`debug`]: #debugsubscription-args

--- a/libs/@guardian/libs/src/logger/log.ts
+++ b/libs/@guardian/libs/src/logger/log.ts
@@ -3,8 +3,8 @@ import { storage } from '../storage/storage';
 import type {
 	LogCall,
 	LogStyle,
+	ManageSubscription,
 	Subscription,
-	SubscriptionStyle,
 } from './@types/logger';
 import { STORAGE_KEY } from './storage-key';
 import {
@@ -30,7 +30,7 @@ export const getSubscriptions = (): Subscription[] => {
  * Subscribe to a log
  * @param subscription the subscription ID
  */
-const subscribeTo: SubscriptionStyle = (subscription) => {
+const subscribeTo: ManageSubscription = (subscription) => {
 	const subscriptions: string[] = getSubscriptions();
 	if (!subscriptions.includes(subscription)) subscriptions.push(subscription);
 	storage.local.set(STORAGE_KEY, subscriptions.join(','));
@@ -41,7 +41,7 @@ const subscribeTo: SubscriptionStyle = (subscription) => {
  * Unsubscribe from a log
  * @param subscription the subscription ID
  */
-const unsubscribeFrom: SubscriptionStyle = (subscription) => {
+const unsubscribeFrom: ManageSubscription = (subscription) => {
 	log(subscription, '🔕 Unsubscribed, good-bye!');
 	const teamSubscriptions: string[] = getSubscriptions().filter(
 		(t) => t !== subscription,

--- a/libs/@guardian/libs/src/logger/log.ts
+++ b/libs/@guardian/libs/src/logger/log.ts
@@ -2,8 +2,8 @@ import { isString } from '../isString/isString';
 import { storage } from '../storage/storage';
 import type {
 	LogCall,
-	Subscription,
 	LogStyle,
+	Subscription,
 	SubscriptionStyle,
 } from './@types/logger';
 import { STORAGE_KEY } from './storage-key';
@@ -20,7 +20,7 @@ export const messageStyle = (subscriptionStyle: LogStyle): string => {
 	return `background: ${background}; color: ${font}; padding: 2px 6px; border-radius:20px`;
 };
 
-const getSubscriptions = (): Subscription[] => {
+export const getSubscriptions = (): Subscription[] => {
 	const subscriptions: unknown = storage.local.get(STORAGE_KEY);
 	if (!isString(subscriptions)) return [];
 	return subscriptions.split(',').filter(isSubscription);
@@ -68,8 +68,10 @@ if (typeof window !== 'undefined') {
 /**
  * Runs in all environments, if local storage values are set.
  */
-export const log: LogCall = (subscription, ...args) => {
-	if (!getSubscriptions().includes(subscription)) return;
+export const log: LogCall = (team, ...args) => {
+	if (!getSubscriptions().includes(team)) return;
+
+	const styles = [messageStyle('common'), '', messageStyle(team), ''];
 
 	console.log(`%c@guardian%c %c${team}%c`, ...styles, ...args);
 };

--- a/libs/@guardian/libs/src/logger/log.ts
+++ b/libs/@guardian/libs/src/logger/log.ts
@@ -38,7 +38,7 @@ const subscribeTo: SubscriptionStyle = (subscription) => {
 };
 
 /**
- * Unsubscribe to a subscription
+ * Unsubscribe from a log
  * @param subscription the subscription ID
  */
 const unsubscribeFrom: SubscriptionStyle = (subscription) => {

--- a/libs/@guardian/libs/src/logger/logger.test.ts
+++ b/libs/@guardian/libs/src/logger/logger.test.ts
@@ -1,10 +1,10 @@
 import { hex } from 'wcag-contrast';
 import { storage } from '../storage/storage';
-import type { TeamName } from './@types/logger';
+import type { Subscription } from './@types/logger';
 import { debug } from './debug';
 import { log } from './log';
 import { STORAGE_KEY } from './storage-key';
-import { teamStyles } from './teamStyles';
+import { subscriptionStyles } from './subscriptions';
 
 const spy = jest
 	.spyOn(console, 'log')
@@ -109,7 +109,7 @@ describe('Add and remove teams', () => {
 });
 
 describe('Team-based logging', () => {
-	const teams: TeamName[] = ['cmp', 'commercial', 'dotcom'];
+	const teams: Subscription[] = ['cmp', 'commercial', 'dotcom'];
 
 	it.each(teams)(`should only log message for team: %s`, (team) => {
 		storage.local.set(STORAGE_KEY, team);
@@ -122,7 +122,7 @@ describe('Team-based logging', () => {
 });
 
 describe('Ensure labels are accessible', () => {
-	it.each(Object.entries(teamStyles))(
+	it.each(Object.entries(subscriptionStyles))(
 		'should have a minimum contrast ratio of 4.5 (AA) for %s',
 		(_, colour) => {
 			const { font, background } = colour;

--- a/libs/@guardian/libs/src/logger/subscriptions.ts
+++ b/libs/@guardian/libs/src/logger/subscriptions.ts
@@ -1,7 +1,7 @@
-import type { TeamName } from './@types/logger';
+import type { Subscription } from './@types/logger';
 
 /** Common Guardian blue label. Do not edit */
-const commonStyle = {
+export const commonStyle = {
 	common: {
 		background: '#C1D8FC',
 		font: '#052962',
@@ -14,7 +14,7 @@ const commonStyle = {
  *
  * Make sure your label has a contrast ratio of 4.5 or more.
  * */
-const teamStyles = {
+export const subscriptionStyles = {
 	commercial: {
 		background: '#77EEAA',
 		font: '#004400',
@@ -49,7 +49,7 @@ const teamStyles = {
 	},
 } as const;
 
-const isTeam = (team: string): team is TeamName =>
-	Object.keys(teamStyles).includes(team);
-
-export { commonStyle, teamStyles, isTeam };
+export const isSubscription = (
+	subscription: string,
+): subscription is Subscription =>
+	Object.keys(subscriptionStyles).includes(subscription);

--- a/libs/@guardian/libs/src/logger/subscriptions.ts
+++ b/libs/@guardian/libs/src/logger/subscriptions.ts
@@ -47,6 +47,10 @@ export const subscriptionStyles = {
 		background: '#C74600',
 		font: '#FEF9F5',
 	},
+	perf: {
+		background: '#FFD700',
+		font: '#000000',
+	},
 } as const;
 
 export const isSubscription = (

--- a/libs/@guardian/libs/src/logger/subscriptions.ts
+++ b/libs/@guardian/libs/src/logger/subscriptions.ts
@@ -51,7 +51,7 @@ export const subscriptionStyles = {
 		background: '#FFD700',
 		font: '#000000',
 	},
-} as const;
+} as const satisfies Record<string, { background: string; font: string}>;
 
 export const isSubscription = (
 	subscription: string,

--- a/libs/@guardian/libs/src/performance/@types/measure.ts
+++ b/libs/@guardian/libs/src/performance/@types/measure.ts
@@ -1,4 +1,4 @@
-import type { TeamName } from '../../logger/@types/logger';
+import type { Subscription } from '../../logger/@types/logger';
 
 declare global {
 	interface Performance {
@@ -15,7 +15,7 @@ declare global {
 }
 
 export type Detail = {
-	team: TeamName;
+	team: Subscription;
 	name: string;
 	action?: string;
 };

--- a/libs/@guardian/libs/src/performance/@types/measure.ts
+++ b/libs/@guardian/libs/src/performance/@types/measure.ts
@@ -15,7 +15,7 @@ declare global {
 }
 
 export type Detail = {
-	team: Subscription;
+	subscription: Subscription;
 	name: string;
 	action?: string;
 };

--- a/libs/@guardian/libs/src/performance/README.md
+++ b/libs/@guardian/libs/src/performance/README.md
@@ -26,15 +26,17 @@ const duration = endPerformanceMeasure(); // duration of task in milliseconds
 
 ### `startPerformanceMeasure(team, name, action)`
 
-Returns: `{ endPerformanceMeasure: () => number }`
+Returns: `PerformanceMeasurementControls`
 
 Start measuring a performance duration.
+
+Returns an object of methods for controlling the current measurement.
 
 #### `team`
 
 Type: `TeamName`<br>
 
-Name of the team interested in this log.
+Name of the team interested in this measurement.
 Used for labelling `PerformanceMeasure`.
 
 #### `name`
@@ -50,6 +52,12 @@ Type: `string | undefined`<br>
 
 Optional action performed as part of a task.
 Used for labelling `PerformanceMeasure`.
+
+##### `PerformanceMeasurementControls#endPerformanceMeasure()`
+
+Returns: `number`
+
+End the performance measurement and return the duration in milliseconds.
 
 ### `getMeasures(teams)`
 

--- a/libs/@guardian/libs/src/performance/getMeasures.ts
+++ b/libs/@guardian/libs/src/performance/getMeasures.ts
@@ -1,4 +1,4 @@
-import type { TeamName } from '../logger/@types/logger';
+import type { Subscription } from '../logger/@types/logger';
 import type { GuardianMeasure } from './@types/measure';
 import { deserialise } from './serialise';
 
@@ -7,7 +7,7 @@ import { deserialise } from './serialise';
  * The type is narrowed to `GuardianMeasure` which contains relevant details
  */
 export const getMeasures = (
-	teams: readonly TeamName[],
+	subscriptions: readonly Subscription[],
 ): readonly GuardianMeasure[] =>
 	// https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType#browser_compatibility
 	'getEntriesByType' in window.performance
@@ -17,7 +17,7 @@ export const getMeasures = (
 					const detail = deserialise(name);
 					return entryType === 'measure' &&
 						detail &&
-						teams.includes(detail.team)
+						subscriptions.includes(detail.subscription)
 						? {
 								name,
 								detail,

--- a/libs/@guardian/libs/src/performance/log.ts
+++ b/libs/@guardian/libs/src/performance/log.ts
@@ -1,0 +1,15 @@
+import { getSubscriptions, messageStyle } from '../logger/log';
+
+export const logPerf = (measurement: string, duration: number) => {
+	if (!getSubscriptions().includes('perf')) return;
+
+	const styles = [
+		messageStyle('common'),
+		'',
+		messageStyle('perf'),
+		'',
+		`font-weight: bold;`,
+	];
+
+	console.log(`%c@guardian%c %c${measurement}%c %c${duration}ms`, ...styles);
+};

--- a/libs/@guardian/libs/src/performance/serialise.ts
+++ b/libs/@guardian/libs/src/performance/serialise.ts
@@ -1,17 +1,19 @@
 import { isNonNullable } from '../isNonNullable/isNonNullable';
 import { isString } from '../isString/isString';
-import { isTeam } from '../logger/teamStyles';
+import { isSubscription } from '../logger/subscriptions';
 import type { Detail } from './@types/measure';
 
 /** Serialisation is an implementation detail */
 const SEPARATOR = ':';
 
-export const serialise = ({ team, name, action }: Detail) =>
-	[team, name, action].filter(isNonNullable).join(SEPARATOR);
+export const serialise = ({ subscription, name, action }: Detail) =>
+	[subscription, name, action].filter(isNonNullable).join(SEPARATOR);
 
 export const deserialise = (id: string): Detail | undefined => {
-	const [team, name, action] = id.split(SEPARATOR);
-	return isString(team) && isTeam(team) && isString(name)
-		? { team, name, action }
+	const [subscription, name, action] = id.split(SEPARATOR);
+	return isString(subscription) &&
+		isSubscription(subscription) &&
+		isString(name)
+		? { subscription, name, action }
 		: undefined;
 };

--- a/libs/@guardian/libs/src/performance/startPerformanceMeasure.ts
+++ b/libs/@guardian/libs/src/performance/startPerformanceMeasure.ts
@@ -1,5 +1,6 @@
-import type { TeamName } from '../logger/@types/logger';
+import type { Subscription } from '../logger/@types/logger';
 import { log } from '../logger/log';
+import { logPerf } from './log';
 import type {} from './@types/measure';
 import { serialise } from './serialise';
 
@@ -11,6 +12,10 @@ const getId = () =>
 	Math.trunc(Math.random() * 1_679_615)
 		.toString(36)
 		.padStart(4, '0');
+
+interface PerformanceMeasurementControls {
+	endPerformanceMeasure: () => number;
+}
 
 /**
  * Helper to measure the duration between two events.
@@ -24,12 +29,12 @@ const getId = () =>
  * const duration = endPerformanceMeasure();
  */
 export const startPerformanceMeasure = (
-	team: TeamName,
+	subscription: Subscription,
 	name: string,
 	action?: string,
-): { endPerformanceMeasure: () => number } => {
+): PerformanceMeasurementControls => {
 	try {
-		const measureName = serialise({ team, name, action });
+		const measureName = serialise({ subscription, name, action });
 		const markName = `${measureName}-${getId()}`;
 		const start = performance.now();
 
@@ -47,16 +52,20 @@ export const startPerformanceMeasure = (
 					duration: performance.now() - start,
 				};
 
-				return Math.ceil(duration);
+				const formattedDuration = Math.ceil(duration);
+
+				logPerf(measureName, formattedDuration);
+
+				return formattedDuration;
 			} catch (error) {
-				log(team, error);
+				log(subscription, error);
 				return fallbackDuration;
 			}
 		};
 
 		return { endPerformanceMeasure };
 	} catch (error) {
-		log(team, error);
+		log(subscription, error);
 		return { endPerformanceMeasure: () => fallbackDuration };
 	}
 };

--- a/libs/@guardian/libs/static/logger.svg
+++ b/libs/@guardian/libs/static/logger.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 272" width="600" height="272">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 296" width="600" height="296">
 	<style>
 		.wrapper {
 			font-family: monospace;
@@ -50,7 +50,7 @@
 			color: #052962;
 		}
 	</style>
-	<foreignObject x="0" y="0" width="600" height="272">
+	<foreignObject x="0" y="0" width="600" height="296">
 		<div class="wrapper" xmlns="http://www.w3.org/1999/xhtml">
 			<div id="console">
 				<div class="line top">Console</div>
@@ -100,6 +100,12 @@
 			<span class="label common">@guardian</span>
 			<span class="label openJournalism" style="background-color: #C74600; color: #FEF9F5">openJournalism</span>
 			<span class="label">message no.7</span>
+			<span class="gap"></span>
+			<span class="label log">console.log</span>
+		</div><div class="line">
+			<span class="label common">@guardian</span>
+			<span class="label perf" style="background-color: #FFD700; color: #000000">perf</span>
+			<span class="label">message no.8</span>
 			<span class="gap"></span>
 			<span class="label log">console.log</span>
 		</div>


### PR DESCRIPTION
## What are you changing?

- renames `teams` in `logger` to `subscriptions`
- adds a `perf` subscription
- logs measurements triggered by `startPerformanceMeasure` when subscribed to `perf`

## Why?

- so we can how long things take from the console

<img width="248" alt="262729139-0328860e-7494-46c5-87c1-7762b70a5e6c" src="https://github.com/guardian/csnx/assets/867233/31c975e4-6b1a-49e3-ae95-9cc0380ca888">

