### PR TITLE
feat(eslint-config-typescript): Improve performance by delegating to `tsc`

### DIFF
--- a/.changeset/few-files-attend.md
+++ b/.changeset/few-files-attend.md
@@ -1,0 +1,7 @@
+---
+'@guardian/eslint-config-typescript': minor
+---
+
+Improve performance by delegating namespace import to TypeScript.
+
+See https://typescript-eslint.io/linting/troubleshooting/performance-troubleshooting/#eslint-plugin-import.

--- a/libs/@guardian/eslint-config-typescript/index.js
+++ b/libs/@guardian/eslint-config-typescript/index.js
@@ -125,5 +125,9 @@ module.exports = {
 
 		// requires any function or method that returns a Promise to be marked async
 		// '@typescript-eslint/promise-function-async': 2,
+
+		// Performance boost, as TypeScript provides the same checks as part of standard type checking.
+		// See https://typescript-eslint.io/linting/troubleshooting/performance-troubleshooting/#eslint-plugin-import
+		'import/namespace': 0,
 	},
 };


### PR DESCRIPTION
## What are you changing?
Do not evaluate the `import/namespace` rule as it is already performed by TypeScript. See https://typescript-eslint.io/linting/troubleshooting/performance-troubleshooting/#eslint-plugin-import.

Disabling it significantly improves performance (see below).

With the rule disabled, `tsc` correctly reports errors, as does the IDE. That is, there is little risk to disabling this rule.

<details><summary>TSC in CI</summary>
<p>

![8chwct](https://github.com/guardian/csnx/assets/836140/78ecb135-fcb5-47a0-be87-6ce32edbc7dc)

</p>
</details> 

## Why?
In the `guardian/service-catalogue` repository this check takes the majority of time:

```console
➜ TIMING=1 npm run lint

> service-catalogue@0.0.1 lint
> eslint packages/** --ext .ts --no-error-on-unmatched-pattern

Rule                                    | Time (ms) | Relative
:---------------------------------------|----------:|--------:
import/namespace                        |  4356.068 |    71.4%
prettier/prettier                       |   736.141 |    12.1%
@typescript-eslint/no-misused-promises  |   259.937 |     4.3%
import/no-cycle                         |   174.544 |     2.9%
@typescript-eslint/no-unsafe-return     |    89.328 |     1.5%
@typescript-eslint/no-unsafe-assignment |    88.562 |     1.5%
@typescript-eslint/no-floating-promises |    64.431 |     1.1%
@typescript-eslint/naming-convention    |    60.667 |     1.0%
@typescript-eslint/no-unsafe-argument   |    54.266 |     0.9%
import/no-unresolved                    |    43.033 |     0.7%
```

With the rule disabled, we have:

```console
➜ TIMING=1 npm run lint

> service-catalogue@0.0.1 lint
> eslint packages/** --ext .ts --no-error-on-unmatched-pattern

Rule                                    | Time (ms) | Relative
:---------------------------------------|----------:|--------:
prettier/prettier                       |   732.655 |    34.4%
import/no-cycle                         |   405.922 |    19.1%
@typescript-eslint/no-misused-promises  |   275.311 |    12.9%
import/order                            |   116.622 |     5.5%
@typescript-eslint/no-unsafe-return     |    95.647 |     4.5%
@typescript-eslint/no-unsafe-assignment |    88.547 |     4.2%
@typescript-eslint/no-floating-promises |    80.920 |     3.8%
@typescript-eslint/naming-convention    |    66.983 |     3.1%
@typescript-eslint/no-unsafe-argument   |    59.754 |     2.8%
import/no-unresolved                    |    57.240 |     2.7%
```