### PR TITLE
Make labels in logs from `logger` less full on

### DIFF
--- a/.changeset/dry-brooms-sparkle.md
+++ b/.changeset/dry-brooms-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Labels used in `logger` are quieter.

--- a/libs/@guardian/libs/src/logger/log.ts
+++ b/libs/@guardian/libs/src/logger/log.ts
@@ -13,7 +13,7 @@ const allStyles = { ...teamStyles, ...commonStyle };
 
 const messageStyle = (teamStyle: TeamStyle): string => {
 	const { background, font } = allStyles[teamStyle];
-	return `background: ${background}; color: ${font}; padding: 2px 3px; border-radius:3px`;
+	return `background: ${background}; color: ${font}; padding: 2px 6px; border-radius:20px`;
 };
 
 const getTeamSubscriptions = (): TeamName[] => {

--- a/libs/@guardian/libs/src/logger/teamStyles.ts
+++ b/libs/@guardian/libs/src/logger/teamStyles.ts
@@ -3,8 +3,8 @@ import type { TeamName } from './@types/logger';
 /** Common Guardian blue label. Do not edit */
 const commonStyle = {
 	common: {
-		background: '#052962',
-		font: '#ffffff',
+		background: '#C1D8FC',
+		font: '#052962',
 	},
 } as const;
 

--- a/libs/@guardian/libs/static/logger.svg
+++ b/libs/@guardian/libs/static/logger.svg
@@ -46,8 +46,8 @@
 		}
 
 		.common {
-			background-color: #052962;
-			color: #ffffff;
+			background-color: #C1D8FC;
+			color: #052962;
 		}
 	</style>
 	<foreignObject x="0" y="0" width="600" height="272">


### PR DESCRIPTION
## What are you changing?

updates logs to look like this:

<img width="289" alt="262933845-2b114fa9-ecb6-4133-ab80-b04e65055db6" src="https://github.com/guardian/csnx/assets/867233/48b791f0-d41f-415b-9652-bd1b2a794f80">


## Why?

- when there are lot, it's very shouty, and labels dominate over what you've actually logged
