### PR TITLE
Identity Auth | Change `isSignedIn` check logic

### DIFF
--- a/.changeset/cold-cycles-exercise.md
+++ b/.changeset/cold-cycles-exercise.md
@@ -1,0 +1,5 @@
+---
+'@guardian/identity-auth': patch
+---
+
+Update `isSignedIn` logic to use `GU_SO` cookie correctly

--- a/.changeset/yellow-poets-smash.md
+++ b/.changeset/yellow-poets-smash.md
@@ -1,0 +1,5 @@
+---
+'@guardian/identity-auth': patch
+---
+
+Remove `GU_U` cookie if we fail to get tokens with it, as it's likely invalid

--- a/libs/@guardian/identity-auth/src/identityAuth.ts
+++ b/libs/@guardian/identity-auth/src/identityAuth.ts
@@ -1,4 +1,4 @@
-import { getCookie } from '@guardian/libs';
+import { getCookie, removeCookie } from '@guardian/libs';
 import type {
 	IdentityAuthOptions,
 	IdentityAuthState,
@@ -153,6 +153,10 @@ export class IdentityAuth<
 						idToken: tokens.idToken,
 						isAuthenticated: true,
 					};
+				} else {
+					// if we weren't able to get the tokens, despite having a GU_U cookie, the user is not signed in
+					// we should clear the GU_U cookie, as it is likely invalid
+					removeCookie({ name: 'GU_U' });
 				}
 			}
 
@@ -165,7 +169,10 @@ export class IdentityAuth<
 		} catch (error) {
 			// check if the error is an OAuthError and the error is login_required, in which case the user is not signed in
 			if (error instanceof OAuthError && error.error === 'login_required') {
-				// so return isAuthenticated: false
+				// remove the GU_U cookie, as it is likely invalid
+				removeCookie({ name: 'GU_U' });
+
+				// and return isAuthenticated: false
 				return {
 					accessToken: undefined,
 					idToken: undefined,

--- a/libs/@guardian/identity-auth/src/identityAuth.ts
+++ b/libs/@guardian/identity-auth/src/identityAuth.ts
@@ -84,33 +84,57 @@ export class IdentityAuth<
 	 *
 	 * This performs side effects.
 	 *
-	 * 1. If the user has a GU_SO cookie, they have recently signed out, so we should clear their tokens (side effect)
-	 * 2. If user tokens already exist, they are signed in
-	 * 3. If the user doesn't have tokens, but they have a GU_U cookie, they are "maybe" signed in
-	 *   a. We can try to get tokens without prompting/redirecting the user for credentials (side effect)
+	 * This follows the flowchart from https://github.com/guardian/gateway/blob/main/docs/okta/web-apps-integration-guide.md#how-to-know-if-a-reader-is-signed-in to determine if the user is signed in
+	 *
+	 * 1. If the user tokens already exist, then verify them to make sure they are still valid
+	 * 2. If they do, check if the user has a `GU_SO` cookie and compare it to the `iat` value of the id token
+	 *   a. If the `GU_SO` cookie value is greater than the `iat` value, the user has recently signed out, so we should clear their tokens (side effect)
+	 *   b. Otherwise, the user is signed in, so return the auth state
+	 * 3. If the user doesn't have tokens, but they have a `GU_U` cookie, they are "maybe" signed in
+	 *  a. We can try to get tokens without prompting/redirecting the user for credentials (side effect)
+	 * 	b. If no tokens are returned, we clear the `GU_U` cookie, as it is likely invalid (side effect)
+	 *  c. If there is an error getting the tokens:
+	 *    i. If the error is an `OAuthError` and the error is `login_required`, the user is not signed in, so we clear the `GU_U` cookie, as it is likely invalid (side effect)
+	 *    ii. Otherwise, there is an unknown error, so clear any tokens and throw the error
 	 * 4. If the user doesn't have tokens or a GU_U cookie, they are not signed in
 	 *
 	 * @returns `AuthState` - Returns the current authentication state
 	 */
 	public async isSignedInWithAuthState(): Promise<IdentityAuthState<AC, IC>> {
 		try {
-			// if the user has a GU_SO cookie, they have recently signed out, so we should clear their tokens
-			// the GU_SO cookie will be automatically cleared when the user signs back in
-			if (getCookie({ name: 'GU_SO', shouldMemoize: true })) {
-				this.tokenManager.clear();
-				return {
-					accessToken: undefined,
-					idToken: undefined,
-					isAuthenticated: false,
-				};
-			}
-
-			// if user tokens already exist, they are signed in
+			// first check if the user has valid access and id tokens
 			const authState = this.authStateManager.getAuthState();
+			// if they do we need to check if a user has recently signed out
 			if (authState.isAuthenticated) {
 				// validate the id token and access token to make sure auth state is still valid
 				await this.token.verifyTokens(authState.idToken, authState.accessToken);
 
+				// if a user has a GU_SO cookie, they might have recently signed out
+				const guSoCookie = parseInt(
+					getCookie({ name: 'GU_SO', shouldMemoize: true }) ?? '',
+				);
+
+				// calculate the clock skew between the user's device and the server
+				const normalisedCurrentTime =
+					Math.floor(Date.now() / 1000) - authState.idToken.clockSkew;
+
+				// if the GU_SO cookie value (the timestamp when a user last signed out) is greater than the id token's iat (issued at) value,
+				// then the user has recently signed out, so we should clear their tokens
+				if (
+					// make sure that the GU_SO cookie is in the past
+					guSoCookie <= normalisedCurrentTime &&
+					// compare the GU_SO cookie to the id token's iat value
+					guSoCookie > authState.idToken.claims.iat
+				) {
+					this.tokenManager.clear();
+					return {
+						accessToken: undefined,
+						idToken: undefined,
+						isAuthenticated: false,
+					};
+				}
+
+				// otherwise the user is signed in, so return the auth state
 				// if the id token is valid, return the auth state
 				return authState;
 			}
@@ -161,10 +185,18 @@ export class IdentityAuth<
 	 *
 	 * This performs side effects.
 	 *
-	 * 1. If the user has a GU_SO cookie, they have recently signed out, so we should clear their tokens (side effect)
-	 * 2. If user tokens already exist, they are signed in
-	 * 3. If the user doesn't have tokens, but they have a GU_U cookie, they are "maybe" signed in
-	 *   a. We can try to get tokens without prompting/redirecting the user for credentials (side effect)
+	 * This follows the flowchart from https://github.com/guardian/gateway/blob/main/docs/okta/web-apps-integration-guide.md#how-to-know-if-a-reader-is-signed-in to determine if the user is signed in
+	 *
+	 * 1. If the user tokens already exist, then verify them to make sure they are still valid
+	 * 2. If they do, check if the user has a `GU_SO` cookie and compare it to the `iat` value of the id token
+	 *   a. If the `GU_SO` cookie value is greater than the `iat` value, the user has recently signed out, so we should clear their tokens (side effect)
+	 *   b. Otherwise, the user is signed in, so return the auth state
+	 * 3. If the user doesn't have tokens, but they have a `GU_U` cookie, they are "maybe" signed in
+	 *  a. We can try to get tokens without prompting/redirecting the user for credentials (side effect)
+	 * 	b. If no tokens are returned, we clear the `GU_U` cookie, as it is likely invalid (side effect)
+	 *  c. If there is an error getting the tokens:
+	 *    i. If the error is an `OAuthError` and the error is `login_required`, the user is not signed in, so we clear the `GU_U` cookie, as it is likely invalid (side effect)
+	 *    ii. Otherwise, there is an unknown error, so clear any tokens and throw the error
 	 * 4. If the user doesn't have tokens or a GU_U cookie, they are not signed in
 	 *
 	 * @returns `boolean` - `true` if the user is signed in, `false` if not


### PR DESCRIPTION
## What are you changing?

- Updates the `isSignedIn` check logic to use the `GU_SO` cookie correctly
- Clear the `GU_U` cookie if we fail to get tokens, as it's likely invalidly set

## Why?

- We discovered an issue in the way that the `GU_SO` cookie works, meaning that a user could sign out, then immediately sign in again as a new user, but the tokens for the old user had not been cleared yet.
  - The problem and solution have been outlined in detail within this PR: https://github.com/guardian/gateway/pull/2529
  - And the documentation was updated in this PR: https://github.com/guardian/gateway/pull/2530
- Regarding the `GU_U` cookie, we should clear this cookie if we fail to get tokens, as otherwise the library will keep trying to get tokens, causing unnecessary API calls, and could if this affected multiple users at once cause our API limits to be reached on the token endpoint