### PR TITLE
Dblatcher/newsletter types in libs

### DIFF
--- a/.changeset/heavy-rings-visit.md
+++ b/.changeset/heavy-rings-visit.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+add types for objects from the newsletters api

--- a/libs/@guardian/libs/src/index.test.ts
+++ b/libs/@guardian/libs/src/index.test.ts
@@ -50,6 +50,11 @@ export type {
 	OphanComponentType,
 	OphanProduct,
 	Switches,
+	AutomatedFrontSection,
+	NewsletterEmailRenderingOptions,
+	NewsletterApiData,
+	NewslettersApiAllNewslettersResponse,
+	NewslettersApiSingleNewslettersResponse,
 } from './index';
 
 // @ts-expect-error: make sure the above list are real exports

--- a/libs/@guardian/libs/src/index.ts
+++ b/libs/@guardian/libs/src/index.ts
@@ -57,3 +57,11 @@ export { storage } from './storage/storage';
 
 export type { Switches } from './switches/@types/Switches';
 export { getSwitches } from './switches/getSwitches';
+
+export type {
+	AutomatedFrontSection,
+	NewsletterEmailRenderingOptions,
+	NewsletterApiData,
+	NewslettersApiAllNewslettersResponse,
+	NewslettersApiSingleNewslettersResponse,
+} from './newsletters/@types';

--- a/libs/@guardian/libs/src/newsletters/@types/index.ts
+++ b/libs/@guardian/libs/src/newsletters/@types/index.ts
@@ -1,3 +1,1 @@
 export * from './newsletters-api';
-
-// TO DO - re-export everything from libs/@guardian/libs/src/index.ts

--- a/libs/@guardian/libs/src/newsletters/@types/index.ts
+++ b/libs/@guardian/libs/src/newsletters/@types/index.ts
@@ -1,0 +1,3 @@
+export * from './newsletters-api';
+
+// TO DO - re-export everything from libs/@guardian/libs/src/index.ts

--- a/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
+++ b/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
@@ -39,47 +39,68 @@ export type NewsletterEmailRenderingOptions = {
 		| 'features';
 };
 
-// have excluded some of the fields from the api data which are
-// used purely for data collection and workflow management
-// internally in the newsletters tool.
-// Other application should not rely on these.
 export type NewsletterApiData = {
+	/** unique identifier in kebab-case format*/
 	identityName: string;
+	/** display name for the newsletter*/
 	name: string;
+	/** How the newsletter is produced and sent to users */
 	category:
 		| 'article-based'
 		| 'article-based-legacy'
 		| 'fronts-based'
 		| 'manual-send'
 		| 'other';
+	/** whether access to the newsletter should restricted - IE not available for any reader to subscribe to */
 	restricted: boolean;
+	/** The status of the newsletter:
+	 *  - **pending**: Initial state after launch - can be promoted, not yet ready to be sent out.
+	 *  - **live**: Able to be sent and/or currently being sent out to subscribers
+	 *  - **paused**: Currently not live, but might be restarted in future
+	 *  - **cancelled**: Permanently cancelled - must still exist in the API for referential integrity
+	 */
 	status: 'paused' | 'cancelled' | 'live' | 'pending';
+	/** whether the user should receive a validation email to confirm they want to subscribe before a subscription request is processed */
 	emailConfirmation: boolean;
 	brazeSubscribeAttributeName: string;
 	brazeSubscribeEventNamePrefix: string;
 	brazeNewsletterName: string;
 	theme: 'news' | 'opinion' | 'culture' | 'sport' | 'lifestyle' | 'features';
+	/** @deprecated the name of a group used to categorise the newsletters into sets. */
 	group: string;
+	/** the desired headline for the sign-up article for this newsletter */
 	signUpHeadline: string;
+	/** the desired description text for the sign-up article for this newsletter */
 	signUpDescription: string;
+	/** the description text used in embedded in-article sign-up forms for this newsletter */
 	signUpEmbedDescription: string;
+	/** the EditionId for the edition (if any) this newsletter is primarily intended for*/
 	regionFocus?: 'UK' | 'AU' | 'US' | 'INTL' | 'EUR';
+	/** display text describing how often the newsletter is sent - eg "weekly", "every day" */
 	frequency: string;
+	/** unique numerical identifier for the newsletter */
 	listId: number;
+	/** @deprecated a legacy numerical identifier included for backwards compatibility */
 	listIdV1: number;
 	campaignName?: string;
 	campaignCode?: string;
 	brazeSubscribeAttributeNameAlternate?: string[];
+	// relative url to a dedicated page on theguardian.com for users to sign up to this newsletter
 	signupPage?: string;
+	// relative url to a page on theguardian.com serving an example of the newsletter
 	exampleUrl?: string;
+	// asset url for a circular image representing the newsletter
 	illustrationCircle?: string;
+	// asset url for a 5:3 image representing the newsletter
 	illustrationCard?: string;
 	creationTimeStamp: number;
 	cancellationTimeStamp?: number;
+	// the series tag that identifies an article as being an instance of this newsletter
 	seriesTag?: string;
+	// a campaign tag to add to articles to indicate that the article should include a promotion for this newsletter.
 	composerCampaignTag?: string;
-
 	renderingOptions?: NewsletterEmailRenderingOptions;
+	// a custom message to display when comfirming to a user that their subscription request was received
 	mailSuccessDescription?: string;
 };
 

--- a/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
+++ b/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
@@ -12,12 +12,12 @@ export type NewsletterEmailRenderingOptions = {
 	podcastSubheading?: string[] | undefined;
 	darkThemeSubheading?: string[] | undefined;
 	readMoreSections?:
-		| {
+		| Array<{
 				subheading: string;
 				wording: string;
 				onwardPath?: string;
 				isDarkTheme?: boolean;
-		  }[]
+		  }>
 		| undefined;
 
 	automatedFrontSections?: AutomatedFrontSection[] | undefined;

--- a/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
+++ b/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
@@ -1,0 +1,104 @@
+export type AutomatedFrontSection = {
+	subheading: string;
+	insertPosition: number;
+	frontPath: string;
+	sectionName: string;
+	maxArticles: number;
+	partBuilderFunction: string;
+};
+
+export type NewsletterEmailRenderingOptions = {
+	linkListSubheading?: string[] | undefined;
+	podcastSubheading?: string[] | undefined;
+	darkThemeSubheading?: string[] | undefined;
+	readMoreSections?:
+		| {
+				subheading: string;
+				wording: string;
+				onwardPath?: string;
+				isDarkTheme?: boolean;
+		  }[]
+		| undefined;
+
+	automatedFrontSections?: AutomatedFrontSection[] | undefined;
+	displayDate: boolean;
+	displayStandfirst: boolean;
+	contactEmail: string;
+	displayImageCaptions: boolean;
+	mainBannerUrl?: string;
+	subheadingBannerUrl?: string;
+	darkSubheadingBannerUrl?: string;
+	darkHeadlineBackground?: boolean;
+	displayNewsletterName?: boolean;
+	paletteOverride?:
+		| 'news'
+		| 'opinion'
+		| 'culture'
+		| 'sport'
+		| 'lifestyle'
+		| 'features';
+};
+
+// have excluded some of the fields from the api data which are
+// used purely for data collection and workflow management
+// internally in the newsletters tool.
+// Other application should not rely on these.
+export type NewsletterApiData = {
+	identityName: string;
+	name: string;
+	category:
+		| 'article-based'
+		| 'article-based-legacy'
+		| 'fronts-based'
+		| 'manual-send'
+		| 'other';
+	restricted: boolean;
+	status: 'paused' | 'cancelled' | 'live' | 'pending';
+	emailConfirmation: boolean;
+	brazeSubscribeAttributeName: string;
+	brazeSubscribeEventNamePrefix: string;
+	brazeNewsletterName: string;
+	theme: 'news' | 'opinion' | 'culture' | 'sport' | 'lifestyle' | 'features';
+	group: string;
+	signUpHeadline: string;
+	signUpDescription: string;
+	signUpEmbedDescription: string;
+	regionFocus?: 'UK' | 'AU' | 'US' | 'INTL' | 'EUR';
+	frequency: string;
+	listId: number;
+	listIdV1: number;
+	campaignName?: string;
+	campaignCode?: string;
+	brazeSubscribeAttributeNameAlternate?: string[];
+	signupPage?: string;
+	exampleUrl?: string;
+	illustrationCircle?: string;
+	illustrationCard?: string;
+	creationTimeStamp: number;
+	cancellationTimeStamp?: number;
+	seriesTag?: string;
+	composerCampaignTag?: string;
+
+	renderingOptions?: NewsletterEmailRenderingOptions;
+	mailSuccessDescription?: string;
+};
+
+type ApiErrorResponse = {
+	ok: false;
+	message?: string;
+};
+
+type ApiSuccessResponse<T> = {
+	ok: true;
+	total: number;
+	data: T;
+};
+
+type ApiResponse<T = unknown> = ApiSuccessResponse<T> | ApiErrorResponse;
+
+export type NewslettersApiAllNewslettersResponse = ApiResponse<
+	NewsletterApiData[]
+>;
+
+export type NewslettersApiSingleNewslettersResponse =
+	ApiResponse<NewsletterApiData>;

--- a/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
+++ b/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
@@ -42,17 +42,13 @@ export type NewsletterEmailRenderingOptions = {
 export type NewsletterApiData = {
 	/** unique identifier in kebab-case format*/
 	identityName: string;
+	/** unique numerical identifier for the newsletter */
+	listId: number;
+	/** @deprecated a legacy numerical identifier included for backwards compatibility */
+	listIdV1: number;
 	/** display name for the newsletter*/
 	name: string;
-	/** How the newsletter is produced and sent to users */
-	category:
-		| 'article-based'
-		| 'article-based-legacy'
-		| 'fronts-based'
-		| 'manual-send'
-		| 'other';
-	/** whether access to the newsletter should restricted - IE not available for any reader to subscribe to */
-	restricted: boolean;
+
 	/** The status of the newsletter:
 	 *  - **pending**: Initial state after launch - can be promoted, not yet ready to be sent out.
 	 *  - **live**: Able to be sent and/or currently being sent out to subscribers
@@ -60,12 +56,31 @@ export type NewsletterApiData = {
 	 *  - **cancelled**: Permanently cancelled - must still exist in the API for referential integrity
 	 */
 	status: 'paused' | 'cancelled' | 'live' | 'pending';
+
+	/** How the newsletter is produced and sent to users */
+	category:
+		| 'article-based'
+		| 'article-based-legacy'
+		| 'fronts-based'
+		| 'manual-send'
+		| 'other';
+
+	/** the name of the pillar the newsletter is aligned to */
+	theme: 'news' | 'opinion' | 'culture' | 'sport' | 'lifestyle' | 'features';
+	/** the EditionId for the edition (if any) this newsletter is primarily intended for*/
+	regionFocus?: 'UK' | 'AU' | 'US' | 'INT' | 'EUR';
 	/** whether the user should receive a validation email to confirm they want to subscribe before a subscription request is processed */
 	emailConfirmation: boolean;
-	brazeSubscribeAttributeName: string;
-	brazeSubscribeEventNamePrefix: string;
-	brazeNewsletterName: string;
-	theme: 'news' | 'opinion' | 'culture' | 'sport' | 'lifestyle' | 'features';
+	/** whether access to the newsletter should restricted - IE not available for any reader to subscribe to */
+	restricted: boolean;
+
+	/** the series tag that identifies an article as being an instance of this newsletter */
+	seriesTag?: string;
+	/**  a campaign tag to add to articles to indicate that the article should include a promotion for this newsletter.*/
+	composerCampaignTag?: string;
+
+	/** display text describing how often the newsletter is sent - eg "weekly", "every day" */
+	frequency: string;
 	/** the name of a group used to categorise the newsletters on the Manage My Account page. */
 	group: string;
 	/** the desired headline for the sign-up article for this newsletter */
@@ -74,34 +89,28 @@ export type NewsletterApiData = {
 	signUpDescription: string;
 	/** the description text used in embedded in-article sign-up forms for this newsletter */
 	signUpEmbedDescription: string;
-	/** the EditionId for the edition (if any) this newsletter is primarily intended for*/
-	regionFocus?: 'UK' | 'AU' | 'US' | 'INT' | 'EUR';
-	/** display text describing how often the newsletter is sent - eg "weekly", "every day" */
-	frequency: string;
-	/** unique numerical identifier for the newsletter */
-	listId: number;
-	/** @deprecated a legacy numerical identifier included for backwards compatibility */
-	listIdV1: number;
+	/** a custom message to display when comfirming to a user that their subscription request was received */
+	mailSuccessDescription?: string;
+
 	campaignName?: string;
 	campaignCode?: string;
+	brazeSubscribeAttributeName: string;
+	brazeSubscribeEventNamePrefix: string;
+	brazeNewsletterName: string;
 	brazeSubscribeAttributeNameAlternate?: string[];
-	// relative url to a dedicated page on theguardian.com for users to sign up to this newsletter
+
+	/** relative url to a dedicated page on theguardian.com for users to sign up to this newsletter */
 	signupPage?: string;
-	// relative url to a page on theguardian.com serving an example of the newsletter
+	/**  relative url to a page on theguardian.com serving an example of the newsletter */
 	exampleUrl?: string;
-	// asset url for a circular image representing the newsletter
+	/** asset url for a circular image representing the newsletter */
 	illustrationCircle?: string;
-	// asset url for a 5:3 image representing the newsletter
+	/** asset url for a 5:3 image representing the newsletter */
 	illustrationCard?: string;
+
 	creationTimeStamp: number;
 	cancellationTimeStamp?: number;
-	// the series tag that identifies an article as being an instance of this newsletter
-	seriesTag?: string;
-	// a campaign tag to add to articles to indicate that the article should include a promotion for this newsletter.
-	composerCampaignTag?: string;
 	renderingOptions?: NewsletterEmailRenderingOptions;
-	// a custom message to display when comfirming to a user that their subscription request was received
-	mailSuccessDescription?: string;
 };
 
 type ApiErrorResponse = {

--- a/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
+++ b/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
@@ -75,7 +75,7 @@ export type NewsletterApiData = {
 	/** the description text used in embedded in-article sign-up forms for this newsletter */
 	signUpEmbedDescription: string;
 	/** the EditionId for the edition (if any) this newsletter is primarily intended for*/
-	regionFocus?: 'UK' | 'AU' | 'US' | 'INTL' | 'EUR';
+	regionFocus?: 'UK' | 'AU' | 'US' | 'INT' | 'EUR';
 	/** display text describing how often the newsletter is sent - eg "weekly", "every day" */
 	frequency: string;
 	/** unique numerical identifier for the newsletter */

--- a/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
+++ b/libs/@guardian/libs/src/newsletters/@types/newsletters-api.ts
@@ -66,7 +66,7 @@ export type NewsletterApiData = {
 	brazeSubscribeEventNamePrefix: string;
 	brazeNewsletterName: string;
 	theme: 'news' | 'opinion' | 'culture' | 'sport' | 'lifestyle' | 'features';
-	/** @deprecated the name of a group used to categorise the newsletters into sets. */
+	/** the name of a group used to categorise the newsletters on the Manage My Account page. */
 	group: string;
 	/** the desired headline for the sign-up article for this newsletter */
 	signUpHeadline: string;

--- a/libs/@guardian/libs/src/newsletters/README.md
+++ b/libs/@guardian/libs/src/newsletters/README.md
@@ -1,0 +1,11 @@
+# Newsletters
+
+Types related to the guardian's editorial newsletters.
+
+THe Newsletters API, and the UI for managing editorial newsletters, is served by https://github.com/guardian/newsletters-nx. That project has its own internal definitions of the types served by this package, but does not publish a type library.
+
+The types exported by this libray contain a subset of the fields on the API data. The fields which are only relevant to the internal workflow of the newsletter tool are not included.
+
+Some typescript projects obtain newsletters data via the identityAPI (https://github.com/guardian/identity). Identity injests the data from the newsletter API and serves it in a modified format. Types representing both formats are exported.
+
+**TO DO** - add types representing the identity format, when identity is updated to use the current data model.


### PR DESCRIPTION
## What are you changing?

- exports a set of types from @guardian/libs describing the output of the [newsletters api](https://newsletters.guardianapis.com/newsletters), published by the [newsletters-nx](https://github.com/guardian/newsletters-nx) project.

## Why?

- avoid duplicating the definitions of the Newsletters Api data in multiple TypeScript projects consuming data from the API
- include annotations explaining the fields
