### PR TITLE
Update `InlineError` warning icon

### DIFF
--- a/.changeset/lucky-queens-clean.md
+++ b/.changeset/lucky-queens-clean.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': major
+---
+
+Replaces triangular warning icon in `InlineError` with circular version for consistency with rest of icon set

--- a/libs/@guardian/source-react-components/src/user-feedback/InlineError.tsx
+++ b/libs/@guardian/source-react-components/src/user-feedback/InlineError.tsx
@@ -1,5 +1,5 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import { SvgAlertTriangle } from '../../vendor/icons/SvgAlertTriangle';
+import { SvgAlertRound } from '../../vendor/icons/SvgAlertRound';
 import type { Theme } from '../@types/Theme';
 import { inlineError } from './styles';
 import type { UserFeedbackProps } from './types';
@@ -24,7 +24,7 @@ export const InlineError = ({
 		role="alert"
 		{...props}
 	>
-		<SvgAlertTriangle />
+		<SvgAlertRound />
 		{children}
 	</span>
 );


### PR DESCRIPTION
## What are you changing?

- Updates triangular warning icon with circular version.

## Why?

- The new rounded icon is now in keeping with the icon set and it also future-proofs us for using these icons as navigation badges.

## Screenshots

### Before

<img width="224" alt="Screenshot 2024-01-11 at 17 29 41" src="https://github.com/guardian/csnx/assets/1166188/47f6560d-c928-425a-8dbd-ac1612d4a0ad">

### After

<img width="227" alt="Screenshot 2024-01-11 at 17 29 36" src="https://github.com/guardian/csnx/assets/1166188/fb2209d4-829a-4eaf-8907-f9d007906235">
