### PR TITLE
Support `ExpandingWrapper` theming with pure CSS

### DIFF
--- a/.changeset/cold-clocks-hear.md
+++ b/.changeset/cold-clocks-hear.md
@@ -1,0 +1,22 @@
+---
+'@guardian/source-react-components-development-kitchen': major
+---
+
+Refactor ExpandingWrapper so it can receive an optional theme. This will require
+consumers to update their calls, but it should be compatible with the existing
+exported light and dark themes.
+
+```tsx
+import {
+	ExpandingWrapper,
+	expandingWrapperDarkTheme,
+} from '@guardian/source-react-components-development-kitchen';
+<ExpandingWrapper
+	name="Expanding Wrapper With Dark Theme"
+	theme={expandingWrapperDarkTheme}
+>
+	{children}
+</ExpandingWrapper>;
+```
+
+Uses CSS Custom Properties under the hood.

--- a/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.stories.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/react';
+import { palette } from '@guardian/source-foundations';
 import type { ReactElement } from 'react';
 import { ExpandingWrapper } from './ExpandingWrapper';
+import { expandingWrapperDarkTheme } from './theme';
 
 /**
  * [Storybook](https://guardian.github.io/csnx/?path=/story/source-react-components-development-kitchen_expandingwrapper--expanding-wrapper)
@@ -122,9 +124,53 @@ const expandingWrapper = (): ReactElement => {
 	);
 };
 
+const expandingWrapperWithDarkTheme = (): ReactElement => {
+	return (
+		<>
+			<ExpandingWrapper
+				name="Lorem Ipsum Text Dark"
+				theme={expandingWrapperDarkTheme}
+			>
+				{Lorem}
+			</ExpandingWrapper>
+			<button>Click me!</button>
+		</>
+	);
+};
+
+const expandingWrapperWithCustomTheme = (): ReactElement => {
+	return (
+		<>
+			<ExpandingWrapper
+				name="Lorem Ipsum With Theme"
+				theme={{
+					'--text': palette.neutral[97],
+					'--background': palette.brand[400],
+					'--border': palette.brand[400],
+					'--collapseBackground': palette.brand[300],
+					'--collapseBackgroundHover': palette.brand[100],
+					'--collapseText': palette.brand[800],
+					'--collapseTextHover': palette.brand[800],
+					'--expandBackground': palette.brand[800],
+					'--expandBackgroundHover': palette.brand[800],
+					'--expandText': palette.brand[100],
+					'--horizontalRules': palette.brand[600],
+				}}
+			>
+				{Lorem}
+			</ExpandingWrapper>
+			<button>Click me!</button>
+		</>
+	);
+};
+
 export default {
 	component: expandingWrapper,
 	title: 'ExpandingWrapper',
 };
 
-export { expandingWrapper };
+export {
+	expandingWrapper,
+	expandingWrapperWithDarkTheme,
+	expandingWrapperWithCustomTheme,
+};

--- a/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/styles.ts
@@ -1,50 +1,49 @@
-import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
 import {
 	focusHalo,
 	remHeight,
 	remSpace,
 	textSans,
 } from '@guardian/source-foundations';
-import { expandingWrapperThemeDefault } from './theme';
+import { themeColour } from './theme';
 
-export const containerStyles = (
-	expander = expandingWrapperThemeDefault.expander,
-): SerializedStyles => css`
+export const containerStyles = css`
 	border-image: repeating-linear-gradient(
 			to bottom,
-			${expander.horizontalRules},
-			${expander.horizontalRules} 1px,
+			${themeColour('--horizontalRules')},
+			${themeColour('--horizontalRules')} 1px,
 			transparent 1px,
 			transparent 4px
 		)
 		13;
-	border-top: 13px solid ${expander.border};
-	background: ${expander.background};
+	border-top: 13px solid ${themeColour('--border')};
+	background: ${themeColour('--background')};
+	color: ${themeColour('--text')};
 	box-shadow: none;
 	position: relative;
 	margin-bottom: ${remSpace[9]};
 
 	.expander__checkbox:checked ~ label {
-		background: ${expander.collapseBackground};
-		color: ${expander.collapseText};
-		border: 1px solid ${expander.collapseText};
+		background: ${themeColour('--collapseBackground')};
+		color: ${themeColour('--collapseText')};
+		border: 1px solid ${themeColour('--collapseText')};
 
 		&:hover {
-			background-color: ${expander.collapseBackgroundHover};
-			color: ${expander.collapseTextHover};
+			background-color: ${themeColour('--collapseBackgroundHover')};
+			color: ${themeColour('--collapseTextHover')};
 
 			#svgminus {
-				fill: ${expander.collapseTextHover};
+				fill: ${themeColour('--collapseTextHover')};
 			}
 		}
 
 		#svgminus {
-			fill: ${expander.collapseText};
+			fill: ${themeColour('--collapseText')};
 		}
 	}
 	.expander__checkbox ~ label #svgplus {
-		fill: ${expander.expandText};
+		fill: ${themeColour('--expandText')};
 	}
 
 	.expander__checkbox:checked ~ .expander__collapsible-body {
@@ -57,13 +56,11 @@ export const containerStyles = (
 	}
 `;
 
-export const overlayStyles = (
-	expander = expandingWrapperThemeDefault.expander,
-): SerializedStyles => css`
+export const overlayStyles = css`
 	background-image: linear-gradient(
 		0deg,
-		${expander.background},
-		${expander.background} 40%,
+		${themeColour('--background')},
+		${themeColour('--background')} 40%,
 		rgba(255, 255, 255, 0)
 	);
 	height: 5rem;
@@ -73,9 +70,7 @@ export const overlayStyles = (
 	display: block;
 `;
 
-export const showHideLabelStyles = (
-	expander = expandingWrapperThemeDefault.expander,
-): SerializedStyles => css`
+export const showHideLabelStyles = css`
 	${textSans.small({ fontWeight: 'bold' })};
 	display: inline-flex;
 	justify-content: space-between;
@@ -88,16 +83,16 @@ export const showHideLabelStyles = (
 	border-radius: ${remHeight.ctaSmall}rem;
 	padding: 0 ${remSpace[4]};
 	padding-bottom: 2px;
-	border: 1px solid ${expander.expandBackground};
+	border: 1px solid ${themeColour('--expandBackground')};
 	text-decoration: none;
-	background: ${expander.expandBackground};
-	color: ${expander.expandText};
+	background: ${themeColour('--expandBackground')};
+	color: ${themeColour('--expandText')};
 	height: ${remHeight.ctaSmall}rem;
 	min-height: ${remHeight.ctaSmall}rem;
 	margin-left: ${remSpace[2]};
 
 	&:hover {
-		background-color: ${expander.expandBackgroundHover};
+		background-color: ${themeColour('--expandBackgroundHover')};
 	}
 `;
 

--- a/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/theme.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/theme.ts
@@ -1,35 +1,35 @@
-import type { Theme as EmotionTheme } from '@emotion/react';
 import { palette } from '@guardian/source-foundations';
 
 export const expandingWrapperThemeDefault = {
-	expander: {
-		background: palette.neutral[97],
-		horizontalRules: palette.neutral[86],
-		border: palette.neutral[7],
-		expandBackground: palette.neutral[7],
-		expandBackgroundHover: '#454545', // One-off colour  to match the primary button hover
-		expandText: palette.neutral[100],
-		collapseBackground: palette.neutral[100],
-		collapseBackgroundHover: '#E5E5E5', // One-off colour variant to match tertiary button hover
-		collapseText: palette.neutral[7],
-		collapseTextHover: palette.neutral[7],
-	},
-};
-export const expandingWrapperDarkTheme = {
-	expander: {
-		background: palette.neutral[20],
-		horizontalRules: palette.neutral[60],
-		border: palette.neutral[60],
-		expandBackground: palette.neutral[86],
-		expandBackgroundHover: palette.neutral[100],
-		expandText: palette.neutral[7],
-		collapseBackground: palette.neutral[10],
-		collapseText: palette.neutral[86],
-		collapseBackgroundHover: palette.neutral[86],
-		collapseTextHover: palette.neutral[7],
-	},
+	['--text']: palette.neutral[7],
+	['--background']: palette.neutral[97],
+	['--horizontalRules']: palette.neutral[86],
+	['--border']: palette.neutral[7],
+	['--expandBackground']: palette.neutral[7],
+	['--expandBackgroundHover']: '#454545', // One-off colour  to match the primary button hover
+	['--expandText']: palette.neutral[100],
+	['--collapseBackground']: palette.neutral[100],
+	['--collapseBackgroundHover']: '#E5E5E5', // One-off colour variant to match tertiary button hover
+	['--collapseText']: palette.neutral[7],
+	['--collapseTextHover']: palette.neutral[7],
 };
 
-export interface Theme extends EmotionTheme {
-	expander?: typeof expandingWrapperThemeDefault.expander;
-}
+export const expandingWrapperDarkTheme = {
+	['--text']: palette.neutral[86],
+	['--background']: palette.neutral[20],
+	['--horizontalRules']: palette.neutral[60],
+	['--border']: palette.neutral[60],
+	['--expandBackground']: palette.neutral[86],
+	['--expandBackgroundHover']: palette.neutral[100],
+	['--expandText']: palette.neutral[7],
+	['--collapseBackground']: palette.neutral[10],
+	['--collapseText']: palette.neutral[86],
+	['--collapseBackgroundHover']: palette.neutral[86],
+	['--collapseTextHover']: palette.neutral[7],
+};
+
+/** enforce valid custom properties for this component */
+export const themeColour = (key: keyof typeof expandingWrapperThemeDefault) =>
+	`var(${key})`;
+
+export type Theme = Record<keyof typeof expandingWrapperThemeDefault, string>;

--- a/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/types.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/types.ts
@@ -1,5 +1,5 @@
-import type { SerializedStyles } from '@emotion/react';
 import type { ReactElement } from 'react';
+import type { Theme } from './theme';
 
 export interface ExpandingWrapperProps {
 	children: ReactElement;
@@ -8,10 +8,7 @@ export interface ExpandingWrapperProps {
 
 	renderExtra?: () => ReactElement;
 	expandCallback?: (expanded: boolean) => void;
-	/**
-	 * Override component styles by passing in the result of [emotion's `css` function/prop](https://emotion.sh/docs/introduction).
-	 */
-	cssOverrides?: SerializedStyles | SerializedStyles[];
+	theme?: Theme;
 	/**
 	 * Override the height of the collapsed content. Defaults to '240px'
 	 */


### PR DESCRIPTION
## What are you changing?

- Refactor ExpandingWrapper so it receives an optional theme object which is used to define relevant custom properties which drive the colour of the component
- Remove CSS Overrides as we enable consumers to override every single colour
- Add stories to demonstrate usage

## Why?

- This enables us to use Callouts with dark mode in dotcom-rendering: https://github.com/guardian/dotcom-rendering/issues/9277
- Proposal for an answer to: https://github.com/guardian/dotcom-rendering/issues/9333
