### PR TITLE
Align ToggleSwitch Tick to Centre when Checked

### DIFF
--- a/.changeset/four-ants-hammer.md
+++ b/.changeset/four-ants-hammer.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+`ToggleSwitch` tick is now centred

--- a/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
@@ -84,7 +84,7 @@ export const toggleStyles = (format?: ArticleFormat): SerializedStyles => {
 			top: 5px;
 			height: 11px;
 			width: 6px;
-			right: 8px;
+			right: 10px;
 			opacity: 0;
 			border-bottom: 2px solid ${success[400]};
 			border-right: 2px solid ${success[400]};


### PR DESCRIPTION
## What are you changing?

- Centre align the tick within `ToggleSwitch`

## Why?

The tick was not centred, as pointed out to me by a designer when I used this component

- Before (checked) 
![image](https://github.com/guardian/csnx/assets/114918544/4bba4d8e-f28b-4daf-8d64-2c889d13b18c)
- After (checked)
![image](https://github.com/guardian/csnx/assets/114918544/c28b1d4e-d410-4ce0-ba8b-da331535e4a3)
- Before (unchecked)
![image](https://github.com/guardian/csnx/assets/114918544/094d6b94-46ea-4ea3-bf6f-84a130107254)
- After (unchecked)
![image](https://github.com/guardian/csnx/assets/114918544/6daf84c5-a8ff-44f2-a802-c5ec82408a6b)

