### PR TITLE
Add Button option to Footer Links

### DIFF
--- a/.changeset/clean-zebras-begin.md
+++ b/.changeset/clean-zebras-begin.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': minor
+---
+
+Update FooterLinks component to support ButtonLinks

--- a/libs/@guardian/source-react-components-development-kitchen/CHANGELOG.md
+++ b/libs/@guardian/source-react-components-development-kitchen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/source-react-components-development-kitchen
 
+## 14.1.0
+
+### Minor Changes
+
+- 51dbf18: Update FooterLinks component to support ButtonLinks
+
 ## 14.0.2
 
 ### Patch Changes

--- a/libs/@guardian/source-react-components-development-kitchen/CHANGELOG.md
+++ b/libs/@guardian/source-react-components-development-kitchen/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @guardian/source-react-components-development-kitchen
 
-## 14.1.0
-
-### Minor Changes
-
-- 51dbf18: Update FooterLinks component to support ButtonLinks
-
 ## 14.0.2
 
 ### Patch Changes

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.stories.tsx
@@ -30,3 +30,16 @@ FooterLinksInColumns.args = {
 		},
 	],
 };
+
+// *****************************************************************************
+
+export const FooterLinksWithFooterButton = Template.bind({});
+FooterLinksWithFooterButton.args = {
+	links: [
+		...defaultGuardianLinks,
+		{
+			text: 'Hello world',
+			onClick: () => alert('Hello world'),
+		},
+	],
+};

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
@@ -1,25 +1,28 @@
 import { ThemeProvider } from '@emotion/react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import {
+	Button,
+	buttonThemeBrand,
 	Column,
 	Columns,
 	Hide,
 	Link,
 	linkThemeBrand,
 } from '@guardian/source-react-components';
-import type { AnchorHTMLAttributes } from 'react';
+import type { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
 import {
 	fullWidthContainer,
 	getItemStyles,
 	getListStyles,
 	linkElementStyles,
+	footerButtonColumnItemStyles,
 } from './footerLinksStyles';
 
 type FooterLink = AnchorHTMLAttributes<HTMLAnchorElement> & {
 	/**
 	 * The URL of the link
 	 */
-	href: string;
+	href?: string;
 	/**
 	 * The visible text of the link
 	 */
@@ -30,7 +33,18 @@ type FooterLink = AnchorHTMLAttributes<HTMLAnchorElement> & {
 	isExternal?: boolean;
 };
 
-export const defaultGuardianLinks: FooterLink[] = [
+type FooterButton = ButtonHTMLAttributes<HTMLButtonElement> & {
+	/**
+	 * onClick handler for the link
+	 */
+	onClick: () => void;
+	/**
+	 * The visible text of the link
+	 */
+	text: string;
+};
+
+export const defaultGuardianLinks: Array<FooterLink | FooterButton> = [
 	{
 		href: 'https://www.theguardian.com/info/privacy',
 		text: 'Privacy policy',
@@ -52,7 +66,7 @@ export interface FooterLinksProps {
 	/**
 	 * An array of links, specifying the link text and href, if the link is external, and any other HTML attributes for an anchor tag
 	 */
-	links?: FooterLink[];
+	links?: Array<FooterLink | FooterButton>;
 	/**
 	 * Force the links into a column layout below desktop, regardless of the amount of links
 	 */
@@ -64,46 +78,101 @@ export const FooterLinks = ({
 	forceColumns = false,
 }: FooterLinksProps): EmotionJSX.Element => {
 	const useColumns = links.length > 3 || forceColumns;
+	const isFooterLink = (
+		link: FooterLink | FooterButton,
+	): link is FooterLink => {
+		return (link as FooterLink).href !== undefined;
+	};
 	return (
 		<div css={fullWidthContainer}>
 			<Hide from="tablet">
 				<ul css={getListStyles(useColumns)}>
-					{links.map(({ href, text, isExternal, ...linkAttrs }) => (
-						<li key={href} css={getItemStyles(useColumns)}>
-							<ThemeProvider theme={linkThemeBrand}>
-								<Link
-									cssOverrides={linkElementStyles}
-									href={href}
-									rel={isExternal ? 'noopener noreferrer' : ''}
-									{...linkAttrs}
-								>
-									{text}
-								</Link>
-							</ThemeProvider>
-						</li>
-					))}
+					{links.map((link, index) => {
+						const key = `link-${index}`;
+						if (isFooterLink(link)) {
+							const { href, text, isExternal, ...linkAttrs } = link;
+							return (
+								<li key={key} css={getItemStyles(useColumns)}>
+									<ThemeProvider theme={linkThemeBrand}>
+										<Link
+											cssOverrides={linkElementStyles}
+											href={href}
+											rel={isExternal ? 'noopener noreferrer' : ''}
+											{...linkAttrs}
+										>
+											{text}
+										</Link>
+									</ThemeProvider>
+								</li>
+							);
+						}
+						const { text, onClick, ...linkAttrs } = link;
+						return (
+							<li key={key} css={getItemStyles(useColumns)}>
+								<ThemeProvider theme={buttonThemeBrand}>
+									<Button
+										cssOverrides={linkElementStyles}
+										iconSide="left"
+										priority="subdued"
+										size="default"
+										onClick={onClick}
+										{...linkAttrs}
+									>
+										{text}
+									</Button>
+								</ThemeProvider>
+							</li>
+						);
+					})}
 				</ul>
 			</Hide>
 			<Hide until="tablet">
 				<Columns cssOverrides={getListStyles(useColumns)}>
-					{links.map(({ href, text, isExternal, ...linkAttrs }) => (
-						<Column
-							key={href}
-							span={[0, 3, 2]}
-							cssOverrides={getItemStyles(useColumns)}
-						>
-							<ThemeProvider theme={linkThemeBrand}>
-								<Link
-									cssOverrides={linkElementStyles}
-									href={href}
-									rel={isExternal ? 'noopener noreferrer' : ''}
-									{...linkAttrs}
+					{links.map((link, index) => {
+						const key = `link-${index}`;
+						if (isFooterLink(link)) {
+							const { href, text, isExternal, ...linkAttrs } = link;
+							return (
+								<Column
+									key={key}
+									span={[0, 3, 2]}
+									cssOverrides={getItemStyles(useColumns)}
 								>
-									{text}
-								</Link>
-							</ThemeProvider>
-						</Column>
-					))}
+									<ThemeProvider theme={linkThemeBrand}>
+										<Link
+											cssOverrides={linkElementStyles}
+											href={href}
+											rel={isExternal ? 'noopener noreferrer' : ''}
+											{...linkAttrs}
+										>
+											{text}
+										</Link>
+									</ThemeProvider>
+								</Column>
+							);
+						}
+						const { text, onClick, ...linkAttrs } = link;
+						return (
+							<Column
+								key={key}
+								span={[0, 3, 2]}
+								cssOverrides={getItemStyles(useColumns)}
+							>
+								<ThemeProvider theme={buttonThemeBrand}>
+									<Button
+										cssOverrides={linkElementStyles}
+										iconSide="left"
+										priority="subdued"
+										size="default"
+										onClick={onClick}
+										{...linkAttrs}
+									>
+										{text}
+									</Button>
+								</ThemeProvider>
+							</Column>
+						);
+					})}
 				</Columns>
 			</Hide>
 		</div>

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
@@ -20,7 +20,7 @@ type FooterLink = AnchorHTMLAttributes<HTMLAnchorElement> & {
 	/**
 	 * The URL of the link
 	 */
-	href?: string;
+	href: string;
 	/**
 	 * The visible text of the link
 	 */
@@ -73,7 +73,6 @@ export interface FooterLinksProps {
 
 const isFooterLink = (link: FooterLink | FooterButton): link is FooterLink => {
 	return 'href' in link;
-	// return (link as FooterLink).href !== undefined;
 };
 
 const getLink = (link: FooterLink) => {

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
@@ -2,7 +2,6 @@ import { ThemeProvider } from '@emotion/react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import {
 	ButtonLink,
-	buttonThemeBrand,
 	Column,
 	Columns,
 	Hide,

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
@@ -71,41 +71,44 @@ export interface FooterLinksProps {
 	forceColumns?: boolean;
 }
 
+const isFooterLink = (link: FooterLink | FooterButton): link is FooterLink => {
+	return 'href' in link;
+	// return (link as FooterLink).href !== undefined;
+};
+
+const getLink = (link: FooterLink) => {
+	const { href, text, isExternal, ...linkAttrs } = link;
+	return (
+		<Link
+			cssOverrides={linkElementStyles}
+			href={href}
+			rel={isExternal ? 'noopener noreferrer' : ''}
+			{...linkAttrs}
+		>
+			{text}
+		</Link>
+	);
+};
+
+const getButtonLink = (link: FooterButton) => {
+	const { text, onClick, ...linkAttrs } = link;
+	return (
+		<ButtonLink
+			cssOverrides={linkElementStyles}
+			onClick={onClick}
+			{...linkAttrs}
+		>
+			{text}
+		</ButtonLink>
+	);
+};
+
 export const FooterLinks = ({
 	links = defaultGuardianLinks,
 	forceColumns = false,
 }: FooterLinksProps): EmotionJSX.Element => {
 	const useColumns = links.length > 3 || forceColumns;
-	const isFooterLink = (
-		link: FooterLink | FooterButton,
-	): link is FooterLink => {
-		return (link as FooterLink).href !== undefined;
-	};
-	const getLink = (link: FooterLink) => {
-		const { href, text, isExternal, ...linkAttrs } = link;
-		return (
-			<Link
-				cssOverrides={linkElementStyles}
-				href={href}
-				rel={isExternal ? 'noopener noreferrer' : ''}
-				{...linkAttrs}
-			>
-				{text}
-			</Link>
-		);
-	};
-	const getButtonLink = (link: FooterButton) => {
-		const { text, onClick, ...linkAttrs } = link;
-		return (
-			<ButtonLink
-				cssOverrides={linkElementStyles}
-				onClick={onClick}
-				{...linkAttrs}
-			>
-				{text}
-			</ButtonLink>
-		);
-	};
+
 	return (
 		<div css={fullWidthContainer}>
 			<Hide from="tablet">

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
@@ -71,32 +71,22 @@ export interface FooterLinksProps {
 	forceColumns?: boolean;
 }
 
-const getLink = (link: FooterLink) => {
-	const { href, text, isExternal, ...linkAttrs } = link;
-	return (
-		<Link
-			cssOverrides={linkElementStyles}
-			href={href}
-			rel={isExternal ? 'noopener noreferrer' : ''}
-			{...linkAttrs}
-		>
-			{text}
-		</Link>
-	);
-};
+const getLink = ({ href, text, isExternal, ...linkAttrs }: FooterLink) => (
+	<Link
+		cssOverrides={linkElementStyles}
+		href={href}
+		rel={isExternal ? 'noopener noreferrer' : ''}
+		{...linkAttrs}
+	>
+		{text}
+	</Link>
+);
 
-const getButtonLink = (link: FooterButton) => {
-	const { text, onClick, ...linkAttrs } = link;
-	return (
-		<ButtonLink
-			cssOverrides={linkElementStyles}
-			onClick={onClick}
-			{...linkAttrs}
-		>
-			{text}
-		</ButtonLink>
-	);
-};
+const getButtonLink = ({ text, onClick, ...linkAttrs }: FooterButton) => (
+	<ButtonLink cssOverrides={linkElementStyles} onClick={onClick} {...linkAttrs}>
+		{text}
+	</ButtonLink>
+);
 
 export const FooterLinks = ({
 	links = defaultGuardianLinks,

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
@@ -71,10 +71,6 @@ export interface FooterLinksProps {
 	forceColumns?: boolean;
 }
 
-const isFooterLink = (link: FooterLink | FooterButton): link is FooterLink => {
-	return 'href' in link;
-};
-
 const getLink = (link: FooterLink) => {
 	const { href, text, isExternal, ...linkAttrs } = link;
 	return (
@@ -117,7 +113,7 @@ export const FooterLinks = ({
 							return (
 								<li key={`link-${index}`} css={getItemStyles(useColumns)}>
 									<ThemeProvider theme={linkThemeBrand}>
-										{isFooterLink(link) ? getLink(link) : getButtonLink(link)}
+										{'href' in link ? getLink(link) : getButtonLink(link)}
 									</ThemeProvider>
 								</li>
 							);
@@ -135,7 +131,7 @@ export const FooterLinks = ({
 								cssOverrides={getItemStyles(useColumns)}
 							>
 								<ThemeProvider theme={linkThemeBrand}>
-									{isFooterLink(link) ? getLink(link) : getButtonLink(link)}
+									{'href' in link ? getLink(link) : getButtonLink(link)}
 								</ThemeProvider>
 							</Column>
 						);

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider } from '@emotion/react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import {
-	Button,
+	ButtonLink,
 	buttonThemeBrand,
 	Column,
 	Columns,
@@ -15,7 +15,6 @@ import {
 	getItemStyles,
 	getListStyles,
 	linkElementStyles,
-	footerButtonColumnItemStyles,
 } from './footerLinksStyles';
 
 type FooterLink = AnchorHTMLAttributes<HTMLAnchorElement> & {
@@ -83,92 +82,59 @@ export const FooterLinks = ({
 	): link is FooterLink => {
 		return (link as FooterLink).href !== undefined;
 	};
+	const getLink = (link: FooterLink) => {
+		const { href, text, isExternal, ...linkAttrs } = link;
+		return (
+			<Link
+				cssOverrides={linkElementStyles}
+				href={href}
+				rel={isExternal ? 'noopener noreferrer' : ''}
+				{...linkAttrs}
+			>
+				{text}
+			</Link>
+		);
+	};
+	const getButtonLink = (link: FooterButton) => {
+		const { text, onClick, ...linkAttrs } = link;
+		return (
+			<ButtonLink
+				cssOverrides={linkElementStyles}
+				onClick={onClick}
+				{...linkAttrs}
+			>
+				{text}
+			</ButtonLink>
+		);
+	};
 	return (
 		<div css={fullWidthContainer}>
 			<Hide from="tablet">
 				<ul css={getListStyles(useColumns)}>
 					{links.map((link, index) => {
-						const key = `link-${index}`;
-						if (isFooterLink(link)) {
-							const { href, text, isExternal, ...linkAttrs } = link;
+						{
 							return (
-								<li key={key} css={getItemStyles(useColumns)}>
+								<li key={`link-${index}`} css={getItemStyles(useColumns)}>
 									<ThemeProvider theme={linkThemeBrand}>
-										<Link
-											cssOverrides={linkElementStyles}
-											href={href}
-											rel={isExternal ? 'noopener noreferrer' : ''}
-											{...linkAttrs}
-										>
-											{text}
-										</Link>
+										{isFooterLink(link) ? getLink(link) : getButtonLink(link)}
 									</ThemeProvider>
 								</li>
 							);
 						}
-						const { text, onClick, ...linkAttrs } = link;
-						return (
-							<li key={key} css={getItemStyles(useColumns)}>
-								<ThemeProvider theme={buttonThemeBrand}>
-									<Button
-										cssOverrides={linkElementStyles}
-										iconSide="left"
-										priority="subdued"
-										size="default"
-										onClick={onClick}
-										{...linkAttrs}
-									>
-										{text}
-									</Button>
-								</ThemeProvider>
-							</li>
-						);
 					})}
 				</ul>
 			</Hide>
 			<Hide until="tablet">
 				<Columns cssOverrides={getListStyles(useColumns)}>
 					{links.map((link, index) => {
-						const key = `link-${index}`;
-						if (isFooterLink(link)) {
-							const { href, text, isExternal, ...linkAttrs } = link;
-							return (
-								<Column
-									key={key}
-									span={[0, 3, 2]}
-									cssOverrides={getItemStyles(useColumns)}
-								>
-									<ThemeProvider theme={linkThemeBrand}>
-										<Link
-											cssOverrides={linkElementStyles}
-											href={href}
-											rel={isExternal ? 'noopener noreferrer' : ''}
-											{...linkAttrs}
-										>
-											{text}
-										</Link>
-									</ThemeProvider>
-								</Column>
-							);
-						}
-						const { text, onClick, ...linkAttrs } = link;
 						return (
 							<Column
-								key={key}
+								key={`link-${index}`}
 								span={[0, 3, 2]}
 								cssOverrides={getItemStyles(useColumns)}
 							>
-								<ThemeProvider theme={buttonThemeBrand}>
-									<Button
-										cssOverrides={linkElementStyles}
-										iconSide="left"
-										priority="subdued"
-										size="default"
-										onClick={onClick}
-										{...linkAttrs}
-									>
-										{text}
-									</Button>
+								<ThemeProvider theme={linkThemeBrand}>
+									{isFooterLink(link) ? getLink(link) : getButtonLink(link)}
 								</ThemeProvider>
 							</Column>
 						);

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/README.md
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/README.md
@@ -18,7 +18,13 @@ $ npm i @guardian/source-react-components-development-kitchen
 
 ### API
 
-See [storybook](https://guardian.github.io/csnx/?path=/docs/source-react-components-development-kitchen_divider--default-divider)
+The `<FooterLinks>` component can take a prop `links`, this prop is an array of `FooterLink` or `FooterButton` objects.
+
+A `FooterLink` object should be used to include an anchor tag with an href in the footer, a `FooterButton` object can be used to include a button with an `onClick` callback of your specification. The anchors and buttons will be styled to appear the same.
+
+If your site uses the Guardian CMP `@guardian/consent-management-platform`, you should include a `FooterButton` object in the `links` prop with an `onClick` callback that launches the CMP and the text "Privacy Settings".
+
+See [storybook](https://guardian.github.io/csnx/?path=/docs/source-react-components-development-kitchen_divider--default-divider) for examples.
 
 ### How to use
 

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/README.md
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/README.md
@@ -20,7 +20,7 @@ $ npm i @guardian/source-react-components-development-kitchen
 
 The `<FooterLinks>` component can take a prop `links`, this prop is an array of `FooterLink` or `FooterButton` objects.
 
-A `FooterLink` object should be used to include an anchor tag with an href in the footer, a `FooterButton` object can be used to include a button with an `onClick` callback of your specification. The anchors and buttons will be styled to appear the same.
+A `FooterLink` object can be used if you want to include an anchor tag with an href in the footer. A `FooterButton` object can be used to include a button with an `onClick` callback of your specification. The anchors and buttons will be styled to appear the same.
 
 If your site uses the Guardian CMP `@guardian/consent-management-platform`, you should include a `FooterButton` object in the `links` prop with an `onClick` callback that launches the CMP and the text "Privacy Settings".
 


### PR DESCRIPTION
## What are you changing?

**Objective:** Currently `FooterLinks` only renders anchor tags (`Link` components) that take users to a URL when clicked on. We'd like to update `FooterLinks` so it can also render an item that when clicked on instead executes an `onClick` function. 

The immediate use case is the Support site requires a "Privacy Settings" link in the footer that launches the Guardian's CMP. Visually this link should look the same as the other links, and it could be placed anywhere within the list of link items.

**Implementation:**  Update the `links` prop on `FooterLinks`  to be an array of `FooterLink` _or_ `FooterButton` objects. When rendering `FooterLinks` iterate through the `links` array and render a `Link` if the object in the `links` array is a `FooterLink`, else render a `ButtonLink` as the object in the `links` array will be a `FooterButton`.

The solution uses a button (using Source's `ButtonLink`) instead of an anchor with a click handler for [accessibility](https://github.com/bradbirdsallCHANGED/eslint-plugin-jsx-a11y/blob/main/docs/rules/anchor-is-valid.md) reasons.

**Storybook screenshot (see "Footer Links With Footer Button"):**

<img width="1016" alt="Screenshot 2023-11-20 at 17 58 49" src="https://github.com/guardian/csnx/assets/1590704/55d29a7c-a1a6-4f80-b229-3478cf1675f0">


