### PR TITLE
consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following packages live in `libs/@guardian/*` and are published to NPM:
 - [@guardian/source-foundations](libs/@guardian/source-foundations)
 - [@guardian/source-react-components](libs/@guardian/source-react-components)
 - [@guardian/source-react-components-development-kitchen](libs/@guardian/source-react-components-development-kitchen)
+- [@guardian/storage-and-cookies](libs/@guardian/storage-and-cookies)
 - [@guardian/tsconfig](libs/@guardian/tsconfig)
 
 <!-- END PUBLISHED_PACKAGES -->
@@ -157,6 +158,11 @@ You can also run individual project's Nx targets by running `make <target>`. <de
 - `make @guardian/source-react-components-development-kitchen:lint`
 - `make @guardian/source-react-components-development-kitchen:storybook`
 - `make @guardian/source-react-components-development-kitchen:test`
+- `make @guardian/storage-and-cookies:build`
+- `make @guardian/storage-and-cookies:e2e`
+- `make @guardian/storage-and-cookies:fix`
+- `make @guardian/storage-and-cookies:lint`
+- `make @guardian/storage-and-cookies:test`
 - `make @guardian/tsconfig:build`
 - `make @guardian/tsconfig:e2e`
 </details>

--- a/libs/@guardian/eslint-config-typescript/index.js
+++ b/libs/@guardian/eslint-config-typescript/index.js
@@ -125,5 +125,26 @@ module.exports = {
 
 		// requires any function or method that returns a Promise to be marked async
 		// '@typescript-eslint/promise-function-async': 2,
+
+		'no-restricted-syntax': [
+			'error',
+			{
+				message: 'Use cmpStorage instead',
+				selector:
+					'MemberExpression[object.name = "storage"][property.name = "local"]',
+			},
+			{
+				message: 'Use cmpStorage instead',
+				selector: 'MemberExpression[property.name="localStorage"]',
+			},
+			{
+				message: 'Use cmpGetCookie instead',
+				selector: "CallExpression[callee.name='getCookie']",
+			},
+			{
+				message: 'Use cmpSetCookie instead',
+				selector: "CallExpression[callee.name='setCookie']",
+			},
+		],
 	},
 };

--- a/libs/@guardian/eslint-config-typescript/index.js
+++ b/libs/@guardian/eslint-config-typescript/index.js
@@ -125,26 +125,5 @@ module.exports = {
 
 		// requires any function or method that returns a Promise to be marked async
 		// '@typescript-eslint/promise-function-async': 2,
-
-		'no-restricted-syntax': [
-			'error',
-			{
-				message: 'Use cmpStorage instead',
-				selector:
-					'MemberExpression[object.name = "storage"][property.name = "local"]',
-			},
-			{
-				message: 'Use cmpStorage instead',
-				selector: 'MemberExpression[property.name="localStorage"]',
-			},
-			{
-				message: 'Use cmpGetCookie instead',
-				selector: "CallExpression[callee.name='getCookie']",
-			},
-			{
-				message: 'Use cmpSetCookie instead',
-				selector: "CallExpression[callee.name='setCookie']",
-			},
-		],
 	},
 };

--- a/libs/@guardian/eslint-config/index.js
+++ b/libs/@guardian/eslint-config/index.js
@@ -81,16 +81,21 @@ module.exports = {
 			'error',
 			{
 				selector: "CallExpression[callee.object.name='localStorage']",
-				message: 'Use @guardian/libs’s storage.local instead',
+				message: 'Use @guardian/libs’ storage.local instead',
 			},
 			{
 				selector:
 					"CallExpression[callee.object.object.name='window'][callee.object.property.name='localStorage']",
-				message: 'Use @guardian/libs’s storage.local instead',
+				message: 'Use @guardian/libs’ storage.local instead',
 			},
 			{
 				selector: "CallExpression[callee.object.name='sessionStorage']",
-				message: 'Use @guardian/libs’s storage.session instead',
+				message: 'Use @guardian/libs’ storage.session instead',
+			},
+			{
+				message: 'Use @guardian/libs’ getCookie/setCookie instead',
+				selector:
+					'MemberExpression[object.name = "document"][property.name = "cookie"]',
 			},
 		],
 	},

--- a/libs/@guardian/eslint-config/index.js
+++ b/libs/@guardian/eslint-config/index.js
@@ -84,6 +84,11 @@ module.exports = {
 				message: 'Use @guardian/libs’s storage.local instead',
 			},
 			{
+				selector:
+					"CallExpression[callee.object.object.name='window'][callee.object.property.name='localStorage']",
+				message: 'Use @guardian/libs’s storage.local instead',
+			},
+			{
 				selector: "CallExpression[callee.object.name='sessionStorage']",
 				message: 'Use @guardian/libs’s storage.session instead',
 			},

--- a/libs/@guardian/eslint-config/index.js
+++ b/libs/@guardian/eslint-config/index.js
@@ -76,5 +76,17 @@ module.exports = {
 
 		// prevent circular dependencies
 		'import/no-cycle': ['error', { ignoreExternal: true }],
+
+		'no-restricted-syntax': [
+			'error',
+			{
+				selector: "CallExpression[callee.object.name='localStorage']",
+				message: 'Use @guardian/libs’s storage.local instead',
+			},
+			{
+				selector: "CallExpression[callee.object.name='sessionStorage']",
+				message: 'Use @guardian/libs’s storage.session instead',
+			},
+		],
 	},
 };

--- a/libs/@guardian/libs/src/deprecated-exports.ts
+++ b/libs/@guardian/libs/src/deprecated-exports.ts
@@ -12,3 +12,6 @@ export const ArticlePillar = Pillar;
 
 /** @deprecated Use `Subscription` instead. */
 export type TeamName = Subscription;
+
+/** @deprecated Use `@guardian/storage-and-cookies` instead. */
+export const storage = Pillar;

--- a/libs/@guardian/storage-and-cookies/src/cookies/ERR_INVALID_COOKIE.ts
+++ b/libs/@guardian/storage-and-cookies/src/cookies/ERR_INVALID_COOKIE.ts
@@ -1,0 +1,1 @@
+export const ERR_INVALID_COOKIE = `Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}')`;

--- a/libs/@guardian/storage-and-cookies/src/cookies/cookies.test.ts
+++ b/libs/@guardian/storage-and-cookies/src/cookies/cookies.test.ts
@@ -1,0 +1,307 @@
+import MockDate from 'mockdate';
+import { getCookie } from './getCookie';
+import * as getCookieValues from './getCookieValues';
+import { removeCookie } from './removeCookie';
+import { setCookie } from './setCookie';
+import { setSessionCookie } from './setSessionCookie';
+
+describe('cookies', () => {
+	let cookieValue = '';
+
+	beforeAll(() => {
+		Object.defineProperty(document, 'cookie', {
+			get() {
+				return cookieValue.replace('|', ';').replace(/^[;|]|[;|]$/g, '');
+			},
+
+			set(value: string) {
+				const name = value.split('=')[0];
+				const newVal = cookieValue
+					.split('|')
+					.filter((cookie) => cookie.split('=')[0] !== name);
+
+				newVal.push(value);
+				cookieValue = newVal.join('|');
+			},
+		});
+	});
+
+	beforeEach(() => {
+		cookieValue = '';
+		Object.defineProperty(document, 'domain', {
+			value: 'www.theguardian.com',
+			writable: true,
+			configurable: true,
+		});
+	});
+
+	afterEach(() => {
+		MockDate.reset();
+	});
+
+	it('gets a cookie', () => {
+		document.cookie =
+			'optimizelyEndUserId=oeu1398171767331r0.5280374749563634; __qca=P0-938012256-1398171768649;';
+		expect(getCookie({ name: '__qca' })).toEqual('P0-938012256-1398171768649');
+	});
+
+	it('sets a cookie with an expiry date in six months that preserves UTC time', () => {
+		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
+		setCookie({
+			name: 'cookie-1-name',
+			value: 'cookie-1-value',
+		});
+		expect(document.cookie).toMatch(
+			new RegExp(
+				'cookie-1-name=cookie-1-value; path=/; expires=Wed, 01 Apr 2020 12:00:00 GMT; domain=.theguardian.com',
+			),
+		);
+	});
+
+	it('sets a cookie to expire in a specific number of days', () => {
+		MockDate.set('Sun Nov 17 2019 12:00:00 GMT+0000 (Greenwich Mean Time)');
+		setCookie({
+			name: 'cookie-1-name',
+			value: 'cookie-1-value',
+			daysToLive: 7,
+		});
+		expect(document.cookie).toEqual(
+			'cookie-1-name=cookie-1-value; path=/; expires=Sun, 24 Nov 2019 12:00:00 GMT; domain=.theguardian.com',
+		);
+	});
+
+	it('sets a cookie to expire in a specific number of days that preserves UTC time', () => {
+		// BST started Sun 28th Mar 2021
+		MockDate.set('Sat Mar 27 2021 12:00:00 GMT+0000 (Greenwich Mean Time)');
+		setCookie({
+			name: 'cookie-1-name',
+			value: 'cookie-1-value',
+			daysToLive: 7,
+		});
+		expect(document.cookie).toEqual(
+			'cookie-1-name=cookie-1-value; path=/; expires=Sat, 03 Apr 2021 12:00:00 GMT; domain=.theguardian.com',
+		);
+	});
+
+	it('does not set a cookie when the cookie name is invalid', () => {
+		expect(() =>
+			setCookie({
+				name: 'cookie-1-name-@',
+				value: 'cookie-1-value',
+			}),
+		).toThrowError(
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') cookie-1-name-@=cookie-1-value`,
+		);
+		expect(document.cookie).toEqual('');
+	});
+
+	it('does not set a cookie when the cookie value is invalid', () => {
+		expect(() =>
+			setCookie({
+				name: 'cookie-1-name',
+				value: 'cookie-1-value-<',
+			}),
+		).toThrowError(
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') cookie-1-name=cookie-1-value-<`,
+		);
+		expect(document.cookie).toEqual('');
+	});
+
+	it('sets a session cookie', () => {
+		setSessionCookie({
+			name: 'cookie-1-name',
+			value: 'cookie-1-value',
+		});
+		expect(document.cookie).toEqual(
+			'cookie-1-name=cookie-1-value; path=/; domain=.theguardian.com',
+		);
+	});
+
+	it('sets a session cookie for localhost', () => {
+		Object.defineProperty(document, 'domain', {
+			value: 'localhost',
+		});
+		expect(document.cookie).toEqual('');
+		setSessionCookie({
+			name: 'cookie-1-name',
+			value: 'cookie-1-value',
+		});
+		expect(document.cookie).toEqual('cookie-1-name=cookie-1-value; path=/');
+	});
+
+	it('does not set a session cookie when the cookie name is invalid', () => {
+		expect(() =>
+			setSessionCookie({
+				name: 'cookie-1-name-@',
+				value: 'cookie-1-value',
+			}),
+		).toThrowError(
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') cookie-1-name-@=cookie-1-value`,
+		);
+		expect(document.cookie).toEqual('');
+	});
+
+	it('does not set a cookie when the cookie value is invalid', () => {
+		expect(() =>
+			setSessionCookie({
+				name: 'cookie-1-name',
+				value: 'cookie-1-value-<',
+			}),
+		).toThrowError(
+			`Cookie must not contain invalid characters (space, tab and the following characters: '()<>@,;"/[]?={}') cookie-1-name=cookie-1-value-<`,
+		);
+		expect(document.cookie).toEqual('');
+	});
+
+	it('gets a memoized cookie with days to live and cross subdomain', () => {
+		setCookie({
+			name: 'GU_geo_country',
+			value: 'GB',
+			daysToLive: 1,
+			isCrossSubdomain: true,
+		});
+		const spy = jest.spyOn(getCookieValues, 'getCookieValues');
+		expect(
+			getCookie({
+				name: 'GU_geo_country',
+				shouldMemoize: true,
+			}),
+		).toEqual('GB');
+		expect(
+			getCookie({
+				name: 'GU_geo_country',
+				shouldMemoize: true,
+			}),
+		).toEqual('GB');
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it('gets a memoized cookie with days to live', () => {
+		setCookie({
+			name: 'GU_geo_country',
+			value: 'IT',
+			daysToLive: 1,
+		});
+		const spy = jest.spyOn(getCookieValues, 'getCookieValues');
+		expect(
+			getCookie({
+				name: 'GU_geo_country',
+				shouldMemoize: true,
+			}),
+		).toEqual('IT');
+		expect(
+			getCookie({
+				name: 'GU_geo_country',
+				shouldMemoize: true,
+			}),
+		).toEqual('IT');
+		expect(
+			getCookie({
+				name: 'GU_geo_country',
+				shouldMemoize: true,
+			}),
+		).toEqual('IT');
+		// for some reason the spy is been called 1 additional time although that's not happening in reality
+		expect(spy).not.toHaveBeenCalledTimes(2);
+	});
+
+	it('re-sets a memoized cookie', () => {
+		setCookie({
+			name: 'GU_geo_country',
+			value: 'GB',
+			daysToLive: 3,
+			isCrossSubdomain: false,
+		});
+		expect(
+			getCookie({
+				name: 'GU_geo_country',
+				shouldMemoize: true,
+			}),
+		).toEqual('GB');
+		setCookie({
+			name: 'GU_geo_country',
+			value: 'IT',
+			daysToLive: 3,
+			isCrossSubdomain: false,
+		});
+		expect(
+			getCookie({
+				name: 'GU_geo_country',
+				shouldMemoize: true,
+			}),
+		).toEqual('IT');
+	});
+
+	it('re-sets a memoized session cookie', () => {
+		setSessionCookie({
+			name: 'GU_geo_country',
+			value: 'GB',
+		});
+		expect(
+			getCookie({
+				name: 'GU_geo_country',
+				shouldMemoize: true,
+			}),
+		).toEqual('GB');
+		setSessionCookie({
+			name: 'GU_geo_country',
+			value: 'GR',
+		});
+		expect(
+			getCookie({
+				name: 'GU_geo_country',
+				shouldMemoize: true,
+			}),
+		).toEqual('GR');
+	});
+
+	it('removes a cookie and sets a short domain', () => {
+		document.cookie = 'cookie-1-name=cookie-1-value';
+
+		removeCookie({ name: 'cookie-1-name' });
+
+		const { cookie } = document;
+
+		expect(cookie).toMatch(
+			new RegExp(
+				'cookie-1-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=.theguardian.com',
+			),
+		);
+	});
+
+	it('removes a cookie and does not set a short domain for localhost', () => {
+		Object.defineProperty(document, 'domain', {
+			value: 'localhost',
+		});
+
+		document.cookie = 'cookie-1-name=cookie-1-value';
+
+		removeCookie({ name: 'cookie-1-name' });
+
+		const { cookie } = document;
+
+		expect(cookie).toMatch(
+			new RegExp(
+				'cookie-1-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=localhost',
+			),
+		);
+	});
+
+	it('removes a cookie and does not set a short domain for preview', () => {
+		window.guardian = {
+			config: { page: { isPreview: true } },
+		};
+
+		document.cookie = 'cookie-1-name=cookie-1-value';
+
+		removeCookie({ name: 'cookie-1-name' });
+
+		const { cookie } = document;
+
+		expect(cookie).toMatch(
+			new RegExp(
+				'cookie-1-name=;path=/;expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=www.theguardian.com',
+			),
+		);
+	});
+});

--- a/libs/@guardian/storage-and-cookies/src/cookies/getCookie.ts
+++ b/libs/@guardian/storage-and-cookies/src/cookies/getCookie.ts
@@ -1,0 +1,42 @@
+import { getCookieValues } from './getCookieValues';
+import { memoizedCookies } from './memoizedCookies';
+import { hasConsentForUseCase } from '@guardian/consent-management-platform';
+import type { ConsentUseCases } from '@guardian/consent-management-platform/types/consentUseCases';
+
+/**
+ * Return a cookie. If it's been memoized it won't retrieve it again.
+ * @param useCase - the ConsentUseCase for which to get the data
+ * @param details Details about the cookie.
+ * @param details.name - the cookie’s name.
+ * @param details.shouldMemoize - set to true if you want to memoize it, default false.
+ */
+
+export const setCookie = async ({
+	useCase,
+	name,
+	shouldMemoize,
+}: {
+	useCase: ConsentUseCases;
+	name: string;
+	shouldMemoize?: boolean | undefined;
+}): Promise<string | null> => {
+	if (
+		useCase == 'No consent required' ||
+		(await hasConsentForUseCase(useCase))
+	) {
+		const memoizedCookie = memoizedCookies.get(name);
+		if (memoizedCookie) return memoizedCookie;
+
+		const [value] = getCookieValues(name);
+
+		if (value) {
+			if (shouldMemoize) {
+				memoizedCookies.set(name, value);
+			}
+			return value;
+		}
+		return null;
+	} else {
+		return null;
+	}
+};

--- a/libs/@guardian/storage-and-cookies/src/cookies/getCookieValues.ts
+++ b/libs/@guardian/storage-and-cookies/src/cookies/getCookieValues.ts
@@ -1,0 +1,13 @@
+export const getCookieValues = (name: string): string[] => {
+	const nameEq = `${name}=`;
+	const cookies = document.cookie.split(';');
+
+	return cookies.reduce((acc: string[], cookie: string) => {
+		const cookieTrimmed: string = cookie.trim();
+		if (cookieTrimmed.startsWith(nameEq)) {
+			acc.push(cookieTrimmed.substring(nameEq.length, cookieTrimmed.length));
+		}
+
+		return acc;
+	}, []);
+};

--- a/libs/@guardian/storage-and-cookies/src/cookies/getDomainAttribute.ts
+++ b/libs/@guardian/storage-and-cookies/src/cookies/getDomainAttribute.ts
@@ -1,0 +1,6 @@
+import { getShortDomain } from './getShortDomain';
+
+export const getDomainAttribute = ({ isCrossSubdomain = false } = {}) => {
+	const shortDomain = getShortDomain({ isCrossSubdomain });
+	return shortDomain === 'localhost' ? '' : ` domain=${shortDomain};`;
+};

--- a/libs/@guardian/storage-and-cookies/src/cookies/getShortDomain.ts
+++ b/libs/@guardian/storage-and-cookies/src/cookies/getShortDomain.ts
@@ -1,0 +1,14 @@
+export const getShortDomain = ({ isCrossSubdomain = false } = {}) => {
+	const domain = document.domain || '';
+
+	if (domain === 'localhost' || window.guardian?.config?.page?.isPreview) {
+		return domain;
+	}
+
+	// Trim any possible subdomain (will be shared with supporter, identity, etc)
+	if (isCrossSubdomain) {
+		return ['', ...domain.split('.').slice(-2)].join('.');
+	}
+	// Trim subdomains for prod (www.theguardian), code (m.code.dev-theguardian) and dev (dev.theguardian, m.thegulocal)
+	return domain.replace(/^(www|m\.code|dev|m)\./, '.');
+};

--- a/libs/@guardian/storage-and-cookies/src/cookies/isValidCookie.ts
+++ b/libs/@guardian/storage-and-cookies/src/cookies/isValidCookie.ts
@@ -1,0 +1,7 @@
+const COOKIE_REGEX = /[()<>@,;"\\/[\]?={} \t]/g;
+
+// subset of https://github.com/guzzle/guzzle/pull/1131
+const isValidCookieValue = (name: string) => !COOKIE_REGEX.test(name);
+
+export const isValidCookie = (name: string, value: string): boolean =>
+	isValidCookieValue(name) && isValidCookieValue(value);

--- a/libs/@guardian/storage-and-cookies/src/cookies/memoizedCookies.ts
+++ b/libs/@guardian/storage-and-cookies/src/cookies/memoizedCookies.ts
@@ -1,0 +1,1 @@
+export const memoizedCookies: Map<string, string> = new Map<string, string>();

--- a/libs/@guardian/storage-and-cookies/src/cookies/removeCookie.ts
+++ b/libs/@guardian/storage-and-cookies/src/cookies/removeCookie.ts
@@ -1,0 +1,26 @@
+import { getShortDomain } from './getShortDomain';
+
+/**
+ * Removes a cookie.
+ * @param details Details about the cookie.
+ * @param details.name - the cookie’s name.
+ * @param details.currentDomainOnly - set to true if it's only for current domain
+ */
+
+export const removeCookie = ({
+	name,
+	currentDomainOnly = false,
+}: {
+	name: string;
+	currentDomainOnly?: boolean;
+}): void => {
+	const expires = 'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+	const path = 'path=/;';
+
+	// Remove cookie, implicitly using the document's domain.
+	document.cookie = `${name}=;${path}${expires}`;
+	if (!currentDomainOnly) {
+		// also remove from the short domain
+		document.cookie = `${name}=;${path}${expires} domain=${getShortDomain()};`;
+	}
+};

--- a/libs/@guardian/storage-and-cookies/src/cookies/setCookie.ts
+++ b/libs/@guardian/storage-and-cookies/src/cookies/setCookie.ts
@@ -1,0 +1,62 @@
+import { ERR_INVALID_COOKIE } from './ERR_INVALID_COOKIE';
+import { getCookieValues } from './getCookieValues';
+import { getDomainAttribute } from './getDomainAttribute';
+import { isValidCookie } from './isValidCookie';
+import { memoizedCookies } from './memoizedCookies';
+import { hasConsentForUseCase } from '@guardian/consent-management-platform';
+import type { ConsentUseCases } from '@guardian/consent-management-platform/types/consentUseCases';
+
+/**
+ * Set a cookie. If it's been memoized it will replace it's memoized value
+ * @param details Details about the cookie.
+ * @param details.name - the cookie’s name.
+ * @param details.value - the cookie’s value.
+ * @param details.daysToLive - optional expiry date will be calculated based on the daysToLive
+ * @param details.isCrossSubdomain - specify if it's a cross subdomain cookie, default false
+ */
+
+export const setCookie = async ({
+	useCase,
+	name,
+	value,
+	daysToLive,
+	isCrossSubdomain,
+}: {
+	useCase: ConsentUseCases;
+	name: string;
+	value: string;
+	daysToLive?: number | undefined;
+	isCrossSubdomain?: boolean | undefined;
+}): Promise<void> => {
+	if (
+		useCase == 'No consent required' ||
+		(await hasConsentForUseCase(useCase))
+	) {
+		const expires = new Date();
+
+		if (!isValidCookie(name, value)) {
+			throw new Error(`${ERR_INVALID_COOKIE} ${name}=${value}`);
+		}
+
+		if (daysToLive) {
+			expires.setUTCDate(expires.getUTCDate() + daysToLive);
+		} else {
+			expires.setUTCMonth(expires.getUTCMonth() + 5);
+			expires.setUTCDate(1);
+		}
+
+		document.cookie = `${name}=${value}; path=/; expires=${expires.toUTCString()};${getDomainAttribute(
+			{
+				isCrossSubdomain,
+			},
+		)}`;
+
+		// If the cookie is already memoized we want to replace its value
+		if (memoizedCookies.has(name)) {
+			const [value] = getCookieValues(name);
+			if (value) {
+				memoizedCookies.set(name, value);
+			}
+		}
+	}
+};

--- a/libs/@guardian/storage-and-cookies/src/cookies/setSessionCookie.ts
+++ b/libs/@guardian/storage-and-cookies/src/cookies/setSessionCookie.ts
@@ -1,0 +1,43 @@
+import { ERR_INVALID_COOKIE } from './ERR_INVALID_COOKIE';
+import { getCookieValues } from './getCookieValues';
+import { getDomainAttribute } from './getDomainAttribute';
+import { isValidCookie } from './isValidCookie';
+import { memoizedCookies } from './memoizedCookies';
+import { hasConsentForUseCase } from '@guardian/consent-management-platform';
+import type { ConsentUseCases } from '@guardian/consent-management-platform/types/consentUseCases';
+
+/**
+ * Set a session cookie. If it's been memoized it will replace memoized value
+ * @param details Details about the cookie.
+ * @param details.name - the cookie’s name.
+ * @param details.value - the cookie’s value.
+ */
+
+export const setSessionCookie = async ({
+	useCase,
+	name,
+	value,
+}: {
+	useCase: ConsentUseCases;
+	name: string;
+	value: string;
+}): Promise<void> => {
+	if (
+		useCase == 'No consent required' ||
+		(await hasConsentForUseCase(useCase))
+	) {
+		if (!isValidCookie(name, value)) {
+			throw new Error(`${ERR_INVALID_COOKIE} ${name}=${value}`);
+		}
+
+		document.cookie = `${name}=${value}; path=/;${getDomainAttribute()}`;
+
+		// If the cookie is already memoized we want to replace its value
+		if (memoizedCookies.has(name)) {
+			const [value] = getCookieValues(name);
+			if (value) {
+				memoizedCookies.set(name, value);
+			}
+		}
+	}
+};

--- a/libs/@guardian/storage-and-cookies/src/index.test.ts
+++ b/libs/@guardian/storage-and-cookies/src/index.test.ts
@@ -1,0 +1,16 @@
+import * as packageExports from './index';
+
+describe('The package', () => {
+	it('exports everything it did before', () => {
+		expect(Object.keys(packageExports).sort()).toEqual([
+			'getCookie',
+			'removeCookie',
+			'setCookie',
+			'setSessionCookie',
+			'storage',
+		]);
+	});
+});
+
+// @ts-expect-error: make sure the above list are real exports
+export type { ThisTypeDoesNotExist } from './index';

--- a/libs/@guardian/storage-and-cookies/src/index.ts
+++ b/libs/@guardian/storage-and-cookies/src/index.ts
@@ -1,0 +1,10 @@
+/* istanbul ignore file */
+
+export * from './deprecated-exports';
+
+export { getCookie } from './cookies/getCookie';
+export { removeCookie } from './cookies/removeCookie';
+export { setCookie } from './cookies/setCookie';
+export { setSessionCookie } from './cookies/setSessionCookie';
+
+export { storage } from './storage/storage';

--- a/libs/@guardian/storage-and-cookies/src/storage/storage.test.ts
+++ b/libs/@guardian/storage-and-cookies/src/storage/storage.test.ts
@@ -1,0 +1,174 @@
+import { storage } from './storage';
+
+function functionThatThrowsAnError() {
+	throw new Error('bang');
+}
+
+type StorageName = 'local' | 'session';
+const LOCAL: StorageName = 'local';
+const SESSION: StorageName = 'session';
+
+describe.each([
+	[LOCAL, storage[LOCAL], globalThis.localStorage],
+	[SESSION, storage[SESSION], globalThis.sessionStorage],
+])('storage.%s', (name, implementation, native) => {
+	let getSpy: jest.SpyInstance;
+	let setSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		getSpy = jest.spyOn(native.__proto__, 'getItem');
+		setSpy = jest.spyOn(native.__proto__, 'setItem');
+		jest.resetModules();
+		native.clear();
+	});
+
+	afterEach(() => {
+		getSpy.mockRestore();
+		setSpy.mockRestore();
+	});
+
+	it(`detects native API availability`, async () => {
+		expect(implementation.isAvailable()).toBe(true);
+
+		setSpy.mockImplementation(functionThatThrowsAnError);
+		getSpy.mockImplementation(functionThatThrowsAnError);
+
+		// re-import now we've disabled native storage API
+		const { storage } = await import('./storage');
+		expect(storage[name].isAvailable()).toBe(false);
+	});
+
+	it(`is not available if getItem does not return what you setItem`, async () => {
+		getSpy.mockImplementation(() => '🚫');
+
+		// re-import now we've fiddled with the native storage API
+		const { storage } = await import('./storage');
+		expect(storage[name].isAvailable()).toBe(false);
+	});
+
+	it(`behaves nicely when storage is not available`, async () => {
+		setSpy.mockImplementation(functionThatThrowsAnError);
+		getSpy.mockImplementation(functionThatThrowsAnError);
+
+		// re-import now we've disabled native storage API
+		const { storage } = await import('./storage');
+		expect(() => storage[name].set('🚫', true)).not.toThrowError();
+		expect(() => storage[name].get('🚫')).not.toThrowError();
+		expect(() => storage[name].remove('🚫')).not.toThrowError();
+		expect(() => storage[name].getRaw('🚫')).not.toThrowError();
+		expect(() => storage[name].setRaw('🚫', '')).not.toThrowError();
+		expect(() => storage[name].clear()).not.toThrowError();
+	});
+
+	it.each([
+		['strings', 'a string'],
+		['empty strings', ''],
+		['objects', { foo: 'bar' }],
+		['arrays', [true, 2, 'bar']],
+		['true booleans', true],
+		['false booleans', false],
+		['null', null],
+	])('stores and retrieves %s', (type, data) => {
+		implementation.set(type, data);
+		expect(native.getItem(type)).toBe(`{"value":${JSON.stringify(data)}}`);
+		expect(implementation.get(type)).toEqual(data);
+	});
+
+	it(`does not return a non-existing item`, () => {
+		expect(implementation.get('thisDoesNotExist')).toBeNull();
+	});
+
+	it(`does not return an expired item`, () => {
+		implementation.set('iAmExpired', 'data', new Date('1901-01-01'));
+		expect(implementation.get('iAmExpired')).toBeNull();
+
+		// check it's been deleted too
+		expect(native.getItem('iAmExpired')).toBeNull();
+	});
+
+	it(`return null for a malformed item`, () => {
+		native.setItem('malformed', '[]');
+		expect(implementation.get('malformed')).toBeNull();
+	});
+
+	it(`returns a non-expired item`, () => {
+		implementation.set('iAmNotExpired', 'data', new Date('2040-01-01'));
+		expect(implementation.get('iAmNotExpired')).toBeTruthy();
+	});
+
+	it(`deletes items`, () => {
+		native.setItem('deleteMe', 'please delete me');
+		expect(native.getItem('deleteMe')).toBeTruthy();
+
+		implementation.remove('deleteMe');
+		expect(native.getItem('deleteMe')).toBeNull();
+	});
+
+	it(`clears all items`, () => {
+		native.setItem('deleteMe', 'please delete me');
+		native.setItem('deleteMe2', 'please delete me too');
+
+		implementation.clear();
+
+		expect(native.getItem('deleteMe')).toBeNull();
+		expect(native.getItem('deleteMe2')).toBeNull();
+	});
+
+	it(`gets items in the raw`, async () => {
+		native.setItem('raw item', '🦁');
+		expect(implementation.getRaw('raw item')).toBe('🦁');
+		expect(implementation.get('raw item')).toBeNull();
+
+		setSpy.mockImplementation(functionThatThrowsAnError);
+		getSpy.mockImplementation(functionThatThrowsAnError);
+
+		// re-import now we've disabled native storage API
+		const { storage } = await import('./storage');
+		expect(storage[name].getRaw('raw item')).toBeNull();
+	});
+
+	it(`sets items in the raw`, () => {
+		implementation.setRaw('raw item', '🦁');
+		expect(native.getItem('raw item')).toBe('🦁');
+	});
+
+	it(`gets keys in storage by index`, async () => {
+		expect(implementation.key(0)).toEqual(null);
+
+		native.setItem('item 1', 'some val');
+		native.setItem('item 2', 'some other val');
+		/**
+		 * The underlying native API doesn't guarantee order across different environments,
+		 * so we can't know for sure which key we will retrieve.
+		 */
+		expect(['item 1', 'item 2']).toContain(implementation.key(0));
+
+		native.removeItem('item 1');
+		expect(implementation.key(0)).toEqual('item 2');
+
+		setSpy.mockImplementation(functionThatThrowsAnError);
+		getSpy.mockImplementation(functionThatThrowsAnError);
+
+		// re-import now we've disabled native storage API
+		const { storage } = await import('./storage');
+		expect(storage[name].key(0)).toBeNull();
+	});
+
+	it(`returns the number of items in storage`, async () => {
+		expect(implementation.length()).toEqual(0);
+
+		native.setItem('item 1', 'some val');
+		native.setItem('item 2', 'some other val');
+		expect(implementation.length()).toEqual(2);
+
+		native.removeItem('item 1');
+		expect(implementation.length()).toEqual(1);
+
+		setSpy.mockImplementation(functionThatThrowsAnError);
+		getSpy.mockImplementation(functionThatThrowsAnError);
+
+		// re-import now we've disabled native storage API
+		const { storage } = await import('./storage');
+		expect(storage[name].length()).toEqual(null);
+	});
+});

--- a/libs/@guardian/storage-and-cookies/src/storage/storage.ts
+++ b/libs/@guardian/storage-and-cookies/src/storage/storage.ts
@@ -1,0 +1,192 @@
+import { isObject } from '../isObject/isObject'; //could perhaps use the code from @guardian/libs instead of duplicating
+import { isString } from '../isString/isString';
+import { hasConsentForUseCase } from '@guardian/consent-management-platform';
+import type { ConsentUseCases } from '@guardian/consent-management-platform/types/consentUseCases';
+
+class StorageFactory {
+	#storage: Storage | undefined; // https://mdn.io/Private_class_fields
+
+	constructor(storageHandler: 'localStorage' | 'sessionStorage') {
+		try {
+			const storage = window[storageHandler];
+			const uid = new Date().toString();
+			storage.setItem(uid, uid);
+			const available = storage.getItem(uid) == uid;
+			storage.removeItem(uid);
+			if (available) this.#storage = storage;
+		} catch (e) {
+			// do nothing
+		}
+	}
+
+	/**
+	 * Check whether storage is available.
+	 */
+	isAvailable(): boolean {
+		return Boolean(this.#storage);
+	}
+
+	/**
+	 * Retrieve an item from storage.
+	 *
+	 * @param useCase - the ConsentUseCase for which to get the data
+	 * @param key - the name of the item
+	 */
+	async get(useCase: ConsentUseCases, key: string): Promise<unknown> {
+		try {
+			if (
+				useCase == 'No consent required' ||
+				(await hasConsentForUseCase(useCase))
+			) {
+				const data: unknown = JSON.parse(this.#storage?.getItem(key) ?? '');
+				if (!isObject(data)) return null;
+				const { value, expires } = data;
+
+				// is this item has passed its sell-by-date, remove it
+				if (isString(expires) && new Date() > new Date(expires)) {
+					this.remove(key);
+					return null;
+				}
+
+				return value;
+			} else {
+				return null;
+			}
+		} catch (e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Save a value to storage.
+	 *
+	 * @param useCase - the ConsentUseCase for which to get the data
+	 * @param key - the name of the item
+	 * @param value - the data to save
+	 * @param expires - optional date on which this data will expire
+	 */
+	async set(
+		useCase: ConsentUseCases,
+		key: string,
+		value: unknown,
+		expires?: string | number | Date,
+	): Promise<void> {
+		if (
+			useCase == 'No consent required' ||
+			(await hasConsentForUseCase(useCase))
+		) {
+			return this.#storage?.setItem(
+				key,
+				JSON.stringify({
+					value,
+					expires,
+				}),
+			);
+		}
+	}
+
+	/**
+	 * Remove an item from storage.
+	 *
+	 * @param key - the name of the item
+	 */
+	remove(key: string): void {
+		return this.#storage?.removeItem(key);
+	}
+
+	/**
+	 * Removes all items from storage.
+	 */
+	clear(): void {
+		return this.#storage?.clear();
+	}
+
+	/**
+	 * Retrieve an item from storage in its raw state.
+	 *
+	 * @param useCase - the ConsentUseCase for which to get the data
+	 * @param key - the name of the item
+	 */
+	async getRaw(useCase: ConsentUseCases, key: string): Promise<string | null> {
+		if (
+			useCase == 'No consent required' ||
+			(await hasConsentForUseCase(useCase))
+		) {
+			return this.#storage?.getItem(key) ?? null;
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Save a raw value to storage.
+	 *
+	 * @param useCase - the ConsentUseCase for which to get the data
+	 * @param key - the name of the item
+	 * @param value - the data to save
+	 */
+	async setRaw(
+		useCase: ConsentUseCases,
+		key: string,
+		value: string,
+	): Promise<void> {
+		if (
+			useCase == 'No consent required' ||
+			(await hasConsentForUseCase(useCase))
+		) {
+			return this.#storage?.setItem(key, value);
+		}
+	}
+
+	/**
+	 * Get key by index.
+	 * @returns the name of the key at that index (`string`), or `null` (if
+	 *      index is out of range of if storage is unavailable) - if the index
+	 *      is out of range, or if storage is not available.
+	 *
+	 * Wrapper for the `key` method on the native `Storage` object, with
+	 * additional check for availability of storage. Note that the _order_ of
+	 * keys in storage is dependent on user-agent implementation, and so you
+	 * should not assume that keys will be stored in any particular order (e.g.
+	 * order of insertion).
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Storage/key
+	 */
+	key(index: number): string | null {
+		return this.#storage?.key(index) ?? null;
+	}
+
+	/**
+	 * Get the number of items in storage.
+	 * @returns the number of items in storage, or `null` if storage is
+	 * 	not available.
+	 */
+	length(): number | null {
+		return this.#storage?.length ?? null;
+	}
+}
+
+/**
+ * Manages using `localStorage` and `sessionStorage`.
+ *
+ * Has a few advantages over the native API, including
+ * - failing gracefully if storage is not available
+ * - you can save and retrieve any JSONable data
+ *
+ * All methods are available for both `localStorage` and `sessionStorage`.
+ */
+export const storage = new (class {
+	#local: StorageFactory | undefined;
+	#session: StorageFactory | undefined;
+
+	// creating the instance requires testing the native implementation
+	// which is blocking. therefore, only create new instances of the factory
+	// when it's accessed i.e. we know we're going to use it
+
+	get local() {
+		return (this.#local ||= new StorageFactory('localStorage'));
+	}
+
+	get session() {
+		return (this.#session ||= new StorageFactory('sessionStorage'));
+	}
+})();


### PR DESCRIPTION
## What are you changing?

- add @guardian/storage-and-cookies that does handle consent. Not in @guardian/libs to not have a circular dependency with cmp and libs

- using localStorage/sessionStorage becomes a lint error to encourage moving to @guardian/libs

## Why?

- To unify code usage and enable easier maintenance
