### PR TITLE
design tokens as source of truth for palette, breakpoint, size

### DIFF
--- a/.changeset/shaggy-trees-fold.md
+++ b/.changeset/shaggy-trees-fold.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-foundations': minor
+---
+
+Changed the source of truth for source foundations to be the design tokens for palette, breakpoints, size

--- a/libs/@guardian/source-foundations/src/breakpoints/breakpoints.ts
+++ b/libs/@guardian/source-foundations/src/breakpoints/breakpoints.ts
@@ -1,24 +1,19 @@
-export type Breakpoint =
-	| 'mobile'
-	| 'mobileMedium'
-	| 'mobileLandscape'
-	| 'phablet'
-	| 'tablet'
-	| 'desktop'
-	| 'leftCol'
-	| 'wide';
+import { tokens } from '@csnx/design-tokens';
+import { pxStringToNumber } from '../utils/px-to-rem';
+
+export type Breakpoint = keyof typeof tokens.breakpoint;
 
 /**
  * [Storybook](https://guardian.github.io/csnx/?path=/docs/source-foundations_media-queries--page) •
  * [Design System](https://theguardian.design/2a1e5182b/p/41be19-grids)
  */
 export const breakpoints = {
-	mobile: 320,
-	mobileMedium: 375,
-	mobileLandscape: 480,
-	phablet: 660,
-	tablet: 740,
-	desktop: 980,
-	leftCol: 1140,
-	wide: 1300,
+	mobile: pxStringToNumber(tokens.breakpoint.mobile),
+	mobileMedium: pxStringToNumber(tokens.breakpoint.mobileMedium),
+	mobileLandscape: pxStringToNumber(tokens.breakpoint.mobileLandscape),
+	phablet: pxStringToNumber(tokens.breakpoint.phablet),
+	tablet: pxStringToNumber(tokens.breakpoint.tablet),
+	desktop: pxStringToNumber(tokens.breakpoint.desktop),
+	leftCol: pxStringToNumber(tokens.breakpoint.leftCol),
+	wide: pxStringToNumber(tokens.breakpoint.wide),
 } as const;

--- a/libs/@guardian/source-foundations/src/colour/palette.ts
+++ b/libs/@guardian/source-foundations/src/colour/palette.ts
@@ -1,105 +1,7 @@
 // Arrays of colours should have pillar colors first
 // e.g. for sport:
 // const [sport300, sport400, sport500, sport600, sport800] = colors.blue
-const colors = {
-	reds: [
-		'#660505', //news-100
-		'#8B0000', //news-200
-		'#AB0613', //news-300
-		'#C70000', //news-400, error-400
-		'#FF5943', //news-500
-		'#FF9081', //news-550, error-500
-		'#FFBAC8', //news-600
-		'#FFF4F2', //news-800
-	],
-	oranges: [
-		'#672005', //opinion-100
-		'#8D2700', //opinion-200
-		'#C74600', //opinion-400, opinion-300 (deprecated)
-		'#E05E00', //opinion-450
-		'#FF7F0F', //opinion-500
-		'#FF9941', //opinion-550
-		'#F9B376', //opinion-600
-		'#FEF9F5', //opinion-800
-	],
-	blues: [
-		'#003C60', //sport-100
-		'#004E7C', //sport-200
-		'#005689', //sport-300
-		'#0077B6', //sport-400, focus-400, brand-500
-		'#00B2FF', //sport-500
-		'#90DCFF', //sport-600
-		'#F1F8FC', //sport-800
-		'#001536', //brand-100
-		'#041F4A', //brand-300
-		'#052962', //brand-400
-		'#506991', //brand-600
-		'#C1D8FC', //brand-800
-	],
-	browns: [
-		'#2B2625', //culture-50
-		'#3E3323', //culture-100
-		'#574835', //culture-200
-		'#6B5840', //culture-300
-		'#866D50', //culture-400, culture-350 (deprecated)
-		'#A1845C', //culture-450
-		'#EACCA0', //culture-500
-		'#E7D4B9', //culture-600
-		'#EFE8DD', //culture-700
-		'#FBF6EF', //culture-800
-	],
-	pinks: [
-		'#510043', //lifestyle-100
-		'#650054', //lifestyle-200
-		'#7D0068', //lifestyle-300
-		'#BB3B80', //lifestyle-400
-		'#F37ABC', //lifestyle-450
-		'#FFABDB', //lifestyle-500
-		'#FEC8D3', //lifestyle-600
-		'#FEEEF7', //lifestyle-800
-	],
-	yellows: [
-		'#F3C100', //brandAlt-200
-		'#FFD900', //brandAlt-300
-		'#FFE500', //brandAlt-400
-	],
-	greens: [
-		'#185E36', //green-300
-		'#22874D', //green-400, success-400
-		'#58D08B', //green-500, success-500
-		'#0C7A73', //labs-200
-		'#65A897', //labs-300
-		'#69D1CA', //labs-400
-	],
-	grays: [
-		'#000000', //neutral-0
-		'#121212', //neutral-7
-		'#1A1A1A', //neutral-10
-		'#333333', //neutral-20
-		'#606060', //neutral-38
-		'#707070', //neutral-46
-		'#999999', //neutral-60
-		'#DCDCDC', //neutral-86
-		'#EDEDED', //neutral-93
-		'#F6F6F6', //neutral-97
-		'#FFFFFF', //neutral-100
-	],
-	special: [
-		'#222527', //specialReport-100
-		'#303538', //specialReport-200
-		'#3F464A', //specialReport-300
-		'#595C5F', //specialReport-400
-		'#9DA0A2', //specialReport-450
-		'#ABC2C9', //specialReport-500
-		'#E4E5E8', //specialReport-700
-		'#EFF1F2', //specialReport-800
-		'#2B2B2A', //specialReportAlt-100
-		'#B9300A', //specialReportAlt-200
-		'#FF663D', //specialReportAlt-300
-		'#EBE6E1', //specialReportAlt-700
-		'#F5F0EB', //specialReportAlt-800
-	],
-} as const;
+import { tokens } from '@csnx/design-tokens';
 
 /**
  * [Storybook](https://guardian.github.io/csnx/?path=/docs/source-foundations_palette--palette) •
@@ -108,124 +10,20 @@ const colors = {
  * Colour palette organised by type e.g. 'error', or pillar e.g. 'opinion'
  */
 export const palette = {
-	brand: {
-		100: colors.blues[7],
-		300: colors.blues[8],
-		400: colors.blues[9],
-		500: colors.blues[3],
-		600: colors.blues[10],
-		800: colors.blues[11],
-	},
-	brandAlt: {
-		200: colors.yellows[0],
-		300: colors.yellows[1],
-		400: colors.yellows[2],
-	},
-	neutral: {
-		0: colors.grays[0],
-		7: colors.grays[1],
-		10: colors.grays[2],
-		20: colors.grays[3],
-		38: colors.grays[4],
-		46: colors.grays[5],
-		60: colors.grays[6],
-		86: colors.grays[7],
-		93: colors.grays[8],
-		97: colors.grays[9],
-		100: colors.grays[10],
-	},
-	error: {
-		400: colors.reds[3],
-		500: colors.reds[5],
-	},
-	success: {
-		400: colors.greens[1],
-		500: colors.greens[2],
-	},
-	news: {
-		100: colors.reds[0],
-		200: colors.reds[1],
-		300: colors.reds[2],
-		400: colors.reds[3],
-		500: colors.reds[4],
-		550: colors.reds[5],
-		600: colors.reds[6],
-		800: colors.reds[7],
-	},
-	opinion: {
-		100: colors.oranges[0],
-		200: colors.oranges[1],
-		/**
-		 * @deprecated, use opinion[400]
-		 */
-		300: colors.oranges[2],
-		400: colors.oranges[2],
-		450: colors.oranges[3],
-		500: colors.oranges[4],
-		550: colors.oranges[5],
-		600: colors.oranges[6],
-		800: colors.oranges[7],
-	},
-	sport: {
-		100: colors.blues[0],
-		200: colors.blues[1],
-		300: colors.blues[2],
-		400: colors.blues[3],
-		500: colors.blues[4],
-		600: colors.blues[5],
-		800: colors.blues[6],
-	},
-	culture: {
-		50: colors.browns[0],
-		100: colors.browns[1],
-		200: colors.browns[2],
-		300: colors.browns[3],
-		/**
-		 * @deprecated, use culture[400]
-		 */
-		350: colors.browns[4],
-		400: colors.browns[4],
-		450: colors.browns[5],
-		500: colors.browns[6],
-		600: colors.browns[7],
-		700: colors.browns[8],
-		800: colors.browns[9],
-	},
-	lifestyle: {
-		100: colors.pinks[0],
-		200: colors.pinks[1],
-		300: colors.pinks[2],
-		400: colors.pinks[3],
-		450: colors.pinks[4],
-		500: colors.pinks[5],
-		600: colors.pinks[6],
-		800: colors.pinks[7],
-	},
-	labs: {
-		200: colors.greens[3],
-		300: colors.greens[4],
-		400: colors.greens[5],
-	},
-	specialReport: {
-		100: colors.special[0],
-		200: colors.special[1],
-		300: colors.special[2],
-		400: colors.special[3],
-		450: colors.special[4],
-		500: colors.special[5],
-		700: colors.special[6],
-		800: colors.special[7],
-	},
-	specialReportAlt: {
-		100: colors.special[8],
-		200: colors.special[9],
-		300: colors.special[10],
-		700: colors.special[11],
-		800: colors.special[12],
-	},
-	focus: {
-		400: colors.blues[3],
-	},
+	brand: tokens.palette.brand,
+	brandAlt: tokens.palette.brandAlt,
+	neutral: tokens.palette.neutral,
+	error: tokens.palette.error,
+	success: tokens.palette.success,
+	news: tokens.palette.news,
+	opinion: tokens.palette.opinion,
+	sport: tokens.palette.sport,
+	culture: tokens.palette.culture,
+	lifestyle: tokens.palette.lifestyle,
+	labs: tokens.palette.labs,
+	specialReport: tokens.palette.specialReport,
+	specialReportAlt: tokens.palette.specialReportAlt,
+	focus: tokens.palette.focus,
 } as const;
 
 // Hover colours are snowflakes as they are manipulations of colours from the

--- a/libs/@guardian/source-foundations/src/size/size.ts
+++ b/libs/@guardian/source-foundations/src/size/size.ts
@@ -1,4 +1,5 @@
-import { pxToRem } from '../utils/px-to-rem';
+import { tokens } from '@csnx/design-tokens';
+import { pxStringToNumber, pxToRem } from '../utils/px-to-rem';
 
 /**
  * [Storybook](https://guardian.github.io/csnx/?path=/docs/source-foundations_size--page#global-size-values) •
@@ -7,9 +8,9 @@ import { pxToRem } from '../utils/px-to-rem';
  * May be used for call to action buttons and user input fields.
  */
 export const size = {
-	xsmall: 24,
-	small: 36,
-	medium: 44, // meets WCAG 2.1 AAA compliance for touch targets.
+	xsmall: pxStringToNumber(tokens.size.xSmall),
+	small: pxStringToNumber(tokens.size.small),
+	medium: pxStringToNumber(tokens.size.medium), // meets WCAG 2.1 AAA compliance for touch targets.
 } as const;
 
 /**
@@ -35,9 +36,9 @@ const remSize: { [K in keyof typeof size]: number } = {
    component.
 */
 export const iconSize = {
-	xsmall: 20,
-	small: 26,
-	medium: 30,
+	xsmall: pxStringToNumber(tokens.size.icon.xSmall),
+	small: pxStringToNumber(tokens.size.icon.small),
+	medium: pxStringToNumber(tokens.size.icon.medium),
 } as const;
 
 const remIconSize: { [K in keyof typeof iconSize]: number } = {


### PR DESCRIPTION
## What are you changing?

- Added the design tokens as source of truth for palette.ts, breakpoint.ts, size.ts

## Why?

- We are moving the source of truth for all source foundations exports to the design tokens
