### PR TITLE
Add prettier checks to repo and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - task: check-formatting
           - task: lint
           - task: test
           - task: build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,14 +9,14 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ['main']
   schedule:
     - cron: '38 22 * * 6'
 
@@ -32,41 +32,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ['javascript']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/stale-PRs.yml
+++ b/.github/workflows/stale-PRs.yml
@@ -1,8 +1,8 @@
-name: "Stale PR Handler"
+name: 'Stale PR Handler'
 
 on:
   schedule:
-    - cron: "0 6 * * *"
+    - cron: '0 6 * * *'
 
 permissions:
   pull-requests: write
@@ -14,17 +14,17 @@ jobs:
       - uses: actions/stale@v8
         id: stale
         # Read about options here: https://github.com/actions/stale#all-options
-        with:          
+        with:
           # do not mark issues as stale (they're used for planning)
           days-before-issue-stale: -1
-          
+
           days-before-stale: 30
           stale-pr-message: >
             "This PR was marked stale because it has been open for 30 days without activity. If nothing happens, it will be closed 3 days from now."
-          
+
           days-before-close: 3
-          close-pr-message: "This PR was closed because nothing happened for 3 days after becoming stale."
-          
+          close-pr-message: 'This PR was closed because nothing happened for 3 days after becoming stale.'
+
           delete-branch: true
-          
-          exempt-pr-labels: "dependencies"
+
+          exempt-pr-labels: 'dependencies'

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,4 @@
 module.exports = {
-	'*.{js,jsx,ts,tsx,cjs,mjs,cts,mts,json,css,html,md,mdx}': 'prettier --write',
+	'*': 'prettier --ignore-unknown --write --cache',
 	'package.json': 'sort-package-json',
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+.nx
+
+# specific files
+pnpm-lock.yaml

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,18 @@ lint: install
 	@corepack pnpm nx run-many --target=lint --skip-nx-cache=$(SKIP_NX_CACHE)
 	@node ./tools/scripts/check-packages-for-tslib.mjs
 
+# check repo for formatting errors
+.PHONY: check-formatting
+check-formatting: install
+	$(call log,"Checking formatting across repo")
+	@corepack pnpm prettier --ignore-unknown --cache --check .
+
 # attemps to fix lint errors across all projects
 .PHONY: fix
 fix: install
-	$(call log,"Attempting to fix lint error in projects")
+	$(call log,"Attempting to fix issues across all projects")
 	@corepack pnpm nx run-many --target=fix --skip-nx-cache=$(SKIP_NX_CACHE)
+	@corepack pnpm prettier --ignore-unknown --cache --write .
 
 # makes sure absolutely everything is working
 .PHONY: validate

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Tasks are defined in the [`Makefile`](./Makefile).
 - `make build-storybooks` _builds all storybooks_
 - `make build` _builds all projects_
 - `make changeset` _creates a new [changeset](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md)_
+- `make check-formatting` _check repo for formatting errors_
 - `make clean` _removes all build artifacts_
 - `make e2e` _runs the e2e tests for all projects_
 - `make fix` _attemps to fix lint errors across all projects_

--- a/libs/@guardian/identity-auth/src/token.ts
+++ b/libs/@guardian/identity-auth/src/token.ts
@@ -1009,9 +1009,8 @@ export class Token<
 		};
 
 		// perform the authorization code flow with PKCE using an iframe
-		const authorizeResponse = await this.#performAuthCodeFlowIframe(
-			authorizeParams,
-		);
+		const authorizeResponse =
+			await this.#performAuthCodeFlowIframe(authorizeParams);
 
 		// check for an error response
 		if (isOAuthAuthorizeResponseError(authorizeResponse)) {

--- a/libs/@guardian/libs/src/cookies/README.md
+++ b/libs/@guardian/libs/src/cookies/README.md
@@ -6,19 +6,19 @@ Robust API over `document.cookie`.
 
 ```js
 import {
-    getCookie,
-    removeCookie,
-    setCookie,
-    setSessionCookie
- } from '@guardian/libs';
+	getCookie,
+	removeCookie,
+	setCookie,
+	setSessionCookie,
+} from '@guardian/libs';
 ```
 
 ## Methods
 
--   [`setCookie({name, value, daysToLive?, isCrossSubdomain?})`](#setCookie)
--   [`setSessionCookie({name, value})`](#setSessionCookie)
--   [`getCookie({name, shouldMemoize?})`](#getCookie)
--   [`removeCookie(name)`](#removeCookie)
+- [`setCookie({name, value, daysToLive?, isCrossSubdomain?})`](#setCookie)
+- [`setSessionCookie({name, value})`](#setSessionCookie)
+- [`getCookie({name, shouldMemoize?})`](#getCookie)
+- [`removeCookie(name)`](#removeCookie)
 
 ## `setCookie({name, value, daysToLive?, isCrossSubdomain?})`
 
@@ -53,9 +53,14 @@ Set this true if the cookie is cross subdomain.
 ### Example
 
 ```js
-setCookie({name:'GU_country_code', value:'GB'})
-setCookie({name:'GU_country_code', value:'GB', daysToLive: 7})
-setCookie({name:'GU_country_code', value:'GB', daysToLive: 7, isCrossSubdomain: true})
+setCookie({ name: 'GU_country_code', value: 'GB' });
+setCookie({ name: 'GU_country_code', value: 'GB', daysToLive: 7 });
+setCookie({
+	name: 'GU_country_code',
+	value: 'GB',
+	daysToLive: 7,
+	isCrossSubdomain: true,
+});
 ```
 
 ## `setSessionCookie({name, value})`
@@ -79,7 +84,7 @@ Value of the cookie.
 ### Example
 
 ```js
-setSessionCookie({name:'GU_country_code', value: 'GB'})
+setSessionCookie({ name: 'GU_country_code', value: 'GB' });
 ```
 
 ## `getCookie({name, shouldMemoize?})`
@@ -92,19 +97,17 @@ Type: `string`
 
 Name of the cookie to retrieve.
 
-
 #### `shouldMemoize?`
 
 Type: `boolean`<br>
 
 When this is set to true it will keep the cookie in memory to avoid fetching more than once.
 
-
 ### Example
 
 ```js
-getCookie({name:'GU_geo_country'}); //GB
-getCookie({name:'GU_geo_country', shouldMemoize: true}); //GB
+getCookie({ name: 'GU_geo_country' }); //GB
+getCookie({ name: 'GU_geo_country', shouldMemoize: true }); //GB
 ```
 
 ## `removeCookie({name, currentDomainOnly?})`
@@ -124,9 +127,10 @@ Name of the stored cookie to remove.
 Type: `boolean`
 
 Set to true if it's a cookie for current domain only, defaults to false
+
 ### Example
 
 ```js
-removeCookie({name:'GU_geo_country'});
-removeCookie({name:'GU_geo_country', currentDomainOnly: true});
+removeCookie({ name: 'GU_geo_country' });
+removeCookie({ name: 'GU_geo_country', currentDomainOnly: true });
 ```

--- a/libs/@guardian/libs/src/cookies/cookies.test.ts
+++ b/libs/@guardian/libs/src/cookies/cookies.test.ts
@@ -11,9 +11,7 @@ describe('cookies', () => {
 	beforeAll(() => {
 		Object.defineProperty(document, 'cookie', {
 			get() {
-				return cookieValue
-					.replace('|', ';')
-					.replace(/^[;|]|[;|]$/g, '');
+				return cookieValue.replace('|', ';').replace(/^[;|]|[;|]$/g, '');
 			},
 
 			set(value: string) {
@@ -44,9 +42,7 @@ describe('cookies', () => {
 	it('gets a cookie', () => {
 		document.cookie =
 			'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649;';
-		expect(getCookie({ name: '__qca' })).toEqual(
-			'P0-938012256-1398171768649',
-		);
+		expect(getCookie({ name: '__qca' })).toEqual('P0-938012256-1398171768649');
 	});
 
 	it('sets a cookie with an expiry date in six months that preserves UTC time', () => {

--- a/libs/@guardian/libs/src/cookies/getCookieValues.ts
+++ b/libs/@guardian/libs/src/cookies/getCookieValues.ts
@@ -5,9 +5,7 @@ export const getCookieValues = (name: string): string[] => {
 	return cookies.reduce((acc: string[], cookie: string) => {
 		const cookieTrimmed: string = cookie.trim();
 		if (cookieTrimmed.startsWith(nameEq)) {
-			acc.push(
-				cookieTrimmed.substring(nameEq.length, cookieTrimmed.length),
-			);
+			acc.push(cookieTrimmed.substring(nameEq.length, cookieTrimmed.length));
 		}
 
 		return acc;

--- a/libs/@guardian/libs/src/countries/@types/Country.ts
+++ b/libs/@guardian/libs/src/countries/@types/Country.ts
@@ -1,3 +1,3 @@
 import type { countries } from '../countries';
 
-export type Country = typeof countries[keyof typeof countries];
+export type Country = (typeof countries)[keyof typeof countries];

--- a/libs/@guardian/libs/src/countries/README.md
+++ b/libs/@guardian/libs/src/countries/README.md
@@ -50,8 +50,8 @@ Type: `CountryCode`
 
 ```typescript
 type Country = {
-    countryCode: CountryCode;
-    name: string;
+	countryCode: CountryCode;
+	name: string;
 };
 ```
 

--- a/libs/@guardian/libs/src/countries/getCountryByCountryCode.ts
+++ b/libs/@guardian/libs/src/countries/getCountryByCountryCode.ts
@@ -7,6 +7,6 @@ export const getCountryByCountryCodeCache: {
 } = {};
 
 export const getCountryByCountryCode = (countryCode: CountryCode): Country =>
-	(getCountryByCountryCodeCache[countryCode] ||= Object.values(
-		countries,
-	).find((country) => country.countryCode === countryCode)) as Country;
+	(getCountryByCountryCodeCache[countryCode] ||= Object.values(countries).find(
+		(country) => country.countryCode === countryCode,
+	)) as Country;

--- a/libs/@guardian/libs/src/datetime/README.md
+++ b/libs/@guardian/libs/src/datetime/README.md
@@ -1,9 +1,9 @@
-
 # `timeAgo`
 
 Takes an absolute date in [epoch format](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#description) and returns a string representing relative time ago.
 
 ## Usage
+
 `timeAgo(epoch, opts)`
 
 Returns: `string | false`
@@ -19,6 +19,7 @@ The date when an event happened in epoch format
 `opts`
 
 Type:
+
 ```typescript
 type Opts = {
     verbose?: boolean, // Return a longer, more descriptive string when true
@@ -29,9 +30,11 @@ type Opts = {
 Options to control the response
 
 ## Examples
+
 ```ts
-timeAgo(twoSecondsAgoAsEpoch) // 'now'
-timeAgo(fiveMinutesAgoAsEpoch) // '5m ago'
-timeAgo(twoDaysAgoAsEpoch) // '2d ago'
-timeAgo(sixDaysAgoAsEpoch, { verbose: true }) // '6 days ago'
-timeAgo(sixDaysAgoAsEpoch, { daysUntilAbsolute: 4 }) // '12 Mar 2021'
+timeAgo(twoSecondsAgoAsEpoch); // 'now'
+timeAgo(fiveMinutesAgoAsEpoch); // '5m ago'
+timeAgo(twoDaysAgoAsEpoch); // '2d ago'
+timeAgo(sixDaysAgoAsEpoch, { verbose: true }); // '6 days ago'
+timeAgo(sixDaysAgoAsEpoch, { daysUntilAbsolute: 4 }); // '12 Mar 2021'
+```

--- a/libs/@guardian/libs/src/format/README.md
+++ b/libs/@guardian/libs/src/format/README.md
@@ -7,9 +7,9 @@ Types and enums related to editorial formats.
 ```ts
 import type { ArticleTheme, ArticleFormat } from '@guardian/libs';
 import {
-    ArticlePillar,
-    ArticleSpecial,
-    ArticleDesign,
-    ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+	ArticleDesign,
+	ArticleDisplay,
 } from '@guardian/libs';
 ```

--- a/libs/@guardian/libs/src/joinUrl/joinUrl.test.ts
+++ b/libs/@guardian/libs/src/joinUrl/joinUrl.test.ts
@@ -40,9 +40,7 @@ describe('joinUrl', () => {
 
 	it('works when the filename has special characters in it', () => {
 		expect(
-			joinUrl(
-				'/vendors~AudioAtomWrapper~elements-YoutubeBlockComponent.js',
-			),
+			joinUrl('/vendors~AudioAtomWrapper~elements-YoutubeBlockComponent.js'),
 		).toBe('/vendors~AudioAtomWrapper~elements-YoutubeBlockComponent.js');
 	});
 });

--- a/libs/@guardian/libs/src/loadScript/README.md
+++ b/libs/@guardian/libs/src/loadScript/README.md
@@ -28,10 +28,10 @@ import { loadScript } from '@guardian/libs';
 loadScript('my-polyfills.js', { async: false });
 
 loadScript('my-functions.js')
-    .then(() => {
-        // do something now that my-functions.js has loaded
-    })
-    .catch(() => {
-        // do something if my-functions.js script fails to load
-    });
+	.then(() => {
+		// do something now that my-functions.js has loaded
+	})
+	.catch(() => {
+		// do something if my-functions.js script fails to load
+	});
 ```

--- a/libs/@guardian/libs/src/locale/README.md
+++ b/libs/@guardian/libs/src/locale/README.md
@@ -14,7 +14,7 @@ Lookups are cached, so you can call this function as many times as you want with
 import { getLocale } from '@guardian/libs';
 
 getLocale().then((locale) => {
-    console.log(locale); // UK, AU etc
+	console.log(locale); // UK, AU etc
 });
 ```
 

--- a/libs/@guardian/libs/src/switches/README.md
+++ b/libs/@guardian/libs/src/switches/README.md
@@ -12,8 +12,8 @@ If `window.guardian.config.switches` exists it will return that. Otherwise it fe
 import { getSwitches } from '@guardian/libs';
 
 getSwitches().then((switches) => {
-    if (switches.mySwitch) {
-        // do the thing i want
-    }
+	if (switches.mySwitch) {
+		// do the thing i want
+	}
 });
 ```

--- a/libs/@guardian/libs/src/switches/getSwitches.ts
+++ b/libs/@guardian/libs/src/switches/getSwitches.ts
@@ -14,9 +14,7 @@ const fetchSwitches = () =>
 			validate(switches)
 				? (switches as Switches)
 				: Promise.reject(
-						new Error(
-							'Error getting remote switches – config is malformed',
-						),
+						new Error('Error getting remote switches – config is malformed'),
 				  ),
 		);
 

--- a/libs/@guardian/source-foundations/.storybook/preview-head.html
+++ b/libs/@guardian/source-foundations/.storybook/preview-head.html
@@ -3,7 +3,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff')
 				format('woff'),
@@ -15,7 +16,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff')
 				format('woff'),
@@ -27,7 +29,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff')
 				format('woff'),
@@ -39,7 +42,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff')
 				format('woff'),
@@ -51,7 +55,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff')
 				format('woff'),
@@ -63,7 +68,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff')
 				format('woff'),
@@ -75,7 +81,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff')
 				format('woff'),
@@ -87,7 +94,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff')
 				format('woff'),
@@ -99,7 +107,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff')
 				format('woff'),
@@ -111,7 +120,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff')
 				format('woff'),
@@ -123,7 +133,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff')
 				format('woff'),
@@ -135,7 +146,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff')
 				format('woff'),
@@ -149,7 +161,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff')
 				format('woff'),
@@ -161,7 +174,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff')
 				format('woff'),
@@ -173,7 +187,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.woff')
 				format('woff'),
@@ -185,7 +200,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.woff')
 				format('woff'),
@@ -197,7 +213,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff')
 				format('woff'),
@@ -209,7 +226,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff')
 				format('woff'),
@@ -221,7 +239,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.woff')
 				format('woff'),
@@ -233,7 +252,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.woff')
 				format('woff'),
@@ -247,7 +267,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff')
 				format('woff'),
@@ -259,7 +280,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff')
 				format('woff'),
@@ -271,7 +293,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff')
 				format('woff'),
@@ -283,7 +306,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff')
 				format('woff'),
@@ -295,7 +319,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff')
 				format('woff'),
@@ -307,7 +332,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff')
 				format('woff'),
@@ -319,7 +345,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.woff')
 				format('woff'),
@@ -331,7 +358,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff')
 				format('woff'),
@@ -345,7 +373,8 @@
 
 	@font-face {
 		font-family: 'GT Guardian Titlepiece';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff')
 				format('woff'),

--- a/libs/@guardian/source-foundations/src/accessibility/focus-style-manager.ts
+++ b/libs/@guardian/source-foundations/src/accessibility/focus-style-manager.ts
@@ -14,7 +14,10 @@ const TAB_KEY_CODE = 9;
 export class InteractionModeEngine {
 	private isRunning = false;
 
-	constructor(private container: Element, private className: string) {}
+	constructor(
+		private container: Element,
+		private className: string,
+	) {}
 
 	/** Returns whether the engine is currently running. */
 	public isActive(): boolean {

--- a/libs/@guardian/source-foundations/src/typography/types.ts
+++ b/libs/@guardian/source-foundations/src/typography/types.ts
@@ -22,7 +22,7 @@ export type TypographyStyles<Unit extends ScaleUnit = ScaleUnit> = {
 	fontFamily: string;
 	fontSize: Unit extends 'px' ? number : `${number}rem`;
 	lineHeight: string | number;
-	fontWeight?: typeof fontWeights[keyof typeof fontWeights] | FontWeight;
+	fontWeight?: (typeof fontWeights)[keyof typeof fontWeights] | FontWeight;
 	fontStyle?: 'normal' | 'italic';
 	textDecorationThickness?: number;
 };

--- a/libs/@guardian/source-react-components-development-kitchen/.storybook/preview-head.html
+++ b/libs/@guardian/source-react-components-development-kitchen/.storybook/preview-head.html
@@ -3,7 +3,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff')
 				format('woff'),
@@ -15,7 +16,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff')
 				format('woff'),
@@ -27,7 +29,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff')
 				format('woff'),
@@ -39,7 +42,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff')
 				format('woff'),
@@ -51,7 +55,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff')
 				format('woff'),
@@ -63,7 +68,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff')
 				format('woff'),
@@ -75,7 +81,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff')
 				format('woff'),
@@ -87,7 +94,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff')
 				format('woff'),
@@ -99,7 +107,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff')
 				format('woff'),
@@ -111,7 +120,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff')
 				format('woff'),
@@ -123,7 +133,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff')
 				format('woff'),
@@ -135,7 +146,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff')
 				format('woff'),
@@ -149,7 +161,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff')
 				format('woff'),
@@ -161,7 +174,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff')
 				format('woff'),
@@ -173,7 +187,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.woff')
 				format('woff'),
@@ -185,7 +200,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.woff')
 				format('woff'),
@@ -197,7 +213,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff')
 				format('woff'),
@@ -209,7 +226,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff')
 				format('woff'),
@@ -221,7 +239,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.woff')
 				format('woff'),
@@ -233,7 +252,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.woff')
 				format('woff'),
@@ -247,7 +267,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff')
 				format('woff'),
@@ -259,7 +280,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff')
 				format('woff'),
@@ -271,7 +293,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff')
 				format('woff'),
@@ -283,7 +306,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff')
 				format('woff'),
@@ -295,7 +319,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff')
 				format('woff'),
@@ -307,7 +332,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff')
 				format('woff'),
@@ -319,7 +345,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.woff')
 				format('woff'),
@@ -331,7 +358,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff')
 				format('woff'),
@@ -345,7 +373,8 @@
 
 	@font-face {
 		font-family: 'GT Guardian Titlepiece';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff')
 				format('woff'),

--- a/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/numericInputStyles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/numericInputStyles.ts
@@ -34,31 +34,30 @@ export const width4 = css`
 
 export const textInput = (
 	textInput = textInputThemeDefault.textInput,
-): SerializedStyles =>
-	css`
-		${inputBase(textInput)}
-		max-width: 100%;
-		flex-grow: 1;
+): SerializedStyles => css`
+	${inputBase(textInput)}
+	max-width: 100%;
+	flex-grow: 1;
 
-		&:active {
-			border: 2px solid ${textInput.borderActive};
-		}
+	&:active {
+		border: 2px solid ${textInput.borderActive};
+	}
 
-		&:focus {
-			/* Focus outline is provided on the wrapper */
-			outline: none;
-		}
+	&:focus {
+		/* Focus outline is provided on the wrapper */
+		outline: none;
+	}
 
-		&:invalid {
-			/*
+	&:invalid {
+		/*
 			We automatically apply error styling to fields in an invalid state,
 			but stop short of applying it to empty required fields.
 			*/
-			&[value]:not([value='']) {
-				${errorInput(textInput)};
-			}
+		&[value]:not([value='']) {
+			${errorInput(textInput)};
 		}
-	`;
+	}
+`;
 
 export const hasExtensions = (prefix?: string, suffix?: string) => css`
 	${prefix &&

--- a/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/sharedStyles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/sharedStyles.ts
@@ -5,30 +5,29 @@ import { textInputThemeDefault } from '@guardian/source-react-components';
 
 export const inputBase = (
 	textInput = textInputThemeDefault.textInput,
-): SerializedStyles =>
-	css`
-		box-sizing: border-box;
-		height: ${height.inputMedium}px;
-		${textSans.medium()};
-		color: ${textInput.textUserInput};
-		background-color: ${textInput.backgroundInput};
-		border: 1px solid ${textInput.border};
-		border-radius: 4px;
-		padding: 0 ${space[2]}px;
+): SerializedStyles => css`
+	box-sizing: border-box;
+	height: ${height.inputMedium}px;
+	${textSans.medium()};
+	color: ${textInput.textUserInput};
+	background-color: ${textInput.backgroundInput};
+	border: 1px solid ${textInput.border};
+	border-radius: 4px;
+	padding: 0 ${space[2]}px;
 
-		&:invalid {
-			/* Remove styling of invalid input elements that gets applied in Firefox */
-			box-shadow: none;
+	&:invalid {
+		/* Remove styling of invalid input elements that gets applied in Firefox */
+		box-shadow: none;
 
-			/*
+		/*
 			We automatically apply error styling to fields in an invalid state,
 			but stop short of applying it to empty required fields.
 			*/
-			&[value]:not([value='']) {
-				${errorInput(textInput)};
-			}
+		&[value]:not([value='']) {
+			${errorInput(textInput)};
 		}
-	`;
+	}
+`;
 
 export const errorInput = (
 	textInput = textInputThemeDefault.textInput,

--- a/libs/@guardian/source-react-components/.storybook/preview-head.html
+++ b/libs/@guardian/source-react-components/.storybook/preview-head.html
@@ -3,7 +3,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff')
 				format('woff'),
@@ -15,7 +16,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff')
 				format('woff'),
@@ -27,7 +29,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff')
 				format('woff'),
@@ -39,7 +42,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff')
 				format('woff'),
@@ -51,7 +55,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff')
 				format('woff'),
@@ -63,7 +68,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff')
 				format('woff'),
@@ -75,7 +81,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff')
 				format('woff'),
@@ -87,7 +94,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff')
 				format('woff'),
@@ -99,7 +107,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff')
 				format('woff'),
@@ -111,7 +120,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff')
 				format('woff'),
@@ -123,7 +133,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff')
 				format('woff'),
@@ -135,7 +146,8 @@
 
 	@font-face {
 		font-family: 'GH Guardian Headline';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff')
 				format('woff'),
@@ -149,7 +161,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff')
 				format('woff'),
@@ -161,7 +174,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff')
 				format('woff'),
@@ -173,7 +187,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.woff')
 				format('woff'),
@@ -185,7 +200,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.woff')
 				format('woff'),
@@ -197,7 +213,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff')
 				format('woff'),
@@ -209,7 +226,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff')
 				format('woff'),
@@ -221,7 +239,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.woff')
 				format('woff'),
@@ -233,7 +252,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextSans';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.woff')
 				format('woff'),
@@ -247,7 +267,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff')
 				format('woff'),
@@ -259,7 +280,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff')
 				format('woff'),
@@ -271,7 +293,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff')
 				format('woff'),
@@ -283,7 +306,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff')
 				format('woff'),
@@ -295,7 +319,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff')
 				format('woff'),
@@ -307,7 +332,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff')
 				format('woff'),
@@ -319,7 +345,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.woff')
 				format('woff'),
@@ -331,7 +358,8 @@
 
 	@font-face {
 		font-family: 'GuardianTextEgyptian';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff')
 				format('woff'),
@@ -345,7 +373,8 @@
 
 	@font-face {
 		font-family: 'GT Guardian Titlepiece';
-		src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2')
+		src:
+			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2')
 				format('woff2'),
 			url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff')
 				format('woff'),

--- a/libs/@guardian/source-react-components/src/button/styles.ts
+++ b/libs/@guardian/source-react-components/src/button/styles.ts
@@ -299,15 +299,14 @@ export const buttonStyles =
 	}: SharedButtonProps) =>
 	(
 		theme: Theme,
-	): Array<string | SerializedStyles | SerializedStyles[] | undefined> =>
-		[
-			button,
-			sizes[size],
-			priorities[priority](theme.button),
-			iconSvg || isLoading ? iconSizes[size] : '',
-			(iconSvg || isLoading) && !hideLabel ? iconSides[iconSide] : '',
-			nudgeIcon ? iconNudgeAnimation : '',
-			hideLabel ? iconOnlySizes[size] : '',
-			isLoading ? applyButtonStylesToLoadingSpinner(size) : undefined,
-			cssOverrides,
-		];
+	): Array<string | SerializedStyles | SerializedStyles[] | undefined> => [
+		button,
+		sizes[size],
+		priorities[priority](theme.button),
+		iconSvg || isLoading ? iconSizes[size] : '',
+		(iconSvg || isLoading) && !hideLabel ? iconSides[iconSide] : '',
+		nudgeIcon ? iconNudgeAnimation : '',
+		hideLabel ? iconOnlySizes[size] : '',
+		isLoading ? applyButtonStylesToLoadingSpinner(size) : undefined,
+		cssOverrides,
+	];

--- a/libs/@guardian/source-react-components/src/select/styles.ts
+++ b/libs/@guardian/source-react-components/src/select/styles.ts
@@ -67,35 +67,36 @@ export const selectWrapper = (
 	}
 `;
 
-export const select = (select = selectThemeDefault.select): SerializedStyles =>
-	css`
-		color: ${select.textUserInput};
-		box-sizing: border-box;
-		height: ${height.inputMedium}px;
-		width: 100%;
-		${textSans.medium()};
-		background-color: ${select.backgroundInput};
-		border: 1px solid ${select.border};
-		border-radius: 4px;
-		padding-left: ${space[2]}px;
+export const select = (
+	select = selectThemeDefault.select,
+): SerializedStyles => css`
+	color: ${select.textUserInput};
+	box-sizing: border-box;
+	height: ${height.inputMedium}px;
+	width: 100%;
+	${textSans.medium()};
+	background-color: ${select.backgroundInput};
+	border: 1px solid ${select.border};
+	border-radius: 4px;
+	padding-left: ${space[2]}px;
 
-		@supports (${appearance}) {
-			appearance: none;
-			padding-right: ${space[2]}px;
+	@supports (${appearance}) {
+		appearance: none;
+		padding-right: ${space[2]}px;
 
-			& ~ svg {
-				display: block;
-			}
+		& ~ svg {
+			display: block;
 		}
+	}
 
-		&:focus {
-			${focusHalo};
-		}
+	&:focus {
+		${focusHalo};
+	}
 
-		&:invalid {
-			${errorInput(select)};
-		}
-	`;
+	&:invalid {
+		${errorInput(select)};
+	}
+`;
 
 export const labelMargin = css`
 	margin-top: ${space[1]}px;

--- a/libs/@guardian/source-react-components/src/text-input/styles.ts
+++ b/libs/@guardian/source-react-components/src/text-input/styles.ts
@@ -28,34 +28,33 @@ export const successInput = (
 
 export const textInput = (
 	textInput = textInputThemeDefault.textInput,
-): SerializedStyles =>
-	css`
-		box-sizing: border-box;
-		height: ${height.inputMedium}px;
-		${textSans.medium()};
-		color: ${textInput.textUserInput};
-		background-color: ${textInput.backgroundInput};
-		border: 1px solid ${textInput.border};
-		border-radius: 4px;
-		padding: 0 ${space[2]}px;
+): SerializedStyles => css`
+	box-sizing: border-box;
+	height: ${height.inputMedium}px;
+	${textSans.medium()};
+	color: ${textInput.textUserInput};
+	background-color: ${textInput.backgroundInput};
+	border: 1px solid ${textInput.border};
+	border-radius: 4px;
+	padding: 0 ${space[2]}px;
 
-		&:focus {
-			${focusHalo}
-		}
+	&:focus {
+		${focusHalo}
+	}
 
-		&:invalid {
-			/* Remove styling of invalid input elements that gets applied in Firefox */
-			box-shadow: none;
+	&:invalid {
+		/* Remove styling of invalid input elements that gets applied in Firefox */
+		box-shadow: none;
 
-			/*
+		/*
 			We automatically apply error styling to fields in an invalid state,
 			but stop short of applying it to empty required fields.
 			*/
-			&[value]:not([value='']) {
-				${errorInput(textInput)};
-			}
+		&[value]:not([value='']) {
+			${errorInput(textInput)};
 		}
-	`;
+	}
+`;
 
 export const labelMargin = css`
 	margin-top: ${space[1]}px;


### PR DESCRIPTION
## What are you changing?

- adds `make check-formatting` to check for prettier conformance
- updates `make fix` to fix formatting issues
- runs `make check-formatting` in CI
- ignores some files when checking/fixing formatting
- fixes outstanding formatting issues

## Why?

In #926 @mxdvl identified some issues in libs. This should address those and stop further ommissions creeping in.

(also closes #926)
