### PR TITLE
Support `Tabs` theming with pure CSS

### DIFF
--- a/.changeset/cold-clocks-hear.md
+++ b/.changeset/cold-clocks-hear.md
@@ -2,21 +2,37 @@
 '@guardian/source-react-components-development-kitchen': major
 ---
 
-Refactor ExpandingWrapper so it can receive an optional theme. This will require
-consumers to update their calls, but it should be compatible with the existing
-exported light and dark themes.
+Refactor `ExpandingWrapper` so it can receive an optional theme. This will
+require consumers relying on `cssOverrides` to use the `theme` prop instead. The
+exported exported light (default) and dark themes are compatible with this API.
 
-```tsx
+```jsx
+import { css } from '@emotion/react';
 import {
 	ExpandingWrapper,
-	expandingWrapperDarkTheme,
+	expandingWrapperThemeDefault,
 } from '@guardian/source-react-components-development-kitchen';
-<ExpandingWrapper
-	name="Expanding Wrapper With Dark Theme"
-	theme={expandingWrapperDarkTheme}
->
-	{children}
-</ExpandingWrapper>;
+
+const Before = ({ children }) => (
+	<ExpandingWrapper
+		cssOverrides={css`
+			color: aquamarine;
+		`}
+	>
+		{children}
+	</ExpandingWrapper>
+);
+
+const After = ({ children }) => (
+	<ExpandingWrapper
+		theme={{
+			...expandingWrapperThemeDefault,
+			'--text': 'aquamarine',
+		}}
+	>
+		{children}
+	</ExpandingWrapper>
+);
 ```
 
 Uses CSS Custom Properties under the hood.

--- a/.changeset/nervous-mirrors-dress.md
+++ b/.changeset/nervous-mirrors-dress.md
@@ -1,0 +1,30 @@
+---
+'@guardian/source-react-components-development-kitchen': major
+---
+
+Refactor `Tabs` so it can receive an optional theme. This will require consumers
+relying on `cssOverrides` to use the `theme` prop instead. The exported exported
+light (default) and dark themes are compatible with this API
+
+```tsx
+import { css } from '@emotion/react';
+import {
+	Tabs,
+	tabsThemeDefault,
+} from '@guardian/source-react-components-development-kitchen';
+
+const Before = () => (
+	<Tabs
+		tabs={tabs}
+		cssOverride={css`
+			border-color: darkbrown;
+		`}
+	/>
+);
+
+const After = () => (
+	<Tabs tabs={tabs} theme={{ ...tabsThemeDefault, '--border': 'darkbrown' }} />
+);
+```
+
+Uses CSS Custom Properties under the hood.

--- a/.changeset/orange-bulldogs-hug.md
+++ b/.changeset/orange-bulldogs-hug.md
@@ -1,0 +1,7 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Internals rewritten as read-only. No change for consumers, they are still able
+to provide a mutable data structure, but we guarantee that this component will
+not modify it

--- a/libs/@guardian/source-react-components-development-kitchen/src/tabs/Tabs.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/tabs/Tabs.stories.tsx
@@ -1,41 +1,12 @@
 import { css } from '@emotion/react';
+import { palette } from '@guardian/source-foundations';
 import { SvgAppleBrand } from '@guardian/source-react-components';
 import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { Tabs } from './tabs';
+import { tabsDarkTheme } from './theme';
+import type { TabProps } from './types';
 
-const dogsTab = {
-	id: 'dog',
-	text: (
-		<div
-			css={css`
-				display: flex;
-				flex-wrap: wrap;
-				align-items: center;
-			`}
-		>
-			<span
-				css={css`
-					padding-right: 4px;
-				`}
-			>
-				Dogs
-			</span>
-			<span>(are the best)</span>
-		</div>
-	),
-	content: (
-		<p>
-			Vestibulum fermentum nibh ac est venenatis facilisis. In vehicula mattis
-			mi, id eleifend metus suscipit posuere. Nulla sed sem magna. Sed ante
-			orci, convallis a facilisis sed, mollis id lacus. Aenean ullamcorper
-			pellentesque nisi sed vehicula. Aenean quis auctor libero. Vestibulum
-			aliquam in tellus id varius. Donec congue consectetur sem, sit amet
-			sagittis turpis. Maecenas mattis massa augue, sit amet aliquet libero
-			elementum nec.
-		</p>
-	),
-};
 const tabsContent = [
 	{
 		id: 'cat',
@@ -55,37 +26,71 @@ const tabsContent = [
 			</p>
 		),
 	},
-	dogsTab,
-];
+	{
+		id: 'dog',
+		text: (
+			<div
+				css={css`
+					display: flex;
+					flex-wrap: wrap;
+					align-items: center;
+				`}
+			>
+				<span
+					css={css`
+						padding-right: 4px;
+					`}
+				>
+					Dogs
+				</span>
+				<span>(are the best)</span>
+			</div>
+		),
+		content: (
+			<p>
+				Vestibulum fermentum nibh ac est venenatis facilisis. In vehicula mattis
+				mi, id eleifend metus suscipit posuere. Nulla sed sem magna. Sed ante
+				orci, convallis a facilisis sed, mollis id lacus. Aenean ullamcorper
+				pellentesque nisi sed vehicula. Aenean quis auctor libero. Vestibulum
+				aliquam in tellus id varius. Donec congue consectetur sem, sit amet
+				sagittis turpis. Maecenas mattis massa augue, sit amet aliquet libero
+				elementum nec.
+			</p>
+		),
+	},
+] as const satisfies readonly TabProps[];
 
 const tabs = (): ReactElement => {
-	const [selectedTab, setSelectedTab] = useState('cat');
+	const [selectedTab, setSelectedTab] = useState<string>(tabsContent[1].id);
 	return (
 		<Tabs
 			tabsLabel="Pets"
 			tabElement="button"
 			tabs={tabsContent}
 			selectedTab={selectedTab}
-			onTabChange={(tabName: string): void => {
-				setSelectedTab(tabName);
-			}}
+			onTabChange={setSelectedTab}
 		/>
 	);
 };
+
 const singleTab = (): ReactElement => {
+	const dog = tabsContent[1];
 	return (
 		<Tabs
 			tabsLabel="Pets"
 			tabElement="button"
-			tabs={[dogsTab]}
-			selectedTab={'dog'}
-			onTabChange={(): void => {}}
+			tabs={[dog]}
+			selectedTab={dog.id}
+			onTabChange={() => {
+				// do nothing
+			}}
 		/>
 	);
 };
+
 const tabWithNodeTitle = (): ReactElement => {
-	const tabs = {
-		id: 'dog',
+	const fruit = {
+		id: 'fruit',
 		text: (
 			<div
 				css={css`
@@ -96,15 +101,52 @@ const tabWithNodeTitle = (): ReactElement => {
 				<SvgAppleBrand size="xsmall" />
 			</div>
 		),
-		content: dogsTab.content,
-	};
+		content: (
+			<p>The apple is a fresh fruit that also happen to be massively tasty!</p>
+		),
+	} satisfies TabProps;
 	return (
 		<Tabs
 			tabsLabel="Pets"
 			tabElement="button"
-			tabs={[tabs]}
-			selectedTab={'dog'}
-			onTabChange={(): void => {}}
+			tabs={[fruit]}
+			selectedTab={fruit.id}
+			onTabChange={() => {
+				// do nothing
+			}}
+		/>
+	);
+};
+
+const tabWithDarkTheme = (): ReactElement => {
+	const [selectedTab, setSelectedTab] = useState<string>(tabsContent[0].id);
+	return (
+		<Tabs
+			tabsLabel="Themed"
+			tabElement="button"
+			tabs={tabsContent}
+			selectedTab={selectedTab}
+			onTabChange={setSelectedTab}
+			theme={tabsDarkTheme}
+		/>
+	);
+};
+
+const tabWithCustomTheme = (): ReactElement => {
+	const [selectedTab, setSelectedTab] = useState<string>(tabsContent[0].id);
+	return (
+		<Tabs
+			tabsLabel="Themed"
+			tabElement="button"
+			tabs={tabsContent}
+			selectedTab={selectedTab}
+			onTabChange={setSelectedTab}
+			theme={{
+				'--background': palette.brand[300],
+				'--border': palette.brand[100],
+				'--inactiveBackground': palette.brand[600],
+				'--text': palette.neutral[97],
+			}}
 		/>
 	);
 };
@@ -114,4 +156,10 @@ export default {
 	title: 'Tabs',
 };
 
-export { tabs, singleTab, tabWithNodeTitle };
+export {
+	tabs,
+	singleTab,
+	tabWithNodeTitle,
+	tabWithDarkTheme,
+	tabWithCustomTheme,
+};

--- a/libs/@guardian/source-react-components-development-kitchen/src/tabs/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/tabs/styles.ts
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
-import type { SerializedStyles } from '@emotion/react';
 import { from, space, textSans } from '@guardian/source-foundations';
-import { tabsThemeDefault } from './theme';
+import { tabThemeColour } from './theme';
 
 export const tabList = css`
 	display: flex;
@@ -9,10 +8,8 @@ export const tabList = css`
 	justify-content: flex-start;
 `;
 
-export const tabButton = (
-	tabs = tabsThemeDefault.tabs,
-): SerializedStyles => css`
-	background-color: ${tabs.background};
+export const tabButton = css`
+	background-color: ${tabThemeColour('--background')};
 	${textSans.medium({
 		fontWeight: 'bold',
 	})}
@@ -26,15 +23,18 @@ export const tabButton = (
 	min-height: ${space[12]}px;
 	align-self: stretch;
 	text-align: left;
-	color: ${tabs.text};
+	color: ${tabThemeColour('--text')};
 	padding: ${space[2]}px ${space[3]}px;
-	border: 1px solid ${tabs.border};
+	border: 1px solid ${tabThemeColour('--border')};
 	border-bottom: none;
 	cursor: pointer;
 
 	:first-of-type {
 		margin-left: ${space[2]}px;
 		border-top-left-radius: ${space[2]}px;
+	}
+	:nth-of-type(n + 2) {
+		border-left: none;
 	}
 	:last-of-type {
 		margin-right: ${space[2]}px;
@@ -49,7 +49,7 @@ export const tabButton = (
 	}
 
 	&[aria-selected='false'] {
-		background-color: ${tabs.inactiveBackground};
+		background-color: ${tabThemeColour('--inactiveBackground')};
 	}
 
 	/* Pseudo-element that covers the tab panel bottom border for the active tab */
@@ -65,10 +65,10 @@ export const tabButton = (
 	}
 `;
 
-export const tabPanel = (tabs = tabsThemeDefault.tabs): SerializedStyles => css`
+export const tabPanel = css`
 	position: relative;
 	padding: ${space[3]}px;
-	background: ${tabs.background};
-	border-top: 1px solid ${tabs.border};
-	color: ${tabs.text};
+	background: ${tabThemeColour('--background')};
+	border-top: 1px solid ${tabThemeColour('--border')};
+	color: ${tabThemeColour('--text')};
 `;

--- a/libs/@guardian/source-react-components-development-kitchen/src/tabs/tabs.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/tabs/tabs.tsx
@@ -1,29 +1,38 @@
+import type { CSSProperties } from 'react';
 import { tabButton, tabList, tabPanel } from './styles';
-import type { Theme } from './theme';
+import { tabsThemeDefault } from './theme';
 import type { TabContainerProps } from './types';
 
-function Tabs({
+const Tabs = ({
 	tabsLabel,
 	tabElement,
 	tabs,
 	selectedTab,
 	onTabChange,
-}: TabContainerProps): JSX.Element {
+	theme = tabsThemeDefault,
+}: TabContainerProps): JSX.Element => {
 	const TabControllerElement = tabElement;
 	return (
-		<div>
+		<div
+			style={
+				// Setting CSS Custom Properties is not supported natively
+				// by the underling type definitions, but here we have ensured
+				// that all the keys are valid and start with a double dash `--`
+				theme as CSSProperties
+			}
+		>
 			<div css={tabList} role="tablist" aria-label={tabsLabel}>
 				{tabs.map(({ id, href, text }) => {
 					return (
 						<TabControllerElement
 							key={id}
-							css={(theme: Theme) => tabButton(theme.tabs)}
+							css={tabButton}
 							role="tab"
 							id={id}
 							href={href}
 							aria-selected={selectedTab === id}
 							aria-controls={`${id}-tab`}
-							onClick={(): void => onTabChange(id)}
+							onClick={() => onTabChange(id)}
 						>
 							{text}
 						</TabControllerElement>
@@ -33,7 +42,7 @@ function Tabs({
 			{tabs.map(({ id, content }) => (
 				<div
 					key={`${id}-tab`}
-					css={(theme: Theme) => tabPanel(theme.tabs)}
+					css={tabPanel}
 					role="tabpanel"
 					id={`${id}-tab`}
 					aria-labelledby={id}
@@ -44,6 +53,6 @@ function Tabs({
 			))}
 		</div>
 	);
-}
+};
 
 export { Tabs };

--- a/libs/@guardian/source-react-components-development-kitchen/src/tabs/tabs.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/tabs/tabs.tsx
@@ -1,6 +1,6 @@
 import { tabButton, tabList, tabPanel } from './styles';
 import type { Theme } from './theme';
-import type { TabContainerProps, TabProps } from './types';
+import type { TabContainerProps } from './types';
 
 function Tabs({
 	tabsLabel,
@@ -13,33 +13,33 @@ function Tabs({
 	return (
 		<div>
 			<div css={tabList} role="tablist" aria-label={tabsLabel}>
-				{tabs.map((tab: TabProps) => {
+				{tabs.map(({ id, href, text }) => {
 					return (
 						<TabControllerElement
-							key={tab.id}
+							key={id}
 							css={(theme: Theme) => tabButton(theme.tabs)}
 							role="tab"
-							id={tab.id}
-							href={tab.href}
-							aria-selected={selectedTab === tab.id}
-							aria-controls={`${tab.id}-tab`}
-							onClick={(): void => onTabChange(tab.id)}
+							id={id}
+							href={href}
+							aria-selected={selectedTab === id}
+							aria-controls={`${id}-tab`}
+							onClick={(): void => onTabChange(id)}
 						>
-							{tab.text}
+							{text}
 						</TabControllerElement>
 					);
 				})}
 			</div>
-			{tabs.map((tab: TabProps) => (
+			{tabs.map(({ id, content }) => (
 				<div
-					key={`${tab.id}-tab`}
+					key={`${id}-tab`}
 					css={(theme: Theme) => tabPanel(theme.tabs)}
 					role="tabpanel"
-					id={`${tab.id}-tab`}
-					aria-labelledby={tab.id}
-					hidden={!(tab.id === selectedTab)}
+					id={`${id}-tab`}
+					aria-labelledby={id}
+					hidden={!(id === selectedTab)}
 				>
-					{tab.content}
+					{content}
 				</div>
 			))}
 		</div>

--- a/libs/@guardian/source-react-components-development-kitchen/src/tabs/theme.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/tabs/theme.ts
@@ -1,23 +1,20 @@
-import type { Theme as EmotionTheme } from '@emotion/react';
 import { palette } from '@guardian/source-foundations';
 
 export const tabsThemeDefault = {
-	tabs: {
-		background: palette.neutral[97],
-		text: palette.neutral[7],
-		border: palette.neutral[60],
-		inactiveBackground: palette.neutral[86],
-	},
+	['--background']: palette.neutral[97],
+	['--text']: palette.neutral[7],
+	['--border']: palette.neutral[60],
+	['--inactiveBackground']: palette.neutral[86],
 };
 export const tabsDarkTheme = {
-	tabs: {
-		background: palette.neutral[20],
-		text: palette.neutral[97],
-		border: palette.neutral[60],
-		inactiveBackground: palette.neutral[7],
-	},
+	['--background']: palette.neutral[20],
+	['--text']: palette.neutral[97],
+	['--border']: palette.neutral[60],
+	['--inactiveBackground']: palette.neutral[7],
 };
 
-export interface Theme extends EmotionTheme {
-	tabs?: typeof tabsThemeDefault.tabs;
-}
+/** enforce valid custom properties for this component */
+export const tabThemeColour = (key: keyof typeof tabsThemeDefault) =>
+	`var(${key})`;
+
+export type Theme = Record<keyof typeof tabsThemeDefault, string>;

--- a/libs/@guardian/source-react-components-development-kitchen/src/tabs/types.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/tabs/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { Theme } from './theme';
 
 type TabElement = 'a' | 'button';
 export type TabProps = {
@@ -14,4 +15,5 @@ export type TabContainerProps = {
 	tabs: readonly TabProps[];
 	onTabChange: (tabName: string) => void;
 	selectedTab: string;
+	theme?: Theme;
 };

--- a/libs/@guardian/source-react-components-development-kitchen/src/tabs/types.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/tabs/types.ts
@@ -2,15 +2,16 @@ import type { ReactNode } from 'react';
 
 type TabElement = 'a' | 'button';
 export type TabProps = {
-	id: string;
-	text: string | ReactNode;
-	href?: string;
-	content: ReactNode;
+	readonly id: string;
+	readonly text: string | ReactNode;
+	readonly href?: string;
+	readonly content: ReactNode;
 };
+
 export type TabContainerProps = {
 	tabsLabel: string;
 	tabElement: TabElement;
-	tabs: TabProps[];
+	tabs: readonly TabProps[];
 	onTabChange: (tabName: string) => void;
 	selectedTab: string;
 };


### PR DESCRIPTION
## What are you changing?

- Refactor `Tabs` so it receives an optional `theme` object which is used to define relevant custom properties which drive the colour of the component
- Remove CSS Overrides as we enable consumers to override every single colour
- Add stories to demonstrate usage
- Refactors `Tabs` with some destructuring, but this can be kept to a different PR 0a756696f44266f2d3f2deb195bc0e3836b6685c

## Why?


- This enables us to use Callouts with dark mode in dotcom-rendering: https://github.com/guardian/dotcom-rendering/issues/9277
- Proposal for an answer to: https://github.com/guardian/dotcom-rendering/issues/9333


## Screenshots

<img width="866" alt="image" src="https://github.com/guardian/csnx/assets/76776/e867b355-f61d-418e-8343-debe00b7c92f">

<img width="863" alt="image" src="https://github.com/guardian/csnx/assets/76776/a288cfce-5dc8-4439-8edf-e6aa20d61b43">

<img width="863" alt="image" src="https://github.com/guardian/csnx/assets/76776/c52231b6-0e7b-4d22-bc49-3ff29e023a81">
