### PR TITLE
Make members of AB Ophan API required

### DIFF
--- a/.changeset/curvy-experts-film.md
+++ b/.changeset/curvy-experts-film.md
@@ -1,0 +1,20 @@
+---
+'@guardian/ab-core': major
+---
+
+Members of the `OphanAPIConfig` are now **required**. Consumers must pass a
+record function, an error reporter and an object of server-side tests.
+
+With the previously optional members, failure to record tests to Ophan would
+fail silently. This has been the case in `dotcom-rendering` since Oct 2023.
+
+In order to update your code to work identically, you must now provide the
+following keys to the constructor’s argument. They are listed here along with
+the fallbacks previously applied:
+
+- `serverSideTests` &rarr; `{}`
+- `errorReporter` &rarr; `() => undefined`
+- `ophanRecord` &rarr; `() => undefined`
+
+Note that `errorReporter` has also been narrowed and it now receives a single
+parameter, which is still `unknown` due to the fact than anything can be thrown.

--- a/.changeset/curvy-experts-film.md
+++ b/.changeset/curvy-experts-film.md
@@ -1,5 +1,6 @@
 ---
 '@guardian/ab-core': major
+'@guardian/ab-react': major
 ---
 
 Members of the `OphanAPIConfig` are now **required**. Consumers must pass a

--- a/libs/@guardian/ab-core/src/@types/index.ts
+++ b/libs/@guardian/ab-core/src/@types/index.ts
@@ -23,9 +23,9 @@ export type CoreAPI = {
 };
 
 export type OphanAPIConfig = {
-	serverSideTests?: ServerSideTests;
-	errorReporter?: ErrorReporterFunc;
-	ophanRecord?: OphanRecordFunction;
+	serverSideTests: ServerSideTests;
+	errorReporter: ErrorReporterFunc;
+	ophanRecord: OphanRecordFunction;
 };
 
 export type OphanAPI = {
@@ -97,5 +97,8 @@ export type Runnable<ABTest> = ABTest & {
 
 export type ServerSideTests = Record<string, string>;
 
-// We don't know what the error reporter for the platform might need
-export type ErrorReporterFunc = (...args: unknown[]) => void;
+/**
+ * Anything can be throw in JS, so you might want to narrow your return type
+ * with `error instanceof Error`
+ */
+export type ErrorReporterFunc = (error: unknown) => void;

--- a/libs/@guardian/ab-core/src/ophan.ts
+++ b/libs/@guardian/ab-core/src/ophan.ts
@@ -82,8 +82,8 @@ const registerCompleteEvent =
 
 		try {
 			listener(buildOphanSubmitter(test, variant, complete, ophanRecord));
-		} catch (err: unknown) {
-			errorReporter(err, {}, false);
+		} catch (error: unknown) {
+			errorReporter(error);
 		}
 	};
 
@@ -117,17 +117,13 @@ const buildOphanPayload = (
 		return log;
 	} catch (error: unknown) {
 		// Encountering an error should invalidate the logging process.
-		errorReporter(error, {}, false);
+		errorReporter(error);
 		return {};
 	}
 };
 
 export const initOphan = (config: OphanAPIConfig): OphanAPI => {
-	const {
-		serverSideTests = {},
-		errorReporter = () => undefined,
-		ophanRecord = () => undefined,
-	} = config;
+	const { serverSideTests, errorReporter, ophanRecord } = config;
 
 	const registerCompleteEvents: OphanAPI['registerCompleteEvents'] = (
 		tests,

--- a/libs/@guardian/ab-react/package.json
+++ b/libs/@guardian/ab-react/package.json
@@ -16,7 +16,7 @@
 		"typescript": "5.1.3"
 	},
 	"peerDependencies": {
-		"@guardian/ab-core": "^5.0.0",
+		"@guardian/ab-core": "^6.0.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"tslib": "^2.5.3",

--- a/libs/@guardian/ab-react/src/context.test.tsx
+++ b/libs/@guardian/ab-react/src/context.test.tsx
@@ -48,6 +48,9 @@ describe('AB', () => {
 				abTestSwitches={{ abDummyTest: true }}
 				mvtId={19}
 				pageIsSensitive={false}
+				serverSideTests={{}}
+				errorReporter={() => void 0}
+				ophanRecord={() => void 0}
 			>
 				<Example />
 			</ABProvider>,
@@ -63,6 +66,9 @@ describe('AB', () => {
 				abTestSwitches={{ abDummyTest: true }}
 				mvtId={20}
 				pageIsSensitive={false}
+				serverSideTests={{}}
+				errorReporter={() => void 0}
+				ophanRecord={() => void 0}
 			>
 				<Example />
 			</ABProvider>,
@@ -78,6 +84,9 @@ describe('AB', () => {
 				abTestSwitches={{ abDummyTest: false }}
 				mvtId={19}
 				pageIsSensitive={false}
+				serverSideTests={{}}
+				errorReporter={() => void 0}
+				ophanRecord={() => void 0}
 			>
 				<Example />
 			</ABProvider>,
@@ -93,6 +102,9 @@ describe('AB', () => {
 				abTestSwitches={{ abDummyTest: true }}
 				mvtId={19}
 				pageIsSensitive={true}
+				serverSideTests={{}}
+				errorReporter={() => void 0}
+				ophanRecord={() => void 0}
 			>
 				<Example />
 			</ABProvider>,
@@ -108,6 +120,9 @@ describe('AB', () => {
 				abTestSwitches={{ abDummyTest: true }}
 				mvtId={19}
 				pageIsSensitive={false}
+				serverSideTests={{}}
+				errorReporter={() => void 0}
+				ophanRecord={() => void 0}
 			>
 				<Example />
 			</ABProvider>,


### PR DESCRIPTION
## What are you changing?

Members of the `OphanAPIConfig` are now **required**. Consumers must pass a record function, an error reporter and an object of server-side tests.

In order to update your code to work identically, you must now provide the
following keys to the constructor’s argument. They are listed here along with
the fallbacks previously applied:

- `serverSideTests` &rarr; `{}`
- `errorReporter` &rarr; `() => undefined`
- `ophanRecord` &rarr; `() => undefined`

## Why?

With the previously optional members, failure to record tests to Ophan would fail silently. [This has been the case in `dotcom-rendering` since Oct 2023](https://github.com/guardian/dotcom-rendering/pull/8965/files#r1403449259).
