### PR TITLE
Clean up typography CSS output

### DIFF
--- a/libs/@guardian/source-foundations/jest.config.ts
+++ b/libs/@guardian/source-foundations/jest.config.ts
@@ -13,5 +13,8 @@ export default {
 	},
 	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
 	coverageDirectory: '../../../coverage/libs/@guardian/source-foundations',
-	setupFilesAfterEnv: ['./lib/jest-matchers/toBeValidCSS.ts'],
+	setupFilesAfterEnv: [
+		'./lib/jest-matchers/toBeValidCSS.ts',
+		'./lib/jest-matchers/toMatchCSS.ts',
+	],
 };

--- a/libs/@guardian/source-foundations/jest.e2e.setup.ts
+++ b/libs/@guardian/source-foundations/jest.e2e.setup.ts
@@ -8,5 +8,6 @@ import * as dist from '../../../dist/libs/@guardian/source-foundations';
 
 // Register our custom Jest matcher.
 import './lib/jest-matchers/toBeValidCSS';
+import './lib/jest-matchers/toMatchCSS';
 
 jest.mock('./src/index', () => dist);

--- a/libs/@guardian/source-foundations/lib/jest-matchers/index.d.ts
+++ b/libs/@guardian/source-foundations/lib/jest-matchers/index.d.ts
@@ -1,10 +1,11 @@
 declare namespace jest {
 	interface Matchers<R> {
-		toBeValidCSS(options?: ToBeValidCSSOptions): R;
+		toBeValidCSS(options?: CSSMatcherOptions): R;
+		toMatchCSS(expected: string, options?: CSSMatcherOptions): R;
 	}
 }
 
-type ToBeValidCSSOptions = {
+type CSSMatcherOptions = {
 	/**
 	 * Set this to true if the CSS is a fragment (e.g. not wrapped in a selector and valid on its own)
 	 */

--- a/libs/@guardian/source-foundations/lib/jest-matchers/toBeValidCSS.ts
+++ b/libs/@guardian/source-foundations/lib/jest-matchers/toBeValidCSS.ts
@@ -10,7 +10,7 @@ expect.extend({
 	 */
 	toBeValidCSS(
 		received: string,
-		options: ToBeValidCSSOptions = {},
+		options: CSSMatcherOptions = {},
 	): jest.CustomMatcherResult {
 		const { isFragment = false } = options;
 

--- a/libs/@guardian/source-foundations/lib/jest-matchers/toMatchCSS.ts
+++ b/libs/@guardian/source-foundations/lib/jest-matchers/toMatchCSS.ts
@@ -34,7 +34,10 @@ expect.extend({
 				normalisedReceivedCSS.code.toString() !==
 				normalisedExpectedCSS.code.toString()
 			) {
-				throw new Error('Received CSS does not match expected CSS.');
+				throw new Error(
+					'Received CSS does not match expected CSS\n\n' +
+						normalisedReceivedCSS.code.toString(),
+				);
 			}
 
 			return {

--- a/libs/@guardian/source-foundations/lib/jest-matchers/toMatchCSS.ts
+++ b/libs/@guardian/source-foundations/lib/jest-matchers/toMatchCSS.ts
@@ -1,0 +1,53 @@
+import type { Warning } from 'lightningcss';
+import { transform } from 'lightningcss';
+
+expect.extend({
+	/**
+	 * Uses lightningcss library to normalise and compare given CSS
+	 *
+	 * @param received - The CSS to compare
+	 * @param options - Specify whether the CSS being compared is a fragment (not wrapped in a selector)
+	 */
+	toMatchCSS(
+		received: string,
+		expected: string,
+		options: CSSMatcherOptions = {},
+	): jest.CustomMatcherResult {
+		const { isFragment = false } = options;
+
+		// We wrap the CSS in a selector if it is a fragment to ensure it is valid.
+		const recievedCSS = isFragment ? `* { ${received} }` : received;
+		const expectedCSS = isFragment ? `* { ${expected} }` : expected;
+
+		try {
+			const normalisedReceivedCSS = transform({
+				code: Buffer.from(recievedCSS, 'utf8'),
+				filename: '',
+			});
+
+			const normalisedExpectedCSS = transform({
+				code: Buffer.from(expectedCSS, 'utf8'),
+				filename: '',
+			});
+
+			if (
+				normalisedReceivedCSS.code.toString() !==
+				normalisedExpectedCSS.code.toString()
+			) {
+				throw new Error('Received CSS does not match expected CSS.');
+			}
+
+			return {
+				pass: true,
+				message: () => '',
+			};
+		} catch (error) {
+			const message = (error as Warning).message;
+			if (!message) throw error;
+			return {
+				pass: false,
+				message: () => message,
+			};
+		}
+	},
+});

--- a/libs/@guardian/source-foundations/src/tokens.test.ts
+++ b/libs/@guardian/source-foundations/src/tokens.test.ts
@@ -499,342 +499,216 @@ describe('Typography tokens', () => {
 
 describe('Typography API CSS output', () => {
 	it('should match expected output', () => {
-		expect(textSans.xxsmall()).toEqual(`
+		expect(textSans.xxsmall()).toMatchCSS(
+			`
 			font-family: GuardianTextSans, "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 			font-size: 0.75rem;
 			line-height: 1.3;
 			font-weight: 400;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 2px;
-		`);
-		expect(textSans.xsmall()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(textSans.xsmall()).toMatchCSS(
+			`
 			font-family: GuardianTextSans, "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 			font-size: 0.875rem;
 			line-height: 1.3;
 			font-weight: 400;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 2px;
-		`);
-		expect(textSans.small()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(textSans.small()).toMatchCSS(
+			`
 			font-family: GuardianTextSans, "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 			font-size: 0.9375rem;
 			line-height: 1.3;
 			font-weight: 400;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 2px;
-		`);
-		expect(textSans.medium()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(textSans.medium()).toMatchCSS(
+			`
 			font-family: GuardianTextSans, "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 			font-size: 1.0625rem;
 			line-height: 1.3;
 			font-weight: 400;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 2px;
-		`);
-		expect(textSans.large()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(textSans.large()).toMatchCSS(
+			`
 			font-family: GuardianTextSans, "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 			font-size: 1.25rem;
 			line-height: 1.3;
 			font-weight: 400;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 3px;
-		`);
-		expect(textSans.xlarge()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(textSans.xlarge()).toMatchCSS(
+			`
 			font-family: GuardianTextSans, "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 			font-size: 1.5rem;
 			line-height: 1.3;
 			font-weight: 400;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 3px;
-		`);
-		expect(textSans.xxlarge()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(textSans.xxlarge()).toMatchCSS(
+			`
 			font-family: GuardianTextSans, "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 			font-size: 1.75rem;
 			line-height: 1.3;
 			font-weight: 400;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 3px;
-		`);
-		expect(textSans.xxxlarge()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(textSans.xxxlarge()).toMatchCSS(
+			`
 			font-family: GuardianTextSans, "Guardian Text Sans Web", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 			font-size: 2.125rem;
 			line-height: 1.3;
 			font-weight: 400;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 4px;
-		`);
-		expect(body.xsmall()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(body.xsmall()).toMatchCSS(
+			`
 			font-family: GuardianTextEgyptian, "Guardian Text Egyptian Web", Georgia, serif;
 			font-size: 0.875rem;
 			line-height: 1.4;
 			font-weight: 400;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 2px;
-		`);
-		expect(body.small()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(body.small()).toMatchCSS(
+			`
 			font-family: GuardianTextEgyptian, "Guardian Text Egyptian Web", Georgia, serif;
 			font-size: 0.9375rem;
 			line-height: 1.4;
 			font-weight: 400;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 2px;
-		`);
-		expect(body.medium()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(body.medium()).toMatchCSS(
+			`
 			font-family: GuardianTextEgyptian, "Guardian Text Egyptian Web", Georgia, serif;
 			font-size: 1.0625rem;
 			line-height: 1.4;
 			font-weight: 400;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 2px;
-		`);
-		expect(headline.xxxsmall()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(headline.xxxsmall()).toMatchCSS(
+			`
 			font-family: "GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
 			font-size: 1.0625rem;
 			line-height: 1.15;
 			font-weight: 500;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 2px;
-		`);
-		expect(headline.xxsmall()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(headline.xxsmall()).toMatchCSS(
+			`
 			font-family: "GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
 			font-size: 1.25rem;
 			line-height: 1.15;
 			font-weight: 500;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 3px;
-		`);
-		expect(headline.xsmall()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(headline.xsmall()).toMatchCSS(
+			`
 			font-family: "GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
 			font-size: 1.5rem;
 			line-height: 1.15;
 			font-weight: 500;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 3px;
-		`);
-		expect(headline.small()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(headline.small()).toMatchCSS(
+			`
 			font-family: "GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
 			font-size: 1.75rem;
 			line-height: 1.15;
 			font-weight: 500;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 3px;
-		`);
-		expect(headline.medium()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(headline.medium()).toMatchCSS(
+			`
 			font-family: "GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
 			font-size: 2.125rem;
 			line-height: 1.15;
 			font-weight: 500;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 4px;
-		`);
-		expect(headline.large()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(headline.large()).toMatchCSS(
+			`
 			font-family: "GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
 			font-size: 2.625rem;
 			line-height: 1.15;
 			font-weight: 500;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 5px;
-		`);
-		expect(headline.xlarge()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(headline.xlarge()).toMatchCSS(
+			`
 			font-family: "GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
 			font-size: 3.125rem;
 			line-height: 1.15;
 			font-weight: 500;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 6px;
-		`);
-		expect(titlepiece.small()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(titlepiece.small()).toMatchCSS(
+			`
 			font-family: "GT Guardian Titlepiece", Georgia, serif;
 			font-size: 2.625rem;
 			line-height: 1.15;
 			font-weight: 700;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 5px;
-		`);
-		expect(titlepiece.medium()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(titlepiece.medium()).toMatchCSS(
+			`
 			font-family: "GT Guardian Titlepiece", Georgia, serif;
 			font-size: 3.125rem;
 			line-height: 1.15;
 			font-weight: 700;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 6px;
-		`);
-		expect(titlepiece.large()).toEqual(`
+		`,
+			{ isFragment: true },
+		);
+		expect(titlepiece.large()).toMatchCSS(
+			`
 			font-family: "GT Guardian Titlepiece", Georgia, serif;
 			font-size: 4.375rem;
 			line-height: 1.15;
 			font-weight: 700;
-			;
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
 			--source-text-decoration-thickness: 6px;
-		`);
+		`,
+			{ isFragment: true },
+		);
 	});
 });
 

--- a/libs/@guardian/source-foundations/src/typography/font-styles.ts
+++ b/libs/@guardian/source-foundations/src/typography/font-styles.ts
@@ -130,16 +130,8 @@ export const fontStyleToStringFunction =
 			font-family: ${fontFamily};
 			font-size: ${typeof fontSize === 'number' ? `${fontSize}px` : fontSize};
 			line-height: ${lineHeight};
-			${fontWeight ? `font-weight: ${fontWeight}` : ''};
-			${fontStyle ? `font-style: ${fontStyle}` : ''};
-
-			/*
-			 * Child elements (e.g. <Link/>) can use this variable
-			 * to set the thickness of their underline.
-			 *
-			 * The thickness for each font type and weight is defined
-			 * in the underlineThickness object.
-			 */
+			${fontWeight ? `font-weight: ${fontWeight};` : ''}
+			${fontStyle ? `font-style: ${fontStyle};` : ''}
 			--source-text-decoration-thickness: ${
 				textDecorationThickness === undefined
 					? 'auto'


### PR DESCRIPTION
## What are you changing?

- Strips out comment from typography CSS and places semicolons in correct place so they're not rendered if the corresponding property has no value and is not output
- Adds custom Jest matcher to normalise CSS with [Lightning CSS](https://lightningcss.dev/) and match the result

## Why?

- Our snapshot tests are more verbose than they need to be due to the unnecessary output from the typography API
- By normalising the expected and received CSS with a custom matcher we don't need to worry about formatting and whitespace in the tests and can concentrate on the correct properties and values being present