### PR TITLE
Fix Storybook type annotations

### DIFF
--- a/libs/@guardian/source-react-components-development-kitchen/.storybook/preview/FocusManagerDecorator.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/.storybook/preview/FocusManagerDecorator.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 import { FocusStyleManager } from '@guardian/source-foundations';
+import { Decorator } from '@storybook/react';
 
-export const FocusManagerDecorator = (storyFn) => {
+export const FocusManagerDecorator: Decorator = (storyFn) => {
 	useEffect(() => {
 		FocusStyleManager.onlyShowFocusOnTabs();
 	});

--- a/libs/@guardian/source-react-components-development-kitchen/.storybook/preview/ThemeProviderDecorator.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/.storybook/preview/ThemeProviderDecorator.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider } from '@emotion/react';
+import { Decorator } from '@storybook/react';
 
-export const ThemeProviderDecorator = (storyFn, context) => {
+export const ThemeProviderDecorator: Decorator = (storyFn, context) => {
 	const theme = context.parameters.theme;
 	return theme ? (
 		<ThemeProvider theme={theme}>{storyFn()}</ThemeProvider>

--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.stories.tsx
@@ -1,36 +1,42 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { AgeWarningProps } from './AgeWarning';
 import { AgeWarning } from './AgeWarning';
 
-export default {
+const meta: Meta<typeof AgeWarning> = {
 	component: AgeWarning,
 	title: 'AgeWarning',
 };
 
-const Template: Story<AgeWarningProps> = (args: AgeWarningProps) => (
+export default meta;
+
+const Template: StoryFn<typeof AgeWarning> = (args: AgeWarningProps) => (
 	<AgeWarning {...args} />
 );
 
-export const ageWarning = Template.bind({});
+export const ageWarning: StoryFn<typeof AgeWarning> = Template.bind({});
 ageWarning.args = { age: '10 years old' };
 
-export const smallWarning = Template.bind({});
+export const smallWarning: StoryFn<typeof AgeWarning> = Template.bind({});
 smallWarning.args = { age: '5 months old', size: 'small' };
 
-export const screenReaderVersion = Template.bind({});
+export const screenReaderVersion: StoryFn<typeof AgeWarning> = Template.bind(
+	{},
+);
 screenReaderVersion.args = {
 	age: '20 million years old',
 	isScreenReader: true,
 };
 
-export const missingOldText = Template.bind({});
+export const missingOldText: StoryFn<typeof AgeWarning> = Template.bind({});
 missingOldText.args = { age: '5 years' };
 
-export const emptyWarningPrefix = Template.bind({});
+export const emptyWarningPrefix: StoryFn<typeof AgeWarning> = Template.bind({});
 emptyWarningPrefix.args = { age: '5 years', warningPrefix: '' };
 
-export const customWarningPrefix = Template.bind({});
+export const customWarningPrefix: StoryFn<typeof AgeWarning> = Template.bind(
+	{},
+);
 customWarningPrefix.args = { age: '5 years', warningPrefix: 'This book is ' };
 
-export const supportsDarkMode = Template.bind({});
+export const supportsDarkMode: StoryFn<typeof AgeWarning> = Template.bind({});
 supportsDarkMode.args = { age: '10 years old', supportsDarkMode: true };

--- a/libs/@guardian/source-react-components-development-kitchen/src/divider/Divider.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/divider/Divider.stories.tsx
@@ -1,13 +1,15 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { DividerProps } from './Divider';
 import { Divider } from './Divider';
 
-export default {
+const meta: Meta<typeof Divider> = {
 	title: 'Divider',
 	component: Divider,
 };
 
-const Template: Story = (args: DividerProps) => (
+export default meta;
+
+const Template: StoryFn<typeof Divider> = (args: DividerProps) => (
 	<span>
 		<p>
 			The individual responsible for one of the most significant leaks in US
@@ -28,25 +30,25 @@ const Template: Story = (args: DividerProps) => (
 	</span>
 );
 
-export const DefaultDivider = Template.bind({});
+export const DefaultDivider: StoryFn<typeof Divider> = Template.bind({});
 
 // *****************************************************************************
 
-export const TightDivider = Template.bind({});
+export const TightDivider: StoryFn<typeof Divider> = Template.bind({});
 TightDivider.args = {
 	spaceAbove: 'tight',
 };
 
 // *****************************************************************************
 
-export const FullDivider = Template.bind({});
+export const FullDivider: StoryFn<typeof Divider> = Template.bind({});
 FullDivider.args = {
 	size: 'full',
 };
 
 // *****************************************************************************
 
-export const TextDivider = Template.bind({});
+export const TextDivider: StoryFn<typeof Divider> = Template.bind({});
 TextDivider.args = {
 	displayText: 'I am centred',
 };

--- a/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialButton.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialButton.stories.tsx
@@ -6,7 +6,7 @@ import {
 	ArticleSpecial,
 } from '@guardian/libs';
 import { SvgCross } from '@guardian/source-react-components';
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { EditorialButton } from './EditorialButton';
 import type { EditorialButtonProps } from './EditorialButton';
 
@@ -15,7 +15,7 @@ const defaultFormat = {
 	design: ArticleDesign.Standard,
 };
 
-export default {
+const meta: Meta<typeof EditorialButton> = {
 	title: 'EditorialButton',
 	component: EditorialButton,
 	argTypes: {
@@ -55,14 +55,18 @@ export default {
 	args: {
 		size: 'default',
 		hideLabel: false,
-		icon: 'undefined',
+		icon: undefined,
 		priority: 'primary',
 		iconSide: 'left',
 		nudgeIcon: false,
 	},
 };
 
-const Template: Story = (args: EditorialButtonProps) => {
+export default meta;
+
+const Template: StoryFn<typeof EditorialButton> = (
+	args: EditorialButtonProps,
+) => {
 	// Providing any value for cssOverrides, even undefined, overrides the custom styles
 	// for the editorial button so only pass through if it's defined
 	const { cssOverrides, ...rest } = args;
@@ -85,7 +89,7 @@ const pillars = [
 	ArticleSpecial.Labs,
 ];
 
-const RowTemplate: Story<EditorialButtonProps> = (
+const RowTemplate: StoryFn<typeof EditorialButton> = (
 	args: Partial<EditorialButtonProps>,
 ) => (
 	<div
@@ -106,7 +110,9 @@ const RowTemplate: Story<EditorialButtonProps> = (
 	</div>
 );
 
-export const WhenPrimary = RowTemplate.bind({});
+export const WhenPrimary: StoryFn<typeof EditorialButton> = RowTemplate.bind(
+	{},
+);
 WhenPrimary.args = {
 	priority: 'primary',
 	size: 'small',
@@ -114,7 +120,9 @@ WhenPrimary.args = {
 
 // *****************************************************************************
 
-export const WhenSecondary = RowTemplate.bind({});
+export const WhenSecondary: StoryFn<typeof EditorialButton> = RowTemplate.bind(
+	{},
+);
 WhenSecondary.args = {
 	priority: 'secondary',
 	size: 'small',
@@ -122,7 +130,9 @@ WhenSecondary.args = {
 
 // *****************************************************************************
 
-export const WhenTertiary = RowTemplate.bind({});
+export const WhenTertiary: StoryFn<typeof EditorialButton> = RowTemplate.bind(
+	{},
+);
 WhenTertiary.args = {
 	priority: 'tertiary',
 	size: 'small',
@@ -130,7 +140,9 @@ WhenTertiary.args = {
 
 // *****************************************************************************
 
-export const WhenSubdued = RowTemplate.bind({});
+export const WhenSubdued: StoryFn<typeof EditorialButton> = RowTemplate.bind(
+	{},
+);
 WhenSubdued.args = {
 	priority: 'subdued',
 	size: 'small',
@@ -138,7 +150,7 @@ WhenSubdued.args = {
 
 // *****************************************************************************
 
-export const WithOverrides = Template.bind({});
+export const WithOverrides: StoryFn<typeof EditorialButton> = Template.bind({});
 WithOverrides.args = {
 	cssOverrides: css`
 		background-color: pink;
@@ -147,5 +159,5 @@ WithOverrides.args = {
 
 // *****************************************************************************
 
-export const WithDefaults = Template.bind({});
+export const WithDefaults: StoryFn<typeof EditorialButton> = Template.bind({});
 WithDefaults.args = {};

--- a/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialLinkButton.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialLinkButton.stories.tsx
@@ -6,7 +6,7 @@ import {
 	ArticleSpecial,
 } from '@guardian/libs';
 import { SvgCross } from '@guardian/source-react-components';
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { EditorialLinkButton } from './EditorialLinkButton';
 import type { EditorialLinkButtonProps } from './EditorialLinkButton';
 
@@ -15,7 +15,7 @@ const defaultFormat = {
 	design: ArticleDesign.Standard,
 };
 
-export default {
+const meta: Meta<typeof EditorialLinkButton> = {
 	title: 'EditorialLinkButton',
 	component: EditorialLinkButton,
 	argTypes: {
@@ -55,14 +55,18 @@ export default {
 	args: {
 		size: 'default',
 		hideLabel: false,
-		icon: 'undefined',
+		icon: undefined,
 		priority: 'primary',
 		iconSide: 'left',
 		nudgeIcon: false,
 	},
 };
 
-const Template: Story = (args: EditorialLinkButtonProps) => {
+export default meta;
+
+const Template: StoryFn<typeof EditorialLinkButton> = (
+	args: EditorialLinkButtonProps,
+) => {
 	// Providing any value for cssOverrides, even undefined, overrides the custom styles
 	// for the editorial button so only pass through if it's defined
 	const { cssOverrides, ...rest } = args;
@@ -87,7 +91,7 @@ const pillars = [
 	ArticleSpecial.Labs,
 ];
 
-const RowTemplate: Story<EditorialLinkButtonProps> = (
+const RowTemplate: StoryFn<typeof EditorialLinkButton> = (
 	args: Partial<EditorialLinkButtonProps>,
 ) => (
 	<div
@@ -108,7 +112,8 @@ const RowTemplate: Story<EditorialLinkButtonProps> = (
 	</div>
 );
 
-export const WhenPrimary = RowTemplate.bind({});
+export const WhenPrimary: StoryFn<typeof EditorialLinkButton> =
+	RowTemplate.bind({});
 WhenPrimary.args = {
 	priority: 'primary',
 	size: 'small',
@@ -116,7 +121,8 @@ WhenPrimary.args = {
 
 // *****************************************************************************
 
-export const WhenSecondary = RowTemplate.bind({});
+export const WhenSecondary: StoryFn<typeof EditorialLinkButton> =
+	RowTemplate.bind({});
 WhenSecondary.args = {
 	priority: 'secondary',
 	size: 'small',
@@ -124,7 +130,8 @@ WhenSecondary.args = {
 
 // *****************************************************************************
 
-export const WhenTertiary = RowTemplate.bind({});
+export const WhenTertiary: StoryFn<typeof EditorialLinkButton> =
+	RowTemplate.bind({});
 WhenTertiary.args = {
 	priority: 'tertiary',
 	size: 'small',
@@ -132,7 +139,8 @@ WhenTertiary.args = {
 
 // *****************************************************************************
 
-export const WhenSubdued = RowTemplate.bind({});
+export const WhenSubdued: StoryFn<typeof EditorialLinkButton> =
+	RowTemplate.bind({});
 WhenSubdued.args = {
 	priority: 'subdued',
 	size: 'small',
@@ -140,7 +148,9 @@ WhenSubdued.args = {
 
 // *****************************************************************************
 
-export const WithOverrides = Template.bind({});
+export const WithOverrides: StoryFn<typeof EditorialLinkButton> = Template.bind(
+	{},
+);
 WithOverrides.args = {
 	cssOverrides: css`
 		background-color: pink;
@@ -149,5 +159,7 @@ WithOverrides.args = {
 
 // *****************************************************************************
 
-export const WithDefaults = Template.bind({});
+export const WithDefaults: StoryFn<typeof EditorialLinkButton> = Template.bind(
+	{},
+);
 WithDefaults.args = {};

--- a/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.stories.tsx
@@ -1,6 +1,6 @@
+import type { Meta, StoryFn } from '@storybook/react';
 import { css } from '@emotion/react';
 import { palette } from '@guardian/source-foundations';
-import type { ReactElement } from 'react';
 import { ExpandingWrapper } from './ExpandingWrapper';
 import { expandingWrapperDarkTheme } from './theme';
 
@@ -14,6 +14,13 @@ import { expandingWrapperDarkTheme } from './theme';
  *
  * The following themes are supported: `light`.
  * */
+
+const meta: Meta<typeof ExpandingWrapper> = {
+	component: ExpandingWrapper,
+	title: 'ExpandingWrapper',
+};
+
+export default meta;
 
 const loremStyles = css`
 	padding: 0 10px;
@@ -113,64 +120,51 @@ const renderUpdatedText = () => (
 	</span>
 );
 
-const expandingWrapper = (): ReactElement => {
-	return (
-		<>
-			<ExpandingWrapper renderExtra={renderUpdatedText} name="Lorem Ipsum Text">
-				{Lorem}
-			</ExpandingWrapper>
-			<button>Click me!</button>
-		</>
-	);
-};
+export const ExpandingWrapperDefault: StoryFn<typeof ExpandingWrapper> = () => (
+	<>
+		<ExpandingWrapper renderExtra={renderUpdatedText} name="Lorem Ipsum Text">
+			{Lorem}
+		</ExpandingWrapper>
+		<button>Click me!</button>
+	</>
+);
 
-const expandingWrapperWithDarkTheme = (): ReactElement => {
-	return (
-		<>
-			<ExpandingWrapper
-				name="Lorem Ipsum Text Dark"
-				theme={expandingWrapperDarkTheme}
-			>
-				{Lorem}
-			</ExpandingWrapper>
-			<button>Click me!</button>
-		</>
-	);
-};
+export const ExpandingWrapperWithDarkTheme: StoryFn<
+	typeof ExpandingWrapper
+> = () => (
+	<>
+		<ExpandingWrapper
+			name="Lorem Ipsum Text Dark"
+			theme={expandingWrapperDarkTheme}
+		>
+			{Lorem}
+		</ExpandingWrapper>
+		<button>Click me!</button>
+	</>
+);
 
-const expandingWrapperWithCustomTheme = (): ReactElement => {
-	return (
-		<>
-			<ExpandingWrapper
-				name="Lorem Ipsum With Theme"
-				theme={{
-					'--text': palette.neutral[97],
-					'--background': palette.brand[400],
-					'--border': palette.brand[400],
-					'--collapseBackground': palette.brand[300],
-					'--collapseBackgroundHover': palette.brand[100],
-					'--collapseText': palette.brand[800],
-					'--collapseTextHover': palette.brand[800],
-					'--expandBackground': palette.brand[800],
-					'--expandBackgroundHover': palette.brand[800],
-					'--expandText': palette.brand[100],
-					'--horizontalRules': palette.brand[600],
-				}}
-			>
-				{Lorem}
-			</ExpandingWrapper>
-			<button>Click me!</button>
-		</>
-	);
-};
-
-export default {
-	component: expandingWrapper,
-	title: 'ExpandingWrapper',
-};
-
-export {
-	expandingWrapper,
-	expandingWrapperWithDarkTheme,
-	expandingWrapperWithCustomTheme,
-};
+export const ExpandingWrapperWithCustomTheme: StoryFn<
+	typeof ExpandingWrapper
+> = () => (
+	<>
+		<ExpandingWrapper
+			name="Lorem Ipsum With Theme"
+			theme={{
+				'--text': palette.neutral[97],
+				'--background': palette.brand[400],
+				'--border': palette.brand[400],
+				'--collapseBackground': palette.brand[300],
+				'--collapseBackgroundHover': palette.brand[100],
+				'--collapseText': palette.brand[800],
+				'--collapseTextHover': palette.brand[800],
+				'--expandBackground': palette.brand[800],
+				'--expandBackgroundHover': palette.brand[800],
+				'--expandText': palette.brand[100],
+				'--horizontalRules': palette.brand[600],
+			}}
+		>
+			{Lorem}
+		</ExpandingWrapper>
+		<button>Click me!</button>
+	</>
+);

--- a/libs/@guardian/source-react-components-development-kitchen/src/file-input/FileInput.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/file-input/FileInput.stories.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { FileInput } from './FileInput';
 
 /**
@@ -11,7 +11,14 @@ import { FileInput } from './FileInput';
  * The following themes are supported: `light`.
  * */
 
-const fileInput = (): ReactElement => {
+const meta: Meta<typeof FileInput> = {
+	component: FileInput,
+	title: 'FileInput',
+};
+
+export default meta;
+
+export const FileInputDefault: StoryFn<typeof FileInput> = () => {
 	return (
 		<FileInput
 			id="file-input"
@@ -20,7 +27,8 @@ const fileInput = (): ReactElement => {
 		/>
 	);
 };
-const optionalFileInput = (): ReactElement => {
+
+export const OptionalFileInput: StoryFn<typeof FileInput> = () => {
 	return (
 		<FileInput
 			id="file-input"
@@ -31,7 +39,7 @@ const optionalFileInput = (): ReactElement => {
 	);
 };
 
-const fileInputWithError = (): ReactElement => {
+export const FileInputWithError: StoryFn<typeof FileInput> = () => {
 	return (
 		<FileInput
 			id="file-input"
@@ -42,7 +50,7 @@ const fileInputWithError = (): ReactElement => {
 	);
 };
 
-const fileTypeValidation = (): ReactElement => {
+export const FileTypeValidation: StoryFn<typeof FileInput> = () => {
 	return (
 		<FileInput
 			id="file-input"
@@ -53,7 +61,7 @@ const fileTypeValidation = (): ReactElement => {
 	);
 };
 
-const fileSizeValidation = (): ReactElement => {
+export const FileSizeValidation: StoryFn<typeof FileInput> = () => {
 	return (
 		<FileInput
 			id="file-input"
@@ -64,7 +72,7 @@ const fileSizeValidation = (): ReactElement => {
 	);
 };
 
-const fileInputSizes = (): ReactElement => {
+export const FileInputSizes: StoryFn<typeof FileInput> = () => {
 	return (
 		<>
 			There are three sizes of file input - Default, small and xsmall.
@@ -77,18 +85,4 @@ const fileInputSizes = (): ReactElement => {
 			/>
 		</>
 	);
-};
-
-export default {
-	component: fileInput,
-	title: 'FileInput',
-};
-
-export {
-	fileInput,
-	optionalFileInput,
-	fileInputWithError,
-	fileTypeValidation,
-	fileSizeValidation,
-	fileInputSizes,
 };

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { FooterLinksProps } from './FooterLinks';
 import { defaultGuardianLinks, FooterLinks } from './FooterLinks';
 
-export default {
+const meta: Meta<typeof FooterLinks> = {
 	title: 'FooterLinks',
 	component: FooterLinks,
 	parameters: {
@@ -10,17 +10,23 @@ export default {
 	},
 };
 
-const Template: Story<FooterLinksProps> = (args: FooterLinksProps) => (
+export default meta;
+
+const Template: StoryFn<typeof FooterLinks> = (args: FooterLinksProps) => (
 	<FooterLinks {...args} />
 );
 
 // *****************************************************************************
 
-export const DefaultFooterLinks = Template.bind({});
+export const DefaultFooterLinks: StoryFn<typeof FooterLinks> = Template.bind(
+	{},
+);
 
 // *****************************************************************************
 
-export const FooterLinksInColumns = Template.bind({});
+export const FooterLinksInColumns: StoryFn<typeof FooterLinks> = Template.bind(
+	{},
+);
 FooterLinksInColumns.args = {
 	links: [
 		...defaultGuardianLinks,
@@ -33,7 +39,8 @@ FooterLinksInColumns.args = {
 
 // *****************************************************************************
 
-export const FooterLinksWithFooterButton = Template.bind({});
+export const FooterLinksWithFooterButton: StoryFn<typeof FooterLinks> =
+	Template.bind({});
 FooterLinksWithFooterButton.args = {
 	links: [
 		...defaultGuardianLinks,

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.stories.tsx
@@ -1,4 +1,4 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import {
 	DefaultFooterLinks,
 	FooterLinksInColumns,
@@ -6,7 +6,7 @@ import {
 import type { FooterWithContentsProps } from './FooterWithContents';
 import { FooterWithContents } from './FooterWithContents';
 
-export default {
+const meta: Meta<typeof FooterWithContents> = {
 	title: 'FooterWithContents',
 	component: FooterWithContents,
 	parameters: {
@@ -14,20 +14,24 @@ export default {
 	},
 };
 
-const Template: Story<FooterWithContentsProps> = (
+export default meta;
+
+const Template: StoryFn<typeof FooterWithContents> = (
 	args: FooterWithContentsProps,
 ) => <FooterWithContents {...args} />;
 
 // *****************************************************************************
 
-export const DefaultFooterWithContents = Template.bind({});
+export const DefaultFooterWithContents: StoryFn<typeof FooterWithContents> =
+	Template.bind({});
 DefaultFooterWithContents.args = {
 	children: <DefaultFooterLinks />,
 };
 
 // *****************************************************************************
 
-export const FooterWithColumnLinks = Template.bind({});
+export const FooterWithColumnLinks: StoryFn<typeof FooterWithContents> =
+	Template.bind({});
 FooterWithColumnLinks.args = {
 	children: <FooterLinksInColumns {...FooterLinksInColumns.args} />,
 };

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.tsx
@@ -32,9 +32,7 @@ export const FooterWithContents = ({
 			<ContainerComponent {...footerContainerProps}>
 				<div css={contentWrapperStyles}>
 					{children}
-					<div css={backToTopStyles}>
-						<BackToTop />
-					</div>
+					<div css={backToTopStyles}>{BackToTop}</div>
 				</div>
 			</ContainerComponent>
 			<ContainerComponent

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.tsx
@@ -32,7 +32,9 @@ export const FooterWithContents = ({
 			<ContainerComponent {...footerContainerProps}>
 				<div css={contentWrapperStyles}>
 					{children}
-					<div css={backToTopStyles}>{BackToTop}</div>
+					<div css={backToTopStyles}>
+						<BackToTop />
+					</div>
 				</div>
 			</ContainerComponent>
 			<ContainerComponent

--- a/libs/@guardian/source-react-components-development-kitchen/src/lines/Lines.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/lines/Lines.stories.tsx
@@ -1,19 +1,21 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { DashedLines as DashedLinesComponent } from './DashedLines';
 import { DottedLines as DottedLinesComponent } from './DottedLines';
 import type { LinesProps } from './Lines';
 import { SquigglyLines as SquigglyLinesComponent } from './SquigglyLines';
 import { StraightLines as StraightLinesComponent } from './StraightLines';
 
-export default {
+const meta: Meta<LinesProps> = {
 	title: 'Lines',
 	component: StraightLinesComponent,
 	args: {
-		count: '4',
+		count: 4,
 	},
 };
 
-const Template: Story = (args: LinesProps) => {
+export default meta;
+
+const Template: StoryFn<LinesProps> = (args: LinesProps) => {
 	switch (args.effect) {
 		case 'dotted':
 			return <DottedLinesComponent {...args} />;
@@ -27,53 +29,53 @@ const Template: Story = (args: LinesProps) => {
 	}
 };
 
-export const DefaultLines = Template.bind({});
+export const DefaultLines: StoryFn<LinesProps> = Template.bind({});
 
 // *****************************************************************************
 
-export const DottedLines = Template.bind({});
+export const DottedLines: StoryFn<LinesProps> = Template.bind({});
 DottedLines.args = {
 	effect: 'dotted',
 };
 
 // *****************************************************************************
 
-export const SquigglyLines = Template.bind({});
+export const SquigglyLines: StoryFn<LinesProps> = Template.bind({});
 SquigglyLines.args = {
 	effect: 'squiggly',
 };
 
 // *****************************************************************************
 
-export const DashedLines = Template.bind({});
+export const DashedLines: StoryFn<LinesProps> = Template.bind({});
 DashedLines.args = {
 	effect: 'dashed',
 };
 
 // *****************************************************************************
 
-export const SingleLine = Template.bind({});
+export const SingleLine: StoryFn<LinesProps> = Template.bind({});
 SingleLine.args = {
-	count: '1',
+	count: 1,
 };
 
 // *****************************************************************************
 
-export const FourLines = Template.bind({});
+export const FourLines: StoryFn<LinesProps> = Template.bind({});
 FourLines.args = {
-	count: '4',
+	count: 4,
 };
 
 // *****************************************************************************
 
-export const EightLines = Template.bind({});
+export const EightLines: StoryFn<LinesProps> = Template.bind({});
 EightLines.args = {
-	count: '8',
+	count: 8,
 };
 
 // *****************************************************************************
 
-export const BlueLines = Template.bind({});
+export const BlueLines: StoryFn<LinesProps> = Template.bind({});
 BlueLines.args = {
 	color: 'blue',
 };

--- a/libs/@guardian/source-react-components-development-kitchen/src/logo/Logo.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/logo/Logo.stories.tsx
@@ -1,8 +1,8 @@
 import { breakpoints } from '@guardian/source-foundations';
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Logo } from './Logo';
 
-export default {
+const meta: Meta<typeof Logo> = {
 	title: 'Logo',
 	component: Logo,
 	args: {
@@ -15,7 +15,9 @@ export default {
 	},
 };
 
-const TripleTemplate: Story = () => (
+export default meta;
+
+const TripleTemplate: StoryFn<typeof Logo> = () => (
 	<div>
 		<Logo logoType="standard" />
 		<br />
@@ -27,7 +29,7 @@ const TripleTemplate: Story = () => (
 
 // *****************************************************************************
 
-export const Desktop = TripleTemplate.bind({});
+export const Desktop: StoryFn<typeof Logo> = TripleTemplate.bind({});
 Desktop.parameters = {
 	viewport: {
 		defaultViewport: 'desktop',
@@ -39,7 +41,7 @@ Desktop.parameters = {
 
 // *****************************************************************************
 
-export const Tablet = TripleTemplate.bind({});
+export const Tablet: StoryFn<typeof Logo> = TripleTemplate.bind({});
 Tablet.parameters = {
 	viewport: {
 		defaultViewport: 'tablet',
@@ -51,7 +53,7 @@ Tablet.parameters = {
 
 // *****************************************************************************
 
-export const MobileMedium = TripleTemplate.bind({});
+export const MobileMedium: StoryFn<typeof Logo> = TripleTemplate.bind({});
 MobileMedium.parameters = {
 	viewport: {
 		defaultViewport: 'mobileMedium',
@@ -63,7 +65,7 @@ MobileMedium.parameters = {
 
 // *****************************************************************************
 
-export const Mobile = TripleTemplate.bind({});
+export const Mobile: StoryFn<typeof Logo> = TripleTemplate.bind({});
 Mobile.parameters = {
 	viewport: {
 		defaultViewport: 'mobile',

--- a/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/NumericInput.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/NumericInput.stories.tsx
@@ -1,9 +1,9 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import type { NumericInputProps } from './NumericInput';
 import { NumericInput } from './NumericInput';
 
-export default {
+const meta: Meta<typeof NumericInput> = {
 	title: 'NumericInput',
 	component: NumericInput,
 	args: {
@@ -35,7 +35,9 @@ export default {
 	},
 };
 
-const Template: Story<NumericInputProps> = (args: NumericInputProps) => {
+export default meta;
+
+const Template: StoryFn<typeof NumericInput> = (args: NumericInputProps) => {
 	const [state, setState] = useState('');
 	return (
 		<NumericInput
@@ -46,32 +48,40 @@ const Template: Story<NumericInputProps> = (args: NumericInputProps) => {
 	);
 };
 
-export const DefaultDefaultTheme = Template.bind({});
+export const DefaultDefaultTheme: StoryFn<typeof NumericInput> = Template.bind(
+	{},
+);
 
 // *****************************************************************************
 
-export const OptionalDefaultTheme = Template.bind({});
+export const OptionalDefaultTheme: StoryFn<typeof NumericInput> = Template.bind(
+	{},
+);
 OptionalDefaultTheme.args = {
 	optional: true,
 };
 
 // *****************************************************************************
 
-export const HideLabelDefaultTheme = Template.bind({});
+export const HideLabelDefaultTheme: StoryFn<typeof NumericInput> =
+	Template.bind({});
 HideLabelDefaultTheme.args = {
 	hideLabel: true,
 };
 
 // *****************************************************************************
 
-export const SupportingTextDefaultTheme = Template.bind({});
+export const SupportingTextDefaultTheme: StoryFn<typeof NumericInput> =
+	Template.bind({});
 SupportingTextDefaultTheme.args = {
 	supporting: 'Must be between 6 and 8 digits long',
 };
 
 // *****************************************************************************
 
-export const Width30DefaultTheme = Template.bind({});
+export const Width30DefaultTheme: StoryFn<typeof NumericInput> = Template.bind(
+	{},
+);
 Width30DefaultTheme.args = {
 	width: 30,
 	label: 'Card number',
@@ -79,7 +89,9 @@ Width30DefaultTheme.args = {
 
 // *****************************************************************************
 
-export const Width10DefaultTheme = Template.bind({});
+export const Width10DefaultTheme: StoryFn<typeof NumericInput> = Template.bind(
+	{},
+);
 Width10DefaultTheme.args = {
 	width: 10,
 	label: 'Sort code',
@@ -87,7 +99,9 @@ Width10DefaultTheme.args = {
 
 // *****************************************************************************
 
-export const Width4DefaultTheme = Template.bind({});
+export const Width4DefaultTheme: StoryFn<typeof NumericInput> = Template.bind(
+	{},
+);
 Width4DefaultTheme.args = {
 	width: 4,
 	label: 'Year of birth',
@@ -95,34 +109,38 @@ Width4DefaultTheme.args = {
 
 // *****************************************************************************
 
-export const ErrorWithMessageDefaultTheme = Template.bind({});
+export const ErrorWithMessageDefaultTheme: StoryFn<typeof NumericInput> =
+	Template.bind({});
 ErrorWithMessageDefaultTheme.args = {
 	error: 'error',
 };
 
 // *****************************************************************************
 
-export const SuccessWithMessageDefaultTheme = Template.bind({});
+export const SuccessWithMessageDefaultTheme: StoryFn<typeof NumericInput> =
+	Template.bind({});
 SuccessWithMessageDefaultTheme.args = {
 	success: 'success',
 };
 
 // *****************************************************************************
-export const WithPrefix = Template.bind({});
+export const WithPrefix: StoryFn<typeof NumericInput> = Template.bind({});
 WithPrefix.args = {
 	prefixText: '£',
 	label: 'Contribution amount',
 };
 
 // *****************************************************************************
-export const WithSuffix = Template.bind({});
+export const WithSuffix: StoryFn<typeof NumericInput> = Template.bind({});
 WithSuffix.args = {
 	suffixText: 'kr.',
 	label: 'Contribution amount',
 };
 
 // *****************************************************************************
-export const WithPrefixAndSuffix = Template.bind({});
+export const WithPrefixAndSuffix: StoryFn<typeof NumericInput> = Template.bind(
+	{},
+);
 WithPrefixAndSuffix.args = {
 	prefixText: '£',
 	suffixText: 'per month',
@@ -131,7 +149,9 @@ WithPrefixAndSuffix.args = {
 };
 
 // *****************************************************************************
-export const WithPrefixAndError = Template.bind({});
+export const WithPrefixAndError: StoryFn<typeof NumericInput> = Template.bind(
+	{},
+);
 WithPrefixAndError.args = {
 	prefixText: '£',
 	label: 'Contribution amount',
@@ -139,7 +159,9 @@ WithPrefixAndError.args = {
 };
 
 // *****************************************************************************
-export const WithSuffixAndSuccess = Template.bind({});
+export const WithSuffixAndSuccess: StoryFn<typeof NumericInput> = Template.bind(
+	{},
+);
 WithSuffixAndSuccess.args = {
 	suffixText: 'kr.',
 	label: 'Contribution amount',

--- a/libs/@guardian/source-react-components-development-kitchen/src/quote-icon/QuoteIcon.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/quote-icon/QuoteIcon.stories.tsx
@@ -4,7 +4,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { QuoteIconProps } from './QuoteIcon';
 import { QuoteIcon } from './QuoteIcon';
 
@@ -13,7 +13,7 @@ const defaultFormat = {
 	design: ArticleDesign.Standard,
 };
 
-export default {
+const meta: Meta<typeof QuoteIcon> = {
 	title: 'QuoteIcon',
 	component: QuoteIcon,
 	argTypes: {
@@ -44,7 +44,9 @@ export default {
 	},
 };
 
-const Template: Story<QuoteIconProps> = (args: QuoteIconProps) => (
+export default meta;
+
+const Template: StoryFn<typeof QuoteIcon> = (args: QuoteIconProps) => (
 	<div>
 		<QuoteIcon {...args} />
 		<span>I look like a buffoon. I feel incredible. And then I vomit</span>
@@ -53,7 +55,7 @@ const Template: Story<QuoteIconProps> = (args: QuoteIconProps) => (
 
 // *****************************************************************************
 
-export const News = Template.bind({});
+export const News: StoryFn<typeof QuoteIcon> = Template.bind({});
 News.args = {
 	size: 'medium',
 	// @ts-expect-error - Storybook maps 'news' to ArticlePillar.News
@@ -62,7 +64,7 @@ News.args = {
 
 // *****************************************************************************
 
-export const Sport = Template.bind({});
+export const Sport: StoryFn<typeof QuoteIcon> = Template.bind({});
 Sport.args = {
 	size: 'medium',
 	// @ts-expect-error - Storybook maps 'news' to ArticlePillar.Sport
@@ -71,7 +73,7 @@ Sport.args = {
 
 // *****************************************************************************
 
-export const Culture = Template.bind({});
+export const Culture: StoryFn<typeof QuoteIcon> = Template.bind({});
 Culture.args = {
 	size: 'medium',
 	// @ts-expect-error - Storybook maps 'news' to ArticlePillar.Culture
@@ -80,7 +82,7 @@ Culture.args = {
 
 // *****************************************************************************
 
-export const Lifestyle = Template.bind({});
+export const Lifestyle: StoryFn<typeof QuoteIcon> = Template.bind({});
 Lifestyle.args = {
 	size: 'medium',
 	// @ts-expect-error - Storybook maps 'news' to ArticlePillar.Lifestyle
@@ -89,7 +91,7 @@ Lifestyle.args = {
 
 // *****************************************************************************
 
-export const Opinion = Template.bind({});
+export const Opinion: StoryFn<typeof QuoteIcon> = Template.bind({});
 Opinion.args = {
 	size: 'medium',
 	// @ts-expect-error - Storybook maps 'news' to ArticlePillar.Opinion
@@ -98,7 +100,7 @@ Opinion.args = {
 
 // *****************************************************************************
 
-export const SpecialReport = Template.bind({});
+export const SpecialReport: StoryFn<typeof QuoteIcon> = Template.bind({});
 SpecialReport.args = {
 	size: 'medium',
 	// @ts-expect-error - Storybook maps 'news' to ArticlePillar.SpecialReport
@@ -107,7 +109,7 @@ SpecialReport.args = {
 
 // *****************************************************************************
 
-export const Labs = Template.bind({});
+export const Labs: StoryFn<typeof QuoteIcon> = Template.bind({});
 Labs.args = {
 	size: 'medium',
 	// @ts-expect-error - Storybook maps 'news' to ArticlePillar.Labs
@@ -116,7 +118,7 @@ Labs.args = {
 
 // *****************************************************************************
 
-export const XSmall = Template.bind({});
+export const XSmall: StoryFn<typeof QuoteIcon> = Template.bind({});
 XSmall.args = {
 	size: 'xsmall',
 	// @ts-expect-error - Storybook maps 'news' to ArticlePillar.News
@@ -125,7 +127,7 @@ XSmall.args = {
 
 // *****************************************************************************
 
-export const Small = Template.bind({});
+export const Small: StoryFn<typeof QuoteIcon> = Template.bind({});
 Small.args = {
 	size: 'small',
 	// @ts-expect-error - Storybook maps 'news' to ArticlePillar.News
@@ -134,7 +136,7 @@ Small.args = {
 
 // *****************************************************************************
 
-export const Medium = Template.bind({});
+export const Medium: StoryFn<typeof QuoteIcon> = Template.bind({});
 Medium.args = {
 	size: 'medium',
 	// @ts-expect-error - Storybook maps 'news' to ArticlePillar.News
@@ -143,7 +145,7 @@ Medium.args = {
 
 // *****************************************************************************
 
-export const Large = Template.bind({});
+export const Large: StoryFn<typeof QuoteIcon> = Template.bind({});
 Large.args = {
 	size: 'large',
 	// @ts-expect-error - Storybook maps 'news' to ArticlePillar.News

--- a/libs/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { StarRatingProps } from './StarRating';
 import { StarRating } from './StarRating';
 
-export default {
+const meta: Meta<typeof StarRating> = {
 	title: 'Star Rating',
 	component: StarRating,
 	args: {
@@ -11,67 +11,69 @@ export default {
 	},
 };
 
-const Template: Story<StarRatingProps> = (args: StarRatingProps) => (
+export default meta;
+
+const Template: StoryFn<typeof StarRating> = (args: StarRatingProps) => (
 	<StarRating {...args} />
 );
 
-export const NoStar = Template.bind({});
+export const NoStar: StoryFn<typeof StarRating> = Template.bind({});
 NoStar.args = {
 	rating: 0,
 };
 
 // *****************************************************************************
 
-export const OneStar = Template.bind({});
+export const OneStar: StoryFn<typeof StarRating> = Template.bind({});
 OneStar.args = {
 	rating: 1,
 };
 
 // *****************************************************************************
 
-export const TwoStars = Template.bind({});
+export const TwoStars: StoryFn<typeof StarRating> = Template.bind({});
 TwoStars.args = {
 	rating: 2,
 };
 
 // *****************************************************************************
 
-export const ThreeStars = Template.bind({});
+export const ThreeStars: StoryFn<typeof StarRating> = Template.bind({});
 ThreeStars.args = {
 	rating: 3,
 };
 
 // *****************************************************************************
 
-export const FourStars = Template.bind({});
+export const FourStars: StoryFn<typeof StarRating> = Template.bind({});
 FourStars.args = {
 	rating: 4,
 };
 
 // *****************************************************************************
 
-export const FiveStars = Template.bind({});
+export const FiveStars: StoryFn<typeof StarRating> = Template.bind({});
 FiveStars.args = {
 	rating: 5,
 };
 
 // *****************************************************************************
 
-export const SmallStars = Template.bind({});
+export const SmallStars: StoryFn<typeof StarRating> = Template.bind({});
 SmallStars.args = {
 	size: 'small',
 };
 
 // *****************************************************************************
 
-export const MediumStars = Template.bind({});
+export const MediumStars: StoryFn<typeof StarRating> = Template.bind({});
 MediumStars.args = {
 	size: 'medium',
 };
 
 // *****************************************************************************
 
-export const LargeStars = Template.bind({});
+export const LargeStars: StoryFn<typeof StarRating> = Template.bind({});
 LargeStars.args = {
 	size: 'large',
 };

--- a/libs/@guardian/source-react-components-development-kitchen/src/summary/ErrorSummary.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/summary/ErrorSummary.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { ErrorSummaryProps } from './ErrorSummary';
 import { ErrorSummary } from './ErrorSummary';
 
-export default {
+const meta: Meta<typeof ErrorSummary> = {
 	title: 'Error Summary',
 	component: ErrorSummary,
 	args: {
@@ -12,18 +12,22 @@ export default {
 	} as ErrorSummaryProps,
 };
 
-const Template: Story<ErrorSummaryProps> = (args: ErrorSummaryProps) => (
+export default meta;
+
+const Template: StoryFn<typeof ErrorSummary> = (args: ErrorSummaryProps) => (
 	<ErrorSummary {...args} />
 );
 
-export const ErrorOnly = Template.bind({});
+export const ErrorOnly: StoryFn<typeof ErrorSummary> = Template.bind({});
 ErrorOnly.args = {
 	message: 'This is an example with an error message only',
 };
 
 // *****************************************************************************
 
-export const ErrorOnlyAsReactNode = Template.bind({});
+export const ErrorOnlyAsReactNode: StoryFn<typeof ErrorSummary> = Template.bind(
+	{},
+);
 ErrorOnlyAsReactNode.args = {
 	message: (
 		<>
@@ -34,7 +38,7 @@ ErrorOnlyAsReactNode.args = {
 
 // *****************************************************************************
 
-export const WithContext = Template.bind({});
+export const WithContext: StoryFn<typeof ErrorSummary> = Template.bind({});
 WithContext.args = {
 	message: 'Here is an error',
 	context: 'This is some more information about this error message',
@@ -42,7 +46,8 @@ WithContext.args = {
 
 // *****************************************************************************
 
-export const WithContextAsReactNode = Template.bind({});
+export const WithContextAsReactNode: StoryFn<typeof ErrorSummary> =
+	Template.bind({});
 WithContextAsReactNode.args = {
 	message: 'Here is an error',
 	context: (
@@ -54,7 +59,7 @@ WithContextAsReactNode.args = {
 
 // *****************************************************************************
 
-export const WithReportLink = Template.bind({});
+export const WithReportLink: StoryFn<typeof ErrorSummary> = Template.bind({});
 WithReportLink.args = {
 	message: 'Here is an error',
 	context: 'This is some more information about this error message',

--- a/libs/@guardian/source-react-components-development-kitchen/src/summary/InfoSummary.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/summary/InfoSummary.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { InfoSummaryProps } from './InfoSummary';
 import { InfoSummary } from './InfoSummary';
 
-export default {
+const meta: Meta<typeof InfoSummary> = {
 	title: 'Info Summary',
 	component: InfoSummary,
 	args: {
@@ -11,18 +11,22 @@ export default {
 	},
 };
 
-const Template: Story<InfoSummaryProps> = (args: InfoSummaryProps) => (
+export default meta;
+
+const Template: StoryFn<typeof InfoSummary> = (args: InfoSummaryProps) => (
 	<InfoSummary {...args} />
 );
 
-export const InfoOnly = Template.bind({});
+export const InfoOnly: StoryFn<typeof InfoSummary> = Template.bind({});
 InfoOnly.args = {
 	message: 'This is an example with a info message only',
 };
 
 // *****************************************************************************
 
-export const InfoOnlyAsReactNode = Template.bind({});
+export const InfoOnlyAsReactNode: StoryFn<typeof InfoSummary> = Template.bind(
+	{},
+);
 InfoOnlyAsReactNode.args = {
 	message: (
 		<>
@@ -33,7 +37,7 @@ InfoOnlyAsReactNode.args = {
 
 // *****************************************************************************
 
-export const WithContext = Template.bind({});
+export const WithContext: StoryFn<typeof InfoSummary> = Template.bind({});
 WithContext.args = {
 	message: 'It was insightful',
 	context: 'This is some more information about this info message',
@@ -41,7 +45,8 @@ WithContext.args = {
 
 // *****************************************************************************
 
-export const WithContextAsReactNode = Template.bind({});
+export const WithContextAsReactNode: StoryFn<typeof InfoSummary> =
+	Template.bind({});
 WithContextAsReactNode.args = {
 	message: 'It was insightful',
 	context: (

--- a/libs/@guardian/source-react-components-development-kitchen/src/summary/SuccessSummary.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/summary/SuccessSummary.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { SuccessSummaryProps } from './SuccessSummary';
 import { SuccessSummary } from './SuccessSummary';
 
-export default {
+const meta: Meta<typeof SuccessSummary> = {
 	title: 'Success Summary',
 	component: SuccessSummary,
 	args: {
@@ -11,16 +11,19 @@ export default {
 	},
 };
 
-const Template: Story<SuccessSummaryProps> = (args: SuccessSummaryProps) => (
-	<SuccessSummary {...args} />
-);
+export default meta;
 
-export const SuccessOnly = Template.bind({});
+const Template: StoryFn<typeof SuccessSummary> = (
+	args: SuccessSummaryProps,
+) => <SuccessSummary {...args} />;
+
+export const SuccessOnly: StoryFn<typeof SuccessSummary> = Template.bind({});
 SuccessOnly.args = {
 	message: 'This is an example with a success message only',
 };
 
-export const SuccessOnlyAsReactNode = Template.bind({});
+export const SuccessOnlyAsReactNode: StoryFn<typeof SuccessSummary> =
+	Template.bind({});
 SuccessOnlyAsReactNode.args = {
 	message: (
 		<>
@@ -31,7 +34,7 @@ SuccessOnlyAsReactNode.args = {
 
 // *****************************************************************************
 
-export const WithContext = Template.bind({});
+export const WithContext: StoryFn<typeof SuccessSummary> = Template.bind({});
 WithContext.args = {
 	message: 'It was successful',
 	context: 'This is some more information about this success message',
@@ -39,7 +42,8 @@ WithContext.args = {
 
 // *****************************************************************************
 
-export const WithContextAsReactNode = Template.bind({});
+export const WithContextAsReactNode: StoryFn<typeof SuccessSummary> =
+	Template.bind({});
 WithContextAsReactNode.args = {
 	message: 'It was successful',
 	context: (

--- a/libs/@guardian/source-react-components-development-kitchen/src/tabs/Tabs.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/tabs/Tabs.stories.tsx
@@ -1,11 +1,18 @@
+import type { Meta, StoryFn } from '@storybook/react';
 import { css } from '@emotion/react';
 import { palette } from '@guardian/source-foundations';
 import { SvgAppleBrand } from '@guardian/source-react-components';
 import { useState } from 'react';
-import type { ReactElement } from 'react';
 import { Tabs } from './tabs';
 import { tabsDarkTheme } from './theme';
 import type { TabProps } from './types';
+
+const meta: Meta<typeof Tabs> = {
+	component: Tabs,
+	title: 'Tabs',
+};
+
+export default meta;
 
 const tabsContent = [
 	{
@@ -60,7 +67,7 @@ const tabsContent = [
 	},
 ] as const satisfies readonly TabProps[];
 
-const tabs = (): ReactElement => {
+export const TabsDefault: StoryFn<typeof Tabs> = () => {
 	const [selectedTab, setSelectedTab] = useState<string>(tabsContent[1].id);
 	return (
 		<Tabs
@@ -73,7 +80,7 @@ const tabs = (): ReactElement => {
 	);
 };
 
-const singleTab = (): ReactElement => {
+export const SingleTab: StoryFn<typeof Tabs> = () => {
 	const dog = tabsContent[1];
 	return (
 		<Tabs
@@ -88,7 +95,7 @@ const singleTab = (): ReactElement => {
 	);
 };
 
-const tabWithNodeTitle = (): ReactElement => {
+export const TabWithNodeTitle: StoryFn<typeof Tabs> = () => {
 	const fruit = {
 		id: 'fruit',
 		text: (
@@ -118,7 +125,7 @@ const tabWithNodeTitle = (): ReactElement => {
 	);
 };
 
-const tabWithDarkTheme = (): ReactElement => {
+export const TabWithDarkTheme: StoryFn<typeof Tabs> = () => {
 	const [selectedTab, setSelectedTab] = useState<string>(tabsContent[0].id);
 	return (
 		<Tabs
@@ -132,7 +139,7 @@ const tabWithDarkTheme = (): ReactElement => {
 	);
 };
 
-const tabWithCustomTheme = (): ReactElement => {
+export const TabWithCustomTheme: StoryFn<typeof Tabs> = () => {
 	const [selectedTab, setSelectedTab] = useState<string>(tabsContent[0].id);
 	return (
 		<Tabs
@@ -149,17 +156,4 @@ const tabWithCustomTheme = (): ReactElement => {
 			}}
 		/>
 	);
-};
-
-export default {
-	component: tabs,
-	title: 'Tabs',
-};
-
-export {
-	tabs,
-	singleTab,
-	tabWithNodeTitle,
-	tabWithDarkTheme,
-	tabWithCustomTheme,
 };

--- a/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/ToggleSwitchApps.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/ToggleSwitchApps.stories.tsx
@@ -1,15 +1,17 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import { ToggleSwitchApps } from './ToggleSwitchApps';
 import type { ToggleSwitchAppsProps } from './ToggleSwitchApps';
 
-export default {
+const meta: Meta<typeof ToggleSwitchApps> = {
 	title: 'ToggleSwitchApps',
 	component: ToggleSwitchApps,
 	args: {},
 };
 
-const Template: Story<ToggleSwitchAppsProps> = (
+export default meta;
+
+const Template: StoryFn<typeof ToggleSwitchApps> = (
 	args: ToggleSwitchAppsProps,
 ) => {
 	const [checked, setChecked] = useState(args.checked);
@@ -24,21 +26,25 @@ const Template: Story<ToggleSwitchAppsProps> = (
 	);
 };
 
-export const AndroidNoLabel = Template.bind({});
+export const AndroidNoLabel: StoryFn<typeof ToggleSwitchApps> = Template.bind(
+	{},
+);
 AndroidNoLabel.args = {
 	platform: 'android',
 };
 
 // *****************************************************************************
 
-export const IosNoLabel = Template.bind({});
+export const IosNoLabel: StoryFn<typeof ToggleSwitchApps> = Template.bind({});
 IosNoLabel.args = {
 	platform: 'ios',
 };
 
 // *****************************************************************************
 
-export const AndroidWithLabel = Template.bind({});
+export const AndroidWithLabel: StoryFn<typeof ToggleSwitchApps> = Template.bind(
+	{},
+);
 AndroidWithLabel.args = {
 	label: 'Get alerts on this story',
 	platform: 'android',
@@ -46,7 +52,7 @@ AndroidWithLabel.args = {
 
 // *****************************************************************************
 
-export const IosWithLabel = Template.bind({});
+export const IosWithLabel: StoryFn<typeof ToggleSwitchApps> = Template.bind({});
 IosWithLabel.args = {
 	label: 'Get alerts on this story',
 	platform: 'ios',
@@ -54,7 +60,8 @@ IosWithLabel.args = {
 
 // *****************************************************************************
 
-export const AndroidWithLabelLeft = Template.bind({});
+export const AndroidWithLabelLeft: StoryFn<typeof ToggleSwitchApps> =
+	Template.bind({});
 AndroidWithLabelLeft.args = {
 	label: 'Get alerts on this story',
 	labelPosition: 'left',
@@ -63,7 +70,9 @@ AndroidWithLabelLeft.args = {
 
 // *****************************************************************************
 
-export const IosWithLabelLeft = Template.bind({});
+export const IosWithLabelLeft: StoryFn<typeof ToggleSwitchApps> = Template.bind(
+	{},
+);
 IosWithLabelLeft.args = {
 	label: 'Get alerts on this story',
 	labelPosition: 'left',

--- a/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.stories.tsx
@@ -15,7 +15,7 @@ import {
 	specialReport,
 	sport,
 } from '@guardian/source-foundations';
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import { ToggleSwitch } from './ToggleSwitch';
 import type { ToggleSwitchProps } from './ToggleSwitch';
@@ -59,12 +59,16 @@ const pillars = [
 	ArticleSpecial.Labs,
 ];
 
-export default {
+const meta: Meta<typeof ToggleSwitch> = {
 	title: 'ToggleSwitch',
 	component: ToggleSwitch,
 };
 
-const PillarsTemplate: Story<ToggleSwitchProps> = (args: ToggleSwitchProps) => {
+export default meta;
+
+const PillarsTemplate: StoryFn<typeof ToggleSwitch> = (
+	args: ToggleSwitchProps,
+) => {
 	return (
 		<div
 			css={css`
@@ -83,7 +87,7 @@ const PillarsTemplate: Story<ToggleSwitchProps> = (args: ToggleSwitchProps) => {
 	);
 };
 
-const Template: Story<ToggleSwitchProps> = (args: ToggleSwitchProps) => {
+const Template: StoryFn<typeof ToggleSwitch> = (args: ToggleSwitchProps) => {
 	const [checked, setChecked] = useState(args.checked);
 	return (
 		<div
@@ -105,18 +109,18 @@ const Template: Story<ToggleSwitchProps> = (args: ToggleSwitchProps) => {
 	);
 };
 
-export const WithNoLabel = Template.bind({});
+export const WithNoLabel: StoryFn<typeof ToggleSwitch> = Template.bind({});
 
 // *****************************************************************************
 
-export const WithLabel = Template.bind({});
+export const WithLabel: StoryFn<typeof ToggleSwitch> = Template.bind({});
 WithLabel.args = {
 	label: 'Get alerts on this story',
 };
 
 // *****************************************************************************
 
-export const WithLabelLeft = Template.bind({});
+export const WithLabelLeft: StoryFn<typeof ToggleSwitch> = Template.bind({});
 WithLabelLeft.args = {
 	label: 'Get alerts on this story',
 	labelPosition: 'left',
@@ -124,7 +128,7 @@ WithLabelLeft.args = {
 
 // *****************************************************************************
 
-export const WithBorder = Template.bind({});
+export const WithBorder: StoryFn<typeof ToggleSwitch> = Template.bind({});
 WithBorder.args = {
 	label: 'Get alerts on this story',
 	labelBorder: true,
@@ -132,14 +136,16 @@ WithBorder.args = {
 
 // *****************************************************************************
 
-export const WithFormat = PillarsTemplate.bind({});
+export const WithFormat: StoryFn<typeof ToggleSwitch> = PillarsTemplate.bind(
+	{},
+);
 WithFormat.args = {
 	label: 'Get alerts on this story',
 };
 
 // *****************************************************************************
 
-export const WithMediumFont = Template.bind({});
+export const WithMediumFont: StoryFn<typeof ToggleSwitch> = Template.bind({});
 WithMediumFont.args = {
 	label: 'Get alerts on this story',
 	fontSize: 'medium',
@@ -147,7 +153,7 @@ WithMediumFont.args = {
 
 // *****************************************************************************
 
-export const WithBoldFont = Template.bind({});
+export const WithBoldFont: StoryFn<typeof ToggleSwitch> = Template.bind({});
 WithBoldFont.args = {
 	label: 'Get alerts on this story',
 	fontWeight: 'bold',
@@ -155,7 +161,9 @@ WithBoldFont.args = {
 
 // *****************************************************************************
 
-export const WithBoldMediumFont = Template.bind({});
+export const WithBoldMediumFont: StoryFn<typeof ToggleSwitch> = Template.bind(
+	{},
+);
 WithBoldMediumFont.args = {
 	label: 'Get alerts on this story',
 	fontWeight: 'bold',
@@ -164,7 +172,8 @@ WithBoldMediumFont.args = {
 
 // *****************************************************************************
 
-export const WithMediumFontAndBorder = Template.bind({});
+export const WithMediumFontAndBorder: StoryFn<typeof ToggleSwitch> =
+	Template.bind({});
 WithMediumFontAndBorder.args = {
 	label: 'Get alerts on this story',
 	fontSize: 'medium',
@@ -173,7 +182,8 @@ WithMediumFontAndBorder.args = {
 
 // *****************************************************************************
 
-export const WithBoldMediumFontAndBorder = Template.bind({});
+export const WithBoldMediumFontAndBorder: StoryFn<typeof ToggleSwitch> =
+	Template.bind({});
 WithBoldMediumFontAndBorder.args = {
 	label: 'Get alerts on this story',
 	fontWeight: 'bold',

--- a/libs/@guardian/source-react-components/.storybook/preview/FocusManagerDecorator.tsx
+++ b/libs/@guardian/source-react-components/.storybook/preview/FocusManagerDecorator.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 import { FocusStyleManager } from '@guardian/source-foundations';
+import { Decorator } from '@storybook/react';
 
-export const FocusManagerDecorator = (storyFn) => {
+export const FocusManagerDecorator: Decorator = (storyFn) => {
 	useEffect(() => {
 		FocusStyleManager.onlyShowFocusOnTabs();
 	});

--- a/libs/@guardian/source-react-components/.storybook/preview/ThemeProviderDecorator.tsx
+++ b/libs/@guardian/source-react-components/.storybook/preview/ThemeProviderDecorator.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider } from '@emotion/react';
+import { Decorator } from '@storybook/react';
 
-export const ThemeProviderDecorator = (storyFn, context) => {
+export const ThemeProviderDecorator: Decorator = (storyFn, context) => {
 	const theme = context.parameters.theme;
 	return theme ? (
 		<ThemeProvider theme={theme}>{storyFn()}</ThemeProvider>

--- a/libs/@guardian/source-react-components/src/accordion/Accordion.stories.tsx
+++ b/libs/@guardian/source-react-components/src/accordion/Accordion.stories.tsx
@@ -32,7 +32,7 @@ export const WithCTALabelsDefaultTheme: StoryFn<typeof Accordion> =
 
 // *****************************************************************************
 
-export const WithoutCTALabelsDefaultTheme: StoryFn<AccordionProps> =
+export const WithoutCTALabelsDefaultTheme: StoryFn<typeof Accordion> =
 	Template.bind({});
 WithoutCTALabelsDefaultTheme.args = {
 	hideToggleLabel: true,

--- a/libs/@guardian/source-react-components/src/accordion/Accordion.stories.tsx
+++ b/libs/@guardian/source-react-components/src/accordion/Accordion.stories.tsx
@@ -1,18 +1,19 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { AccordionProps } from './Accordion';
 import { Accordion } from './Accordion';
 import { AccordionRow } from './AccordionRow';
 
-export default {
+const meta: Meta<typeof Accordion> = {
 	title: 'Accordion',
 	component: Accordion,
-	subcomponents: { AccordionRow },
 	args: {
 		hideToggleLabel: false,
 	},
 };
 
-const Template: Story<AccordionProps> = (args: AccordionProps) => (
+export default meta;
+
+const Template: StoryFn<typeof Accordion> = (args: AccordionProps) => (
 	<Accordion {...args}>
 		<AccordionRow label="Collecting from multiple newsagents">
 			Present your card to a newsagent each time you collect the paper. The
@@ -26,11 +27,13 @@ const Template: Story<AccordionProps> = (args: AccordionProps) => (
 	</Accordion>
 );
 
-export const WithCTALabelsDefaultTheme = Template.bind({});
+export const WithCTALabelsDefaultTheme: StoryFn<typeof Accordion> =
+	Template.bind({});
 
 // *****************************************************************************
 
-export const WithoutCTALabelsDefaultTheme = Template.bind({});
+export const WithoutCTALabelsDefaultTheme: StoryFn<AccordionProps> =
+	Template.bind({});
 WithoutCTALabelsDefaultTheme.args = {
 	hideToggleLabel: true,
 };

--- a/libs/@guardian/source-react-components/src/brand/SvgGuardianBestWebsiteLogo.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgGuardianBestWebsiteLogo.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { SvgGuardianBestWebsiteLogoProps } from './SvgGuardianBestWebsiteLogo';
 import { SvgGuardianBestWebsiteLogo } from './SvgGuardianBestWebsiteLogo';
 
-export default {
+const meta: Meta<typeof SvgGuardianBestWebsiteLogo> = {
 	title: 'SvgGuardianBestWebsiteLogo',
 	component: SvgGuardianBestWebsiteLogo,
 	argTypes: {
@@ -12,8 +12,11 @@ export default {
 	},
 };
 
-const Template: Story = (args: SvgGuardianBestWebsiteLogoProps) => (
-	<SvgGuardianBestWebsiteLogo {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
+const Template: StoryFn<typeof SvgGuardianBestWebsiteLogo> = (
+	args: SvgGuardianBestWebsiteLogoProps,
+) => <SvgGuardianBestWebsiteLogo {...args} />;
+
+export const DefaultStoryFn: StoryFn<typeof SvgGuardianBestWebsiteLogo> =
+	Template.bind({});

--- a/libs/@guardian/source-react-components/src/brand/SvgGuardianBestWebsiteLogo.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgGuardianBestWebsiteLogo.stories.tsx
@@ -18,5 +18,5 @@ const Template: StoryFn<typeof SvgGuardianBestWebsiteLogo> = (
 	args: SvgGuardianBestWebsiteLogoProps,
 ) => <SvgGuardianBestWebsiteLogo {...args} />;
 
-export const DefaultStoryFn: StoryFn<typeof SvgGuardianBestWebsiteLogo> =
+export const Default: StoryFn<typeof SvgGuardianBestWebsiteLogo> =
 	Template.bind({});

--- a/libs/@guardian/source-react-components/src/brand/SvgGuardianLiveLogo.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgGuardianLiveLogo.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { SvgGuardianLiveLogoProps } from './SvgGuardianLiveLogo';
 import { SvgGuardianLiveLogo } from './SvgGuardianLiveLogo';
 
-export default {
+const meta: Meta<typeof SvgGuardianLiveLogo> = {
 	title: 'SvgGuardianLiveLogo',
 	component: SvgGuardianLiveLogo,
 	argTypes: {
@@ -12,8 +12,10 @@ export default {
 	},
 };
 
-const Template: Story = (args: SvgGuardianLiveLogoProps) => (
-	<SvgGuardianLiveLogo {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
+const Template: StoryFn<typeof SvgGuardianLiveLogo> = (
+	args: SvgGuardianLiveLogoProps,
+) => <SvgGuardianLiveLogo {...args} />;
+
+export const Default: StoryFn<typeof SvgGuardianLiveLogo> = Template.bind({});

--- a/libs/@guardian/source-react-components/src/brand/SvgGuardianLogo.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgGuardianLogo.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { SvgGuardianLogoProps } from './SvgGuardianLogo';
 import { SvgGuardianLogo } from './SvgGuardianLogo';
 
-export default {
+const meta: Meta<typeof SvgGuardianLogo> = {
 	title: 'SvgGuardianLogo',
 	component: SvgGuardianLogo,
 	argTypes: {
@@ -12,8 +12,10 @@ export default {
 	},
 };
 
-const Template: Story = (args: SvgGuardianLogoProps) => (
-	<SvgGuardianLogo {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
+const Template: StoryFn<typeof SvgGuardianLogo> = (
+	args: SvgGuardianLogoProps,
+) => <SvgGuardianLogo {...args} />;
+
+export const Default: StoryFn<typeof SvgGuardianLogo> = Template.bind({});

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelBrand.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelBrand.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { SvgRoundelBrandProps } from './SvgRoundelBrand';
 import { SvgRoundelBrand } from './SvgRoundelBrand';
 
-export default {
+const meta: Meta<typeof SvgRoundelBrand> = {
 	title: 'SvgRoundelBrand',
 	component: SvgRoundelBrand,
 	argTypes: {
@@ -12,8 +12,10 @@ export default {
 	},
 };
 
-const Template: Story = (args: SvgRoundelBrandProps) => (
-	<SvgRoundelBrand {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
+const Template: StoryFn<typeof SvgRoundelBrand> = (
+	args: SvgRoundelBrandProps,
+) => <SvgRoundelBrand {...args} />;
+
+export const Default: StoryFn<typeof SvgRoundelBrand> = Template.bind({});

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelBrandInverse.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelBrandInverse.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { SvgRoundelBrandInverseProps } from './SvgRoundelBrandInverse';
 import { SvgRoundelBrandInverse } from './SvgRoundelBrandInverse';
 
-export default {
+const meta: Meta<typeof SvgRoundelBrandInverse> = {
 	title: 'SvgRoundelBrandInverse',
 	component: SvgRoundelBrandInverse,
 	argTypes: {
@@ -12,8 +12,12 @@ export default {
 	},
 };
 
-const Template: Story = (args: SvgRoundelBrandInverseProps) => (
-	<SvgRoundelBrandInverse {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
+const Template: StoryFn<typeof SvgRoundelBrandInverse> = (
+	args: SvgRoundelBrandInverseProps,
+) => <SvgRoundelBrandInverse {...args} />;
+
+export const Default: StoryFn<typeof SvgRoundelBrandInverse> = Template.bind(
+	{},
+);

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelDefault.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelDefault.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { SvgRoundelDefaultProps } from './SvgRoundelDefault';
 import { SvgRoundelDefault } from './SvgRoundelDefault';
 
-export default {
+const meta: Meta<typeof SvgRoundelDefault> = {
 	title: 'SvgRoundelDefault',
 	component: SvgRoundelDefault,
 	argTypes: {
@@ -12,8 +12,10 @@ export default {
 	},
 };
 
-const Template: Story = (args: SvgRoundelDefaultProps) => (
-	<SvgRoundelDefault {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
+const Template: StoryFn<typeof SvgRoundelDefault> = (
+	args: SvgRoundelDefaultProps,
+) => <SvgRoundelDefault {...args} />;
+
+export const Default: StoryFn<typeof SvgRoundelDefault> = Template.bind({});

--- a/libs/@guardian/source-react-components/src/brand/SvgRoundelInverse.stories.tsx
+++ b/libs/@guardian/source-react-components/src/brand/SvgRoundelInverse.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { SvgRoundelInverseProps } from './SvgRoundelInverse';
 import { SvgRoundelInverse } from './SvgRoundelInverse';
 
-export default {
+const meta: Meta<typeof SvgRoundelInverse> = {
 	title: 'SvgRoundelInverse',
 	component: SvgRoundelInverse,
 	argTypes: {
@@ -12,8 +12,10 @@ export default {
 	},
 };
 
-const Template: Story = (args: SvgRoundelInverseProps) => (
-	<SvgRoundelInverse {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
+const Template: StoryFn<typeof SvgRoundelInverse> = (
+	args: SvgRoundelInverseProps,
+) => <SvgRoundelInverse {...args} />;
+
+export const Default: StoryFn<typeof SvgRoundelInverse> = Template.bind({});

--- a/libs/@guardian/source-react-components/src/button/Button.stories.tsx
+++ b/libs/@guardian/source-react-components/src/button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import type { Parameters, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { SvgCross } from '../../vendor/icons/SvgCross';
 import type { ButtonProps } from './Button';
 import { Button } from './Button';
@@ -8,9 +8,6 @@ import {
 	buttonThemeReaderRevenueBrand,
 	buttonThemeReaderRevenueBrandAlt,
 } from './theme-reader-revenue';
-
-// These types are the right types, but don't work with Storybook v6 which uses Emotion v10
-// import type { Args, Story } from '@storybook/react';
 
 const themeParameters = {
 	default: {},
@@ -43,7 +40,7 @@ const themeParameters = {
 	},
 };
 
-export default {
+const meta: Meta<typeof Button> = {
 	title: 'Button',
 	component: Button,
 	argTypes: {
@@ -60,38 +57,44 @@ export default {
 		children: 'Subscribe now',
 		size: 'default',
 		hideLabel: false,
-		icon: 'undefined',
+		icon: undefined,
 		priority: 'primary',
 		iconSide: 'left',
 		nudgeIcon: false,
 	},
 };
 
-const Template: Story<ButtonProps> = (args: ButtonProps) => (
+export default meta;
+
+const Template: StoryFn<typeof Button> = (args: ButtonProps) => (
 	<Button {...args} />
 );
 
 // *****************************************************************************
 
-export const PrimaryPriorityDefaultTheme = Template.bind({});
+export const PrimaryPriorityDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 PrimaryPriorityDefaultTheme.args = {
 	priority: 'primary',
 };
 PrimaryPriorityDefaultTheme.parameters = themeParameters.default;
 
-export const SecondaryPriorityDefaultTheme = Template.bind({});
+export const SecondaryPriorityDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 SecondaryPriorityDefaultTheme.args = {
 	priority: 'secondary',
 };
 SecondaryPriorityDefaultTheme.parameters = themeParameters.default;
 
-export const TertiaryPriorityDefaultTheme = Template.bind({});
+export const TertiaryPriorityDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 TertiaryPriorityDefaultTheme.args = {
 	priority: 'tertiary',
 };
 TertiaryPriorityDefaultTheme.parameters = themeParameters.default;
 
-export const SubduedPriorityDefaultTheme = Template.bind({});
+export const SubduedPriorityDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 SubduedPriorityDefaultTheme.args = {
 	priority: 'subdued',
 };
@@ -99,25 +102,32 @@ SubduedPriorityDefaultTheme.parameters = themeParameters.default;
 
 // *****************************************************************************
 
-export const PrimaryPriorityBrandTheme = Template.bind({});
+export const PrimaryPriorityBrandTheme: StoryFn<typeof Button> = Template.bind(
+	{},
+);
 PrimaryPriorityBrandTheme.args = {
 	priority: 'primary',
 };
 PrimaryPriorityBrandTheme.parameters = themeParameters.brand;
 
-export const SecondaryPriorityBrandTheme = Template.bind({});
+export const SecondaryPriorityBrandTheme: StoryFn<typeof Button> =
+	Template.bind({});
 SecondaryPriorityBrandTheme.args = {
 	priority: 'secondary',
 };
 SecondaryPriorityBrandTheme.parameters = themeParameters.brand;
 
-export const TertiaryPriorityBrandTheme = Template.bind({});
+export const TertiaryPriorityBrandTheme: StoryFn<typeof Button> = Template.bind(
+	{},
+);
 TertiaryPriorityBrandTheme.args = {
 	priority: 'tertiary',
 };
 TertiaryPriorityBrandTheme.parameters = themeParameters.brand;
 
-export const SubduedPriorityBrandTheme = Template.bind({});
+export const SubduedPriorityBrandTheme: StoryFn<typeof Button> = Template.bind(
+	{},
+);
 SubduedPriorityBrandTheme.args = {
 	priority: 'subdued',
 };
@@ -125,25 +135,29 @@ SubduedPriorityBrandTheme.parameters = themeParameters.brand;
 
 // *****************************************************************************
 
-export const PrimaryPriorityBrandAltTheme = Template.bind({});
+export const PrimaryPriorityBrandAltTheme: StoryFn<typeof Button> =
+	Template.bind({});
 PrimaryPriorityBrandAltTheme.args = {
 	priority: 'primary',
 };
 PrimaryPriorityBrandAltTheme.parameters = themeParameters.brandAlt;
 
-export const SecondaryPriorityBrandAltTheme = Template.bind({});
+export const SecondaryPriorityBrandAltTheme: StoryFn<typeof Button> =
+	Template.bind({});
 SecondaryPriorityBrandAltTheme.args = {
 	priority: 'secondary',
 };
 SecondaryPriorityBrandAltTheme.parameters = themeParameters.brandAlt;
 
-export const TertiaryPriorityBrandAltTheme = Template.bind({});
+export const TertiaryPriorityBrandAltTheme: StoryFn<typeof Button> =
+	Template.bind({});
 TertiaryPriorityBrandAltTheme.args = {
 	priority: 'tertiary',
 };
 TertiaryPriorityBrandAltTheme.parameters = themeParameters.brandAlt;
 
-export const SubduedPriorityBrandAltTheme = Template.bind({});
+export const SubduedPriorityBrandAltTheme: StoryFn<typeof Button> =
+	Template.bind({});
 SubduedPriorityBrandAltTheme.args = {
 	priority: 'subdued',
 };
@@ -151,13 +165,15 @@ SubduedPriorityBrandAltTheme.parameters = themeParameters.brandAlt;
 
 // *****************************************************************************
 
-export const PrimaryPriorityReaderRevenueTheme = Template.bind({});
+export const PrimaryPriorityReaderRevenueTheme: StoryFn<typeof Button> =
+	Template.bind({});
 PrimaryPriorityReaderRevenueTheme.args = {
 	priority: 'primary',
 };
 PrimaryPriorityReaderRevenueTheme.parameters = themeParameters.readerRevenue;
 
-export const TertiaryPriorityReaderRevenueTheme = Template.bind({});
+export const TertiaryPriorityReaderRevenueTheme: StoryFn<typeof Button> =
+	Template.bind({});
 TertiaryPriorityReaderRevenueTheme.args = {
 	priority: 'tertiary',
 };
@@ -165,14 +181,16 @@ TertiaryPriorityReaderRevenueTheme.parameters = themeParameters.readerRevenue;
 
 // *****************************************************************************
 
-export const PrimaryPriorityReaderRevenueBrandTheme = Template.bind({});
+export const PrimaryPriorityReaderRevenueBrandTheme: StoryFn<typeof Button> =
+	Template.bind({});
 PrimaryPriorityReaderRevenueBrandTheme.args = {
 	priority: 'primary',
 };
 PrimaryPriorityReaderRevenueBrandTheme.parameters =
 	themeParameters.readerRevenueBrand;
 
-export const TertiaryPriorityReaderRevenueBrandTheme = Template.bind({});
+export const TertiaryPriorityReaderRevenueBrandTheme: StoryFn<typeof Button> =
+	Template.bind({});
 TertiaryPriorityReaderRevenueBrandTheme.args = {
 	priority: 'tertiary',
 };
@@ -181,14 +199,17 @@ TertiaryPriorityReaderRevenueBrandTheme.parameters =
 
 // *****************************************************************************
 
-export const PrimaryPriorityReaderRevenueBrandAltTheme = Template.bind({});
+export const PrimaryPriorityReaderRevenueBrandAltTheme: StoryFn<typeof Button> =
+	Template.bind({});
 PrimaryPriorityReaderRevenueBrandAltTheme.args = {
 	priority: 'primary',
 };
 PrimaryPriorityReaderRevenueBrandAltTheme.parameters =
 	themeParameters.readerRevenueBrandAlt;
 
-export const TertiaryPriorityReaderRevenueBrandAltTheme = Template.bind({});
+export const TertiaryPriorityReaderRevenueBrandAltTheme: StoryFn<
+	typeof Button
+> = Template.bind({});
 TertiaryPriorityReaderRevenueBrandAltTheme.args = {
 	priority: 'tertiary',
 };
@@ -197,25 +218,28 @@ TertiaryPriorityReaderRevenueBrandAltTheme.parameters =
 
 // *****************************************************************************
 
-export const DefaultSizeDefaultTheme = Template.bind({});
+export const DefaultSizeDefaultTheme: StoryFn<typeof Button> = Template.bind(
+	{},
+);
 
 // *****************************************************************************
 
-export const SmallSizeDefaultTheme = Template.bind({});
+export const SmallSizeDefaultTheme: StoryFn<typeof Button> = Template.bind({});
 SmallSizeDefaultTheme.args = {
 	size: 'small',
 };
 
 // *****************************************************************************
 
-export const XSmallSizeDefaultTheme = Template.bind({});
+export const XSmallSizeDefaultTheme: StoryFn<typeof Button> = Template.bind({});
 XSmallSizeDefaultTheme.args = {
 	size: 'xsmall',
 };
 
 // *****************************************************************************
 
-export const TextAndIconLeftDefaultSizeDefaultTheme = Template.bind({});
+export const TextAndIconLeftDefaultSizeDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 TextAndIconLeftDefaultSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
 	icon: 'cross',
@@ -224,7 +248,8 @@ TextAndIconLeftDefaultSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconRightDefaultSizeDefaultTheme = Template.bind({});
+export const TextAndIconRightDefaultSizeDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 TextAndIconRightDefaultSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
 	icon: 'cross',
@@ -234,7 +259,8 @@ TextAndIconRightDefaultSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconLeftSmallSizeDefaultTheme = Template.bind({});
+export const TextAndIconLeftSmallSizeDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 TextAndIconLeftSmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
 	icon: 'cross',
@@ -244,7 +270,8 @@ TextAndIconLeftSmallSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconRightSmallSizeDefaultTheme = Template.bind({});
+export const TextAndIconRightSmallSizeDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 TextAndIconRightSmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
 	icon: 'cross',
@@ -255,7 +282,8 @@ TextAndIconRightSmallSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconLeftXSmallSizeDefaultTheme = Template.bind({});
+export const TextAndIconLeftXSmallSizeDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 TextAndIconLeftXSmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
 	icon: 'cross',
@@ -265,7 +293,8 @@ TextAndIconLeftXSmallSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconRightXSmallSizeDefaultTheme = Template.bind({});
+export const TextAndIconRightXSmallSizeDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 TextAndIconRightXSmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
 	icon: 'cross',
@@ -276,7 +305,8 @@ TextAndIconRightXSmallSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const IconOnlyDefaultSizeDefaultTheme = Template.bind({});
+export const IconOnlyDefaultSizeDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 IconOnlyDefaultSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
 	icon: 'cross',
@@ -286,7 +316,8 @@ IconOnlyDefaultSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const IconOnlySmallSizeDefaultTheme = Template.bind({});
+export const IconOnlySmallSizeDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 IconOnlySmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
 	icon: 'cross',
@@ -297,7 +328,8 @@ IconOnlySmallSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const IconOnlyXSmallSizeDefaultTheme = Template.bind({});
+export const IconOnlyXSmallSizeDefaultTheme: StoryFn<typeof Button> =
+	Template.bind({});
 IconOnlyXSmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
 	icon: 'cross',
@@ -308,14 +340,14 @@ IconOnlyXSmallSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const IsLoadingPrimary = Template.bind({});
+export const IsLoadingPrimary: StoryFn<typeof Button> = Template.bind({});
 IsLoadingPrimary.args = {
 	isLoading: true,
 };
 
 // *****************************************************************************
 
-export const IsLoadingPrimarySmall = Template.bind({});
+export const IsLoadingPrimarySmall: StoryFn<typeof Button> = Template.bind({});
 IsLoadingPrimarySmall.args = {
 	isLoading: true,
 	size: 'small',
@@ -323,7 +355,7 @@ IsLoadingPrimarySmall.args = {
 
 // *****************************************************************************
 
-export const IsLoadingPrimaryXSmall = Template.bind({});
+export const IsLoadingPrimaryXSmall: StoryFn<typeof Button> = Template.bind({});
 IsLoadingPrimaryXSmall.args = {
 	isLoading: true,
 	size: 'xsmall',
@@ -331,7 +363,7 @@ IsLoadingPrimaryXSmall.args = {
 
 // *****************************************************************************
 
-export const IsLoadingSecondary = Template.bind({});
+export const IsLoadingSecondary: StoryFn<typeof Button> = Template.bind({});
 IsLoadingSecondary.args = {
 	isLoading: true,
 	priority: 'secondary',
@@ -339,7 +371,7 @@ IsLoadingSecondary.args = {
 
 // *****************************************************************************
 
-export const IsLoadingTertiary = Template.bind({});
+export const IsLoadingTertiary: StoryFn<typeof Button> = Template.bind({});
 IsLoadingTertiary.args = {
 	isLoading: true,
 	priority: 'tertiary',
@@ -347,7 +379,7 @@ IsLoadingTertiary.args = {
 
 // *****************************************************************************
 
-export const IsLoadingSubdued = Template.bind({});
+export const IsLoadingSubdued: StoryFn<typeof Button> = Template.bind({});
 IsLoadingSubdued.args = {
 	isLoading: true,
 	priority: 'subdued',
@@ -355,7 +387,7 @@ IsLoadingSubdued.args = {
 
 // *****************************************************************************
 
-export const IsLoadingIconSideRight = Template.bind({});
+export const IsLoadingIconSideRight: StoryFn<typeof Button> = Template.bind({});
 IsLoadingIconSideRight.args = {
 	isLoading: true,
 	iconSide: 'right',
@@ -363,7 +395,7 @@ IsLoadingIconSideRight.args = {
 
 // *****************************************************************************
 
-export const IsLoadingDisabled = Template.bind({});
+export const IsLoadingDisabled: StoryFn<typeof Button> = Template.bind({});
 IsLoadingDisabled.args = {
 	isLoading: true,
 	disabled: true,
@@ -371,7 +403,7 @@ IsLoadingDisabled.args = {
 
 // *****************************************************************************
 
-export const IsLoadingLabelHidden = Template.bind({});
+export const IsLoadingLabelHidden: StoryFn<typeof Button> = Template.bind({});
 IsLoadingLabelHidden.args = {
 	isLoading: true,
 	hideLabel: true,

--- a/libs/@guardian/source-react-components/src/button/LinkButton.stories.tsx
+++ b/libs/@guardian/source-react-components/src/button/LinkButton.stories.tsx
@@ -1,19 +1,9 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { SvgArrowRightStraight } from '../../vendor/icons/SvgArrowRightStraight';
 import { LinkButton } from './LinkButton';
 import type { LinkButtonProps } from './LinkButton';
-import type { ButtonPriority } from './types';
-// These types are the right types, but don't work with Storybook v6 which uses Emotion v10
-// import type { Args, Story } from '@storybook/react';
 
-const priorityArgs: ButtonPriority[] = [
-	'primary',
-	'secondary',
-	'tertiary',
-	'subdued',
-];
-
-export default {
+const meta: Meta<typeof LinkButton> = {
 	title: 'LinkButton',
 	component: LinkButton,
 	argTypes: {
@@ -30,7 +20,7 @@ export default {
 		children: 'Subscribe now',
 		size: 'default',
 		hideLabel: false,
-		icon: 'undefined',
+		icon: undefined,
 		priority: 'primary',
 		iconSide: 'left',
 		nudgeIcon: false,
@@ -38,28 +28,49 @@ export default {
 	},
 };
 
-const Template: Story<LinkButtonProps> = (args: LinkButtonProps) => (
+export default meta;
+
+const Template: StoryFn<typeof LinkButton> = (args: LinkButtonProps) => (
 	<LinkButton {...args} />
 );
 
-export const [
-	PrimaryPriorityDefaultTheme,
-	SecondaryPriorityDefaultTheme,
-	TertiaryPriorityDefaultTheme,
-	SubduedPriorityDefaultTheme,
-] = priorityArgs.map((priority) => {
-	const story = Template.bind({});
+// *****************************************************************************
 
-	story.args = {
-		priority,
-	};
-
-	return story;
-});
+export const PrimaryPriorityDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
+PrimaryPriorityDefaultTheme.args = {
+	priority: 'primary',
+};
 
 // *****************************************************************************
 
-export const TextAndIconLeftDefaultSizeDefaultTheme = Template.bind({});
+export const SecondaryPriorityDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
+SecondaryPriorityDefaultTheme.args = {
+	priority: 'secondary',
+};
+
+// *****************************************************************************
+
+export const TertiaryPriorityDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
+TertiaryPriorityDefaultTheme.args = {
+	priority: 'tertiary',
+};
+
+// *****************************************************************************
+
+export const SubduedPriorityDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
+SubduedPriorityDefaultTheme.args = {
+	priority: 'subdued',
+};
+
+// *****************************************************************************
+
+export const TextAndIconLeftDefaultSizeDefaultTheme: StoryFn<
+	typeof LinkButton
+> = Template.bind({});
 TextAndIconLeftDefaultSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',
@@ -67,7 +78,9 @@ TextAndIconLeftDefaultSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconRightDefaultSizeDefaultTheme = Template.bind({});
+export const TextAndIconRightDefaultSizeDefaultTheme: StoryFn<
+	typeof LinkButton
+> = Template.bind({});
 TextAndIconRightDefaultSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',
@@ -76,7 +89,8 @@ TextAndIconRightDefaultSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconLeftSmallSizeDefaultTheme = Template.bind({});
+export const TextAndIconLeftSmallSizeDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
 TextAndIconLeftSmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',
@@ -85,7 +99,8 @@ TextAndIconLeftSmallSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconRightSmallSizeDefaultTheme = Template.bind({});
+export const TextAndIconRightSmallSizeDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
 TextAndIconRightSmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',
@@ -95,7 +110,8 @@ TextAndIconRightSmallSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconLeftXSmallSizeDefaultTheme = Template.bind({});
+export const TextAndIconLeftXSmallSizeDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
 TextAndIconLeftXSmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',
@@ -104,7 +120,9 @@ TextAndIconLeftXSmallSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconRightXSmallSizeDefaultTheme = Template.bind({});
+export const TextAndIconRightXSmallSizeDefaultTheme: StoryFn<
+	typeof LinkButton
+> = Template.bind({});
 TextAndIconRightXSmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',
@@ -114,7 +132,8 @@ TextAndIconRightXSmallSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconLeftWithNudgeDefaultTheme = Template.bind({});
+export const TextAndIconLeftWithNudgeDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
 TextAndIconLeftWithNudgeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',
@@ -123,7 +142,8 @@ TextAndIconLeftWithNudgeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const TextAndIconRightWithNudgeDefaultTheme = Template.bind({});
+export const TextAndIconRightWithNudgeDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
 TextAndIconRightWithNudgeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',
@@ -133,7 +153,8 @@ TextAndIconRightWithNudgeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const IconOnlyDefaultSizeDefaultTheme = Template.bind({});
+export const IconOnlyDefaultSizeDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
 IconOnlyDefaultSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',
@@ -142,7 +163,8 @@ IconOnlyDefaultSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const IconOnlySmallSizeDefaultTheme = Template.bind({});
+export const IconOnlySmallSizeDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
 IconOnlySmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',
@@ -152,7 +174,8 @@ IconOnlySmallSizeDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const IconOnlyXSmallSizeDefaultTheme = Template.bind({});
+export const IconOnlyXSmallSizeDefaultTheme: StoryFn<typeof LinkButton> =
+	Template.bind({});
 IconOnlyXSmallSizeDefaultTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',

--- a/libs/@guardian/source-react-components/src/checkbox/Checkbox.stories.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/Checkbox.stories.tsx
@@ -1,10 +1,10 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import type { CheckboxProps } from './Checkbox';
 import { Checkbox } from './Checkbox';
 import { checkboxThemeBrand } from './theme';
 
-export default {
+const meta: Meta<typeof Checkbox> = {
 	title: 'Checkbox',
 	component: Checkbox,
 	argTypes: {},
@@ -15,7 +15,9 @@ export default {
 	},
 };
 
-const Template: Story<CheckboxProps> = (args: CheckboxProps) => {
+export default meta;
+
+const Template: StoryFn<typeof Checkbox> = (args: CheckboxProps) => {
 	const [checked, setChecked] = useState(args.checked);
 
 	return (
@@ -27,11 +29,11 @@ const Template: Story<CheckboxProps> = (args: CheckboxProps) => {
 	);
 };
 
-export const DefaultDefaultTheme = Template.bind({});
+export const DefaultDefaultTheme: StoryFn<typeof Checkbox> = Template.bind({});
 
 // *****************************************************************************
 
-export const DefaultBrandTheme = Template.bind({});
+export const DefaultBrandTheme: StoryFn<typeof Checkbox> = Template.bind({});
 DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -41,14 +43,17 @@ DefaultBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const SupportingTextDefaultTheme = Template.bind({});
+export const SupportingTextDefaultTheme: StoryFn<typeof Checkbox> =
+	Template.bind({});
 SupportingTextDefaultTheme.args = {
 	supporting: 'Supporting text',
 };
 
 // *****************************************************************************
 
-export const SupportingTextBrandTheme = Template.bind({});
+export const SupportingTextBrandTheme: StoryFn<typeof Checkbox> = Template.bind(
+	{},
+);
 SupportingTextBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -61,7 +66,8 @@ SupportingTextBrandTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingTextOnlyDefaultTheme = Template.bind({});
+export const SupportingTextOnlyDefaultTheme: StoryFn<typeof Checkbox> =
+	Template.bind({});
 SupportingTextOnlyDefaultTheme.args = {
 	label: null,
 	supporting: 'Supporting text',
@@ -69,7 +75,8 @@ SupportingTextOnlyDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingTextOnlyBrandTheme = Template.bind({});
+export const SupportingTextOnlyBrandTheme: StoryFn<typeof Checkbox> =
+	Template.bind({});
 SupportingTextOnlyBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -83,7 +90,8 @@ SupportingTextOnlyBrandTheme.args = {
 
 // *****************************************************************************
 
-export const IndeterminateDefaultTheme = Template.bind({});
+export const IndeterminateDefaultTheme: StoryFn<typeof Checkbox> =
+	Template.bind({});
 IndeterminateDefaultTheme.args = {
 	checked: undefined,
 	indeterminate: true,
@@ -91,7 +99,9 @@ IndeterminateDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const IndeterminateBrandTheme = Template.bind({});
+export const IndeterminateBrandTheme: StoryFn<typeof Checkbox> = Template.bind(
+	{},
+);
 IndeterminateBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -104,7 +114,9 @@ IndeterminateBrandTheme.args = {
 
 // *****************************************************************************
 
-export const UnlabelledDefaultTheme = Template.bind({});
+export const UnlabelledDefaultTheme: StoryFn<typeof Checkbox> = Template.bind(
+	{},
+);
 UnlabelledDefaultTheme.args = {
 	label: null,
 	'aria-label': 'Checkbox',

--- a/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import { Checkbox } from './Checkbox';
 import CheckboxStories from './Checkbox.stories';
@@ -6,10 +6,9 @@ import type { CheckboxGroupProps } from './CheckboxGroup';
 import { CheckboxGroup } from './CheckboxGroup';
 import { checkboxThemeBrand } from './theme';
 
-export default {
+const meta: Meta<typeof CheckboxGroup> = {
 	title: 'CheckboxGroup',
 	component: CheckboxGroup,
-	subcomponents: { Checkbox },
 	argTypes: {},
 	args: {
 		name: 'your-newsletters',
@@ -20,8 +19,10 @@ export default {
 	},
 };
 
-const Template: Story<CheckboxGroupProps> = (args: CheckboxGroupProps) => {
-	const [checked, setChecked] = useState(CheckboxStories.args.checked);
+export default meta;
+
+const Template: StoryFn<typeof CheckboxGroup> = (args: CheckboxGroupProps) => {
+	const [checked, setChecked] = useState(CheckboxStories.args?.checked);
 
 	return (
 		<CheckboxGroup {...args}>
@@ -34,11 +35,15 @@ const Template: Story<CheckboxGroupProps> = (args: CheckboxGroupProps) => {
 	);
 };
 
-export const DefaultDefaultTheme = Template.bind({});
+export const DefaultDefaultTheme: StoryFn<typeof CheckboxGroup> = Template.bind(
+	{},
+);
 
 // *****************************************************************************
 
-export const DefaultBrandTheme = Template.bind({});
+export const DefaultBrandTheme: StoryFn<typeof CheckboxGroup> = Template.bind(
+	{},
+);
 DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -48,14 +53,16 @@ DefaultBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const VisuallyHideLegendDefaultTheme = Template.bind({});
+export const VisuallyHideLegendDefaultTheme: StoryFn<typeof CheckboxGroup> =
+	Template.bind({});
 VisuallyHideLegendDefaultTheme.args = {
 	hideLabel: true,
 };
 
 // *****************************************************************************
 
-export const VisuallyHideLegendBrandTheme = Template.bind({});
+export const VisuallyHideLegendBrandTheme: StoryFn<typeof CheckboxGroup> =
+	Template.bind({});
 VisuallyHideLegendBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -68,21 +75,24 @@ VisuallyHideLegendBrandTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingTextDefaultTheme = Template.bind({});
+export const SupportingTextDefaultTheme: StoryFn<typeof CheckboxGroup> =
+	Template.bind({});
 SupportingTextDefaultTheme.args = {
 	supporting: 'Pick the issues and topics that interest you',
 };
 
 // *****************************************************************************
 
-export const OptionalDefaultTheme = Template.bind({});
+export const OptionalDefaultTheme: StoryFn<typeof CheckboxGroup> =
+	Template.bind({});
 OptionalDefaultTheme.args = {
 	optional: true,
 };
 
 // *****************************************************************************
 
-export const SupportingTextBrandTheme = Template.bind({});
+export const SupportingTextBrandTheme: StoryFn<typeof CheckboxGroup> =
+	Template.bind({});
 SupportingTextBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -95,14 +105,16 @@ SupportingTextBrandTheme.args = {
 
 // *****************************************************************************
 
-export const ErrorDefaultTheme = Template.bind({});
+export const ErrorDefaultTheme: StoryFn<typeof CheckboxGroup> = Template.bind(
+	{},
+);
 ErrorDefaultTheme.args = {
 	error: 'This newsletter is not available in your region',
 };
 
 // *****************************************************************************
 
-export const ErrorBrandTheme = Template.bind({});
+export const ErrorBrandTheme: StoryFn<typeof CheckboxGroup> = Template.bind({});
 ErrorBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',

--- a/libs/@guardian/source-react-components/src/choice-card/ChoiceCard.stories.tsx
+++ b/libs/@guardian/source-react-components/src/choice-card/ChoiceCard.stories.tsx
@@ -1,9 +1,9 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { SvgCamera } from '../../vendor/icons/SvgCamera';
 import { ChoiceCard } from './ChoiceCard';
 import type { ChoiceCardProps } from './ChoiceCard';
 
-export default {
+const meta: Meta<typeof ChoiceCard> = {
 	title: 'ChoiceCard',
 	component: ChoiceCard,
 	args: {
@@ -34,31 +34,37 @@ export default {
 	},
 };
 
-const Template: Story<ChoiceCardProps> = (args: ChoiceCardProps) => (
+export default meta;
+
+const Template: StoryFn<typeof ChoiceCard> = (args: ChoiceCardProps) => (
 	<ChoiceCard {...args} />
 );
 
 // *****************************************************************************
 
-export const DefaultDefaultTheme = Template.bind({});
+export const DefaultDefaultTheme: StoryFn<typeof ChoiceCard> = Template.bind(
+	{},
+);
 
 // *****************************************************************************
 
-export const CheckedDefaultTheme = Template.bind({});
+export const CheckedDefaultTheme: StoryFn<typeof ChoiceCard> = Template.bind(
+	{},
+);
 CheckedDefaultTheme.args = {
 	checked: true,
 };
 
 // *****************************************************************************
 
-export const ErrorDefaultTheme = Template.bind({});
+export const ErrorDefaultTheme: StoryFn<typeof ChoiceCard> = Template.bind({});
 ErrorDefaultTheme.args = {
 	error: true,
 };
 
 // *****************************************************************************
 
-export const IconDefaultTheme = Template.bind({});
+export const IconDefaultTheme: StoryFn<typeof ChoiceCard> = Template.bind({});
 IconDefaultTheme.args = {
 	label: 'Camera',
 	// @ts-expect-error - Storybook maps 'JSX element' to <em>Option 1</em>

--- a/libs/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.stories.tsx
@@ -1,15 +1,14 @@
 import { breakpoints } from '@guardian/source-foundations';
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import { ChoiceCard } from './ChoiceCard';
 import ChoiceCardStories from './ChoiceCard.stories';
 import { ChoiceCardGroup } from './ChoiceCardGroup';
 import type { ChoiceCardGroupProps } from './ChoiceCardGroup';
 
-export default {
+const meta: Meta<typeof ChoiceCardGroup> = {
 	title: 'ChoiceCardGroup',
 	component: ChoiceCardGroup,
-	subcomponents: { ChoiceCard },
 	args: {
 		name: 'colours',
 		label: 'Choose an option',
@@ -29,7 +28,11 @@ export default {
 	},
 };
 
-const Template: Story<ChoiceCardGroupProps> = (args: ChoiceCardGroupProps) => (
+export default meta;
+
+const Template: StoryFn<typeof ChoiceCardGroup> = (
+	args: ChoiceCardGroupProps,
+) => (
 	<ChoiceCardGroup {...args}>
 		<ChoiceCard
 			{...ChoiceCardStories.args}
@@ -76,7 +79,8 @@ const Template: Story<ChoiceCardGroupProps> = (args: ChoiceCardGroupProps) => (
 	</ChoiceCardGroup>
 );
 
-export const DefaultDefaultTheme = Template.bind({});
+export const DefaultDefaultTheme: StoryFn<typeof ChoiceCardGroup> =
+	Template.bind({});
 DefaultDefaultTheme.args = {
 	label: undefined,
 	supporting: undefined,
@@ -84,7 +88,8 @@ DefaultDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const DefaultMobileDefaultTheme = Template.bind({});
+export const DefaultMobileDefaultTheme: StoryFn<typeof ChoiceCardGroup> =
+	Template.bind({});
 DefaultMobileDefaultTheme.args = {
 	label: undefined,
 	supporting: undefined,
@@ -98,7 +103,8 @@ DefaultMobileDefaultTheme.parameters = {
 
 // *****************************************************************************
 
-export const DefaultTabletDefaultTheme = Template.bind({});
+export const DefaultTabletDefaultTheme: StoryFn<typeof ChoiceCardGroup> =
+	Template.bind({});
 DefaultTabletDefaultTheme.args = {
 	label: undefined,
 	supporting: undefined,
@@ -112,7 +118,8 @@ DefaultTabletDefaultTheme.parameters = {
 
 // *****************************************************************************
 
-export const DefaultIn2ColumnsDefaultTheme = Template.bind({});
+export const DefaultIn2ColumnsDefaultTheme: StoryFn<typeof ChoiceCardGroup> =
+	Template.bind({});
 DefaultIn2ColumnsDefaultTheme.args = {
 	label: undefined,
 	supporting: undefined,
@@ -121,7 +128,8 @@ DefaultIn2ColumnsDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const DefaultIn3ColumnsDefaultTheme = Template.bind({});
+export const DefaultIn3ColumnsDefaultTheme: StoryFn<typeof ChoiceCardGroup> =
+	Template.bind({});
 DefaultIn3ColumnsDefaultTheme.args = {
 	label: undefined,
 	supporting: undefined,
@@ -130,7 +138,8 @@ DefaultIn3ColumnsDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const DefaultIn4ColumnsDefaultTheme = Template.bind({});
+export const DefaultIn4ColumnsDefaultTheme: StoryFn<typeof ChoiceCardGroup> =
+	Template.bind({});
 DefaultIn4ColumnsDefaultTheme.args = {
 	label: undefined,
 	supporting: undefined,
@@ -139,7 +148,8 @@ DefaultIn4ColumnsDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const DefaultIn5ColumnsDefaultTheme = Template.bind({});
+export const DefaultIn5ColumnsDefaultTheme: StoryFn<typeof ChoiceCardGroup> =
+	Template.bind({});
 DefaultIn5ColumnsDefaultTheme.args = {
 	label: undefined,
 	supporting: undefined,
@@ -148,16 +158,19 @@ DefaultIn5ColumnsDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const WithLabelDefaultTheme = Template.bind({});
+export const WithLabelDefaultTheme: StoryFn<typeof ChoiceCardGroup> =
+	Template.bind({});
 WithLabelDefaultTheme.args = { supporting: undefined };
 
 // *****************************************************************************
 
-export const WithSupportingDefaultTheme = Template.bind({});
+export const WithSupportingDefaultTheme: StoryFn<typeof ChoiceCardGroup> =
+	Template.bind({});
 
 // *****************************************************************************
 
-export const WithErrorDefaultTheme = Template.bind({});
+export const WithErrorDefaultTheme: StoryFn<typeof ChoiceCardGroup> =
+	Template.bind({});
 WithErrorDefaultTheme.args = {
 	error: 'Please select a choice card to continue',
 	label: undefined,
@@ -166,7 +179,8 @@ WithErrorDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const WithLabelAndErrorDefaultTheme = Template.bind({});
+export const WithLabelAndErrorDefaultTheme: StoryFn<typeof ChoiceCardGroup> =
+	Template.bind({});
 WithLabelAndErrorDefaultTheme.args = {
 	error: 'Please select a choice card to continue',
 	supporting: undefined,
@@ -174,14 +188,18 @@ WithLabelAndErrorDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const WithLabelAndSupportingAndErrorDefaultTheme = Template.bind({});
+export const WithLabelAndSupportingAndErrorDefaultTheme: StoryFn<
+	typeof ChoiceCardGroup
+> = Template.bind({});
 WithLabelAndSupportingAndErrorDefaultTheme.args = {
 	error: 'Please select a choice card to continue',
 };
 
 // *****************************************************************************
 
-export const WithWildlyVaryingLengthsDefaultTheme = Template.bind({});
+export const WithWildlyVaryingLengthsDefaultTheme: StoryFn<
+	typeof ChoiceCardGroup
+> = Template.bind({});
 WithWildlyVaryingLengthsDefaultTheme.args = {
 	children: [
 		<ChoiceCard
@@ -202,7 +220,9 @@ WithWildlyVaryingLengthsDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const WithWildlyVaryingLengthsMobileDefaultTheme = Template.bind({});
+export const WithWildlyVaryingLengthsMobileDefaultTheme: StoryFn<
+	typeof ChoiceCardGroup
+> = Template.bind({});
 WithWildlyVaryingLengthsMobileDefaultTheme.args =
 	WithWildlyVaryingLengthsDefaultTheme.args;
 WithWildlyVaryingLengthsMobileDefaultTheme.parameters = {
@@ -214,7 +234,9 @@ WithWildlyVaryingLengthsMobileDefaultTheme.parameters = {
 
 // *****************************************************************************
 
-export const WithWildlyVaryingLengthsTabletDefaultTheme = Template.bind({});
+export const WithWildlyVaryingLengthsTabletDefaultTheme: StoryFn<
+	typeof ChoiceCardGroup
+> = Template.bind({});
 WithWildlyVaryingLengthsTabletDefaultTheme.args =
 	WithWildlyVaryingLengthsDefaultTheme.args;
 WithWildlyVaryingLengthsTabletDefaultTheme.parameters = {
@@ -226,9 +248,9 @@ WithWildlyVaryingLengthsTabletDefaultTheme.parameters = {
 
 // *****************************************************************************
 
-export const ControlledMultiSelectDefaultTheme: Story<ChoiceCardGroupProps> = (
-	args: ChoiceCardGroupProps,
-) => {
+export const ControlledMultiSelectDefaultTheme: StoryFn<
+	typeof ChoiceCardGroup
+> = (args: ChoiceCardGroupProps) => {
 	const [state, setState] = useState({
 		opt1: true,
 		opt2: true,
@@ -265,9 +287,9 @@ ControlledMultiSelectDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const ControlledSingleSelectDefaultTheme: Story<ChoiceCardGroupProps> = (
-	args: ChoiceCardGroupProps,
-) => {
+export const ControlledSingleSelectDefaultTheme: StoryFn<
+	typeof ChoiceCardGroup
+> = (args: ChoiceCardGroupProps) => {
 	const [selected, setSelected] = useState<string | null>('option-2');
 
 	return (
@@ -302,8 +324,8 @@ ControlledSingleSelectDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const UnControlledMultiSelectDefaultTheme: Story<
-	ChoiceCardGroupProps
+export const UnControlledMultiSelectDefaultTheme: StoryFn<
+	typeof ChoiceCardGroup
 > = (args: ChoiceCardGroupProps) => (
 	<ChoiceCardGroup {...args}>
 		<ChoiceCard id="abc1" value="option-1" label="Option 1" defaultChecked />
@@ -317,8 +339,8 @@ UnControlledMultiSelectDefaultTheme.storyName = 'Un-controlled Multi Select';
 
 // *****************************************************************************
 
-export const UnControlledSingleSelectDefaultTheme: Story<
-	ChoiceCardGroupProps
+export const UnControlledSingleSelectDefaultTheme: StoryFn<
+	typeof ChoiceCardGroup
 > = (args: ChoiceCardGroupProps) => (
 	<ChoiceCardGroup {...args}>
 		<ChoiceCard id="abc1" value="option-1" label="Option 1" />

--- a/libs/@guardian/source-react-components/src/columns/Columns.stories.tsx
+++ b/libs/@guardian/source-react-components/src/columns/Columns.stories.tsx
@@ -1,9 +1,8 @@
 import { breakpoints } from '@guardian/source-foundations';
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { HTMLAttributes } from 'react';
 import { Container } from '../container/Container';
 import { Column } from './Column';
-import type { ColumnsProps } from './Columns';
 import { Columns } from './Columns';
 
 const style = { backgroundColor: 'rgba(255, 0, 0, 0.25)' };
@@ -11,13 +10,14 @@ const Code = (args: HTMLAttributes<HTMLElement>) => (
 	<code style={{ whiteSpace: 'nowrap' }} {...args} />
 );
 
-export default {
+const meta: Meta<typeof Column> = {
 	title: 'Columns',
 	component: Columns,
-	subcomponents: { Column },
 };
 
-const Template: Story<ColumnsProps> = (args) => (
+export default meta;
+
+const Template: StoryFn<typeof Columns> = (args) => (
 	<Columns {...args} style={style}>
 		<Column style={style}>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut faucibus nibh
@@ -49,7 +49,7 @@ const Template: Story<ColumnsProps> = (args) => (
 	</Columns>
 );
 
-export const Default = Template.bind({});
+export const Default: StoryFn<typeof Columns> = Template.bind({});
 Default.parameters = {
 	viewport: { defaultViewport: 'tablet' },
 	chromatic: {
@@ -61,7 +61,8 @@ Default.parameters = {
 
 // *****************************************************************************
 
-export const CollapseUntilTabletWithNoSpacing = Template.bind({});
+export const CollapseUntilTabletWithNoSpacing: StoryFn<typeof Columns> =
+	Template.bind({});
 CollapseUntilTabletWithNoSpacing.args = {
 	collapseUntil: 'tablet',
 };
@@ -76,7 +77,8 @@ CollapseUntilTabletWithNoSpacing.parameters = {
 
 // *****************************************************************************
 
-export const CollapseUntilTabletWithSpace1 = Template.bind({});
+export const CollapseUntilTabletWithSpace1: StoryFn<typeof Columns> =
+	Template.bind({});
 CollapseUntilTabletWithSpace1.args = {
 	collapseUntil: 'tablet',
 	spaceY: 1,
@@ -92,7 +94,8 @@ CollapseUntilTabletWithSpace1.parameters = {
 
 // *****************************************************************************
 
-export const CollapseUntilTabletWithSpace2 = Template.bind({});
+export const CollapseUntilTabletWithSpace2: StoryFn<typeof Columns> =
+	Template.bind({});
 CollapseUntilTabletWithSpace2.args = {
 	collapseUntil: 'tablet',
 	spaceY: 2,
@@ -108,7 +111,8 @@ CollapseUntilTabletWithSpace2.parameters = {
 
 // *****************************************************************************
 
-export const CollapseUntilTabletWithSpace3 = Template.bind({});
+export const CollapseUntilTabletWithSpace3: StoryFn<typeof Columns> =
+	Template.bind({});
 CollapseUntilTabletWithSpace3.args = {
 	collapseUntil: 'tablet',
 	spaceY: 3,
@@ -124,7 +128,8 @@ CollapseUntilTabletWithSpace3.parameters = {
 
 // *****************************************************************************
 
-export const CollapseUntilTabletWithSpace4 = Template.bind({});
+export const CollapseUntilTabletWithSpace4: StoryFn<typeof Columns> =
+	Template.bind({});
 CollapseUntilTabletWithSpace4.args = {
 	collapseUntil: 'tablet',
 	spaceY: 4,
@@ -140,7 +145,8 @@ CollapseUntilTabletWithSpace4.parameters = {
 
 // *****************************************************************************
 
-export const CollapseUntilTabletWithSpace5 = Template.bind({});
+export const CollapseUntilTabletWithSpace5: StoryFn<typeof Columns> =
+	Template.bind({});
 CollapseUntilTabletWithSpace5.args = {
 	collapseUntil: 'tablet',
 	spaceY: 5,
@@ -156,7 +162,8 @@ CollapseUntilTabletWithSpace5.parameters = {
 
 // *****************************************************************************
 
-export const CollapseUntilTabletWithSpace6 = Template.bind({});
+export const CollapseUntilTabletWithSpace6: StoryFn<typeof Columns> =
+	Template.bind({});
 CollapseUntilTabletWithSpace6.args = {
 	collapseUntil: 'tablet',
 	spaceY: 6,
@@ -172,7 +179,8 @@ CollapseUntilTabletWithSpace6.parameters = {
 
 // *****************************************************************************
 
-export const CollapseUntilTabletWithSpace9 = Template.bind({});
+export const CollapseUntilTabletWithSpace9: StoryFn<typeof Columns> =
+	Template.bind({});
 CollapseUntilTabletWithSpace9.args = {
 	collapseUntil: 'tablet',
 	spaceY: 9,
@@ -188,7 +196,8 @@ CollapseUntilTabletWithSpace9.parameters = {
 
 // *****************************************************************************
 
-export const CollapseUntilTabletWithSpace12 = Template.bind({});
+export const CollapseUntilTabletWithSpace12: StoryFn<typeof Columns> =
+	Template.bind({});
 CollapseUntilTabletWithSpace12.args = {
 	collapseUntil: 'tablet',
 	spaceY: 12,
@@ -204,7 +213,8 @@ CollapseUntilTabletWithSpace12.parameters = {
 
 // *****************************************************************************
 
-export const CollapseUntilTabletWithSpace24 = Template.bind({});
+export const CollapseUntilTabletWithSpace24: StoryFn<typeof Columns> =
+	Template.bind({});
 CollapseUntilTabletWithSpace24.args = {
 	collapseUntil: 'tablet',
 	spaceY: 24,
@@ -220,7 +230,7 @@ CollapseUntilTabletWithSpace24.parameters = {
 
 // *****************************************************************************
 
-export const WithContainer: Story<ColumnsProps> = (args, ctx) => (
+export const WithContainer: StoryFn<typeof Columns> = (args, ctx) => (
 	<Container style={style}>{Template(args, ctx)}</Container>
 );
 WithContainer.parameters = {
@@ -229,7 +239,7 @@ WithContainer.parameters = {
 
 // *****************************************************************************
 
-export const ResponsiveAtPhablet: Story<ColumnsProps> = (args) => (
+export const ResponsiveAtPhablet: StoryFn<typeof Columns> = (args) => (
 	<Container style={style}>
 		<Columns {...args}>
 			<Column width={[1 / 2, 1 / 4]} style={style}>
@@ -254,7 +264,7 @@ ResponsiveAtPhablet.parameters = {
 
 // *****************************************************************************
 
-export const ResponsiveAtTablet: Story<ColumnsProps> = (args) => (
+export const ResponsiveAtTablet: StoryFn<typeof Columns> = (args) => (
 	<Container style={style}>
 		<Columns {...args}>
 			<Column width={[1 / 2, 1 / 4]} style={style}>
@@ -278,7 +288,7 @@ ResponsiveAtTablet.parameters = {
 
 // *****************************************************************************
 
-export const ResponsiveHideAtTablet: Story<ColumnsProps> = (args) => (
+export const ResponsiveHideAtTablet: StoryFn<typeof Columns> = (args) => (
 	<Container style={style}>
 		<Columns {...args}>
 			<Column width={[0, 1 / 4]} style={style}>
@@ -302,7 +312,7 @@ ResponsiveHideAtTablet.parameters = {
 
 // *****************************************************************************
 
-export const ResponsiveHideAtMobile: Story<ColumnsProps> = (args) => (
+export const ResponsiveHideAtMobile: StoryFn<typeof Columns> = (args) => (
 	<Container style={style}>
 		<Columns {...args}>
 			<Column width={[0, 1 / 4]} style={style}>
@@ -326,7 +336,7 @@ ResponsiveHideAtMobile.parameters = {
 
 // *****************************************************************************
 
-export const WithSpan: Story<ColumnsProps> = () => (
+export const WithSpan: StoryFn<typeof Columns> = () => (
 	<>
 		<p>
 			Elements with a <Code>{'span'}</Code> prop will scale at our{' '}
@@ -423,7 +433,7 @@ WithSpan.parameters = {
 
 // *****************************************************************************
 
-export const WithWidth: Story<ColumnsProps> = () => (
+export const WithWidth: StoryFn<typeof Columns> = () => (
 	<>
 		<Container style={style}>
 			<Columns>

--- a/libs/@guardian/source-react-components/src/container/Container.stories.tsx
+++ b/libs/@guardian/source-react-components/src/container/Container.stories.tsx
@@ -1,8 +1,8 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { ContainerProps } from './Container';
 import { Container } from './Container';
 
-export default {
+const meta: Meta<typeof Container> = {
 	title: 'Container',
 	component: Container,
 	argTypes: {
@@ -18,7 +18,9 @@ export default {
 	},
 };
 
-const Template: Story = (args: ContainerProps) => (
+export default meta;
+
+const Template: StoryFn<typeof Container> = (args: ContainerProps) => (
 	<Container {...args}>
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliud igitur esse
 		censet gaudere, aliud non dolere. Quid turpius quam sapientis vitam ex
@@ -28,25 +30,25 @@ const Template: Story = (args: ContainerProps) => (
 	</Container>
 );
 
-export const Default = Template.bind({});
+export const Default: StoryFn<typeof Container> = Template.bind({});
 
 // *****************************************************************************
 
-export const WithSideBorders = Template.bind({});
+export const WithSideBorders: StoryFn<typeof Container> = Template.bind({});
 WithSideBorders.args = {
 	sideBorders: true,
 };
 
 // *****************************************************************************
 
-export const WithTopBorder = Template.bind({});
+export const WithTopBorder: StoryFn<typeof Container> = Template.bind({});
 WithTopBorder.args = {
 	topBorder: true,
 };
 
 // *****************************************************************************
 
-export const WithBorderColour = Template.bind({});
+export const WithBorderColour: StoryFn<typeof Container> = Template.bind({});
 WithBorderColour.args = {
 	sideBorders: true,
 	topBorder: true,
@@ -55,14 +57,16 @@ WithBorderColour.args = {
 
 // *****************************************************************************
 
-export const WithBackgroundColour = Template.bind({});
+export const WithBackgroundColour: StoryFn<typeof Container> = Template.bind(
+	{},
+);
 WithBackgroundColour.args = {
 	backgroundColor: 'red',
 };
 
 // *****************************************************************************
 
-export const WithAsideElement = Template.bind({});
+export const WithAsideElement: StoryFn<typeof Container> = Template.bind({});
 WithAsideElement.args = {
 	element: 'aside',
 };

--- a/libs/@guardian/source-react-components/src/footer/BackToTop.stories.tsx
+++ b/libs/@guardian/source-react-components/src/footer/BackToTop.stories.tsx
@@ -2,12 +2,12 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { BackToTop } from './BackToTop';
 
 const meta: Meta<typeof BackToTop> = {
-	component: BackToTop,
+	component: () => BackToTop,
 	title: 'BackToTop',
 };
 
 export default meta;
 
-const Template: StoryFn<typeof BackToTop> = () => <BackToTop />;
+const Template: StoryFn<typeof BackToTop> = () => BackToTop;
 
 export const Default: StoryFn<typeof BackToTop> = Template.bind({});

--- a/libs/@guardian/source-react-components/src/footer/BackToTop.stories.tsx
+++ b/libs/@guardian/source-react-components/src/footer/BackToTop.stories.tsx
@@ -1,11 +1,13 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { BackToTop } from './BackToTop';
 
-export default {
+const meta: Meta<typeof BackToTop> = {
 	component: BackToTop,
 	title: 'BackToTop',
 };
 
-const Template: Story = () => BackToTop;
+export default meta;
 
-export const Default = Template.bind({});
+const Template: StoryFn<typeof BackToTop> = () => <BackToTop />;
+
+export const Default: StoryFn<typeof BackToTop> = Template.bind({});

--- a/libs/@guardian/source-react-components/src/footer/BackToTop.tsx
+++ b/libs/@guardian/source-react-components/src/footer/BackToTop.tsx
@@ -3,13 +3,11 @@ import { SvgChevronUpSingle } from '../../vendor/icons/SvgChevronUpSingle';
 import type { Theme } from '../@types/Theme';
 import { backToTop, backToTopIcon } from './styles';
 
-export const BackToTop = (): EmotionJSX.Element => {
-	return (
-		<a href="#top" css={(theme: Theme) => backToTop(theme.footer)}>
-			Back to top
-			<div css={(theme: Theme) => backToTopIcon(theme.footer)}>
-				<SvgChevronUpSingle />
-			</div>
-		</a>
-	);
-};
+export const BackToTop: EmotionJSX.Element = (
+	<a href="#top" css={(theme: Theme) => backToTop(theme.footer)}>
+		Back to top
+		<div css={(theme: Theme) => backToTopIcon(theme.footer)}>
+			<SvgChevronUpSingle />
+		</div>
+	</a>
+);

--- a/libs/@guardian/source-react-components/src/footer/BackToTop.tsx
+++ b/libs/@guardian/source-react-components/src/footer/BackToTop.tsx
@@ -1,12 +1,15 @@
+import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import { SvgChevronUpSingle } from '../../vendor/icons/SvgChevronUpSingle';
 import type { Theme } from '../@types/Theme';
 import { backToTop, backToTopIcon } from './styles';
 
-export const BackToTop = (
-	<a href="#top" css={(theme: Theme) => backToTop(theme.footer)}>
-		Back to top
-		<div css={(theme: Theme) => backToTopIcon(theme.footer)}>
-			<SvgChevronUpSingle />
-		</div>
-	</a>
-);
+export const BackToTop = (): EmotionJSX.Element => {
+	return (
+		<a href="#top" css={(theme: Theme) => backToTop(theme.footer)}>
+			Back to top
+			<div css={(theme: Theme) => backToTopIcon(theme.footer)}>
+				<SvgChevronUpSingle />
+			</div>
+		</a>
+	);
+};

--- a/libs/@guardian/source-react-components/src/footer/Footer.stories.tsx
+++ b/libs/@guardian/source-react-components/src/footer/Footer.stories.tsx
@@ -1,9 +1,9 @@
 import { breakpoints } from '@guardian/source-foundations';
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { FooterProps } from './Footer';
 import { Footer } from './Footer';
 
-export default {
+const meta: Meta<typeof Footer> = {
 	component: Footer,
 	title: 'Footer',
 	argTypes: {
@@ -28,12 +28,18 @@ export default {
 	},
 };
 
-const Template: Story = (args: FooterProps) => <Footer {...args} />;
+export default meta;
 
-export const DefaultDefaultTheme = Template.bind({});
+const Template: StoryFn<typeof Footer> = (args: FooterProps) => (
+	<Footer {...args} />
+);
+
+export const DefaultDefaultTheme: StoryFn<typeof Footer> = Template.bind({});
 DefaultDefaultTheme.args = { children: 'with' };
 
-export const DefaultTabletDefaultTheme = Template.bind({});
+export const DefaultTabletDefaultTheme: StoryFn<typeof Footer> = Template.bind(
+	{},
+);
 DefaultTabletDefaultTheme.args = { children: 'with' };
 DefaultTabletDefaultTheme.parameters = {
 	viewport: { defaultViewport: 'tablet' },
@@ -42,7 +48,9 @@ DefaultTabletDefaultTheme.parameters = {
 	},
 };
 
-export const DefaultMobileDefaultTheme = Template.bind({});
+export const DefaultMobileDefaultTheme: StoryFn<typeof Footer> = Template.bind(
+	{},
+);
 DefaultMobileDefaultTheme.args = { children: 'with' };
 DefaultMobileDefaultTheme.parameters = {
 	viewport: { defaultViewport: 'mobileMedium' },
@@ -51,10 +59,13 @@ DefaultMobileDefaultTheme.parameters = {
 	},
 };
 
-export const WithBackToTopDefaultTheme = Template.bind({});
+export const WithBackToTopDefaultTheme: StoryFn<typeof Footer> = Template.bind(
+	{},
+);
 WithBackToTopDefaultTheme.args = { showBackToTop: true, children: 'with' };
 
-export const WithBackToTopTabletDefaultTheme = Template.bind({});
+export const WithBackToTopTabletDefaultTheme: StoryFn<typeof Footer> =
+	Template.bind({});
 WithBackToTopTabletDefaultTheme.args = {
 	showBackToTop: true,
 	children: 'with',
@@ -66,7 +77,8 @@ WithBackToTopTabletDefaultTheme.parameters = {
 	},
 };
 
-export const WithBackToTopMobileDefaultTheme = Template.bind({});
+export const WithBackToTopMobileDefaultTheme: StoryFn<typeof Footer> =
+	Template.bind({});
 WithBackToTopMobileDefaultTheme.args = {
 	showBackToTop: true,
 	children: 'with',
@@ -78,10 +90,12 @@ WithBackToTopMobileDefaultTheme.parameters = {
 	},
 };
 
-export const WithoutChildrenDefaultTheme = Template.bind({});
+export const WithoutChildrenDefaultTheme: StoryFn<typeof Footer> =
+	Template.bind({});
 WithoutChildrenDefaultTheme.args = { children: 'without' };
 
-export const WithoutChildrenTabletDefaultTheme = Template.bind({});
+export const WithoutChildrenTabletDefaultTheme: StoryFn<typeof Footer> =
+	Template.bind({});
 WithoutChildrenTabletDefaultTheme.args = { children: 'without' };
 WithoutChildrenTabletDefaultTheme.parameters = {
 	viewport: { defaultViewport: 'tablet' },
@@ -90,7 +104,8 @@ WithoutChildrenTabletDefaultTheme.parameters = {
 	},
 };
 
-export const WithoutChildrenMobileDefaultTheme = Template.bind({});
+export const WithoutChildrenMobileDefaultTheme: StoryFn<typeof Footer> =
+	Template.bind({});
 WithoutChildrenMobileDefaultTheme.args = { children: 'without' };
 WithoutChildrenMobileDefaultTheme.parameters = {
 	viewport: { defaultViewport: 'mobileMedium' },
@@ -99,13 +114,16 @@ WithoutChildrenMobileDefaultTheme.parameters = {
 	},
 };
 
-export const WithoutChildrenWithBackToTopDefaultTheme = Template.bind({});
+export const WithoutChildrenWithBackToTopDefaultTheme: StoryFn<typeof Footer> =
+	Template.bind({});
 WithoutChildrenWithBackToTopDefaultTheme.args = {
 	showBackToTop: true,
 	children: 'without',
 };
 
-export const WithoutChildrenWithBackToTopTabletDefaultTheme = Template.bind({});
+export const WithoutChildrenWithBackToTopTabletDefaultTheme: StoryFn<
+	typeof Footer
+> = Template.bind({});
 WithoutChildrenWithBackToTopTabletDefaultTheme.args = {
 	showBackToTop: true,
 	children: 'without',
@@ -117,7 +135,9 @@ WithoutChildrenWithBackToTopTabletDefaultTheme.parameters = {
 	},
 };
 
-export const WithoutChildrenWithBackToTopMobileDefaultTheme = Template.bind({});
+export const WithoutChildrenWithBackToTopMobileDefaultTheme: StoryFn<
+	typeof Footer
+> = Template.bind({});
 WithoutChildrenWithBackToTopMobileDefaultTheme.args = {
 	showBackToTop: true,
 	children: 'without',

--- a/libs/@guardian/source-react-components/src/footer/Footer.tsx
+++ b/libs/@guardian/source-react-components/src/footer/Footer.tsx
@@ -45,7 +45,7 @@ export const Footer = ({
 				]}
 			>
 				<div css={(theme: Theme) => links(theme.footer)}>{children}</div>
-				{showBackToTop ? <BackToTop /> : ''}
+				{showBackToTop ? BackToTop : ''}
 			</div>
 			<small css={[copyright, showBackToTop ? copyrightExtraPadding : '']}>
 				&copy; 2021 Guardian News and Media Limited or its affiliated companies.

--- a/libs/@guardian/source-react-components/src/footer/Footer.tsx
+++ b/libs/@guardian/source-react-components/src/footer/Footer.tsx
@@ -45,7 +45,7 @@ export const Footer = ({
 				]}
 			>
 				<div css={(theme: Theme) => links(theme.footer)}>{children}</div>
-				{showBackToTop ? BackToTop : ''}
+				{showBackToTop ? <BackToTop /> : ''}
 			</div>
 			<small css={[copyright, showBackToTop ? copyrightExtraPadding : '']}>
 				&copy; 2021 Guardian News and Media Limited or its affiliated companies.

--- a/libs/@guardian/source-react-components/src/hide/Hide.stories.tsx
+++ b/libs/@guardian/source-react-components/src/hide/Hide.stories.tsx
@@ -1,9 +1,9 @@
 import { breakpoints } from '@guardian/source-foundations';
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { HideProps } from './Hide';
 import { Hide } from './Hide';
 
-export default {
+const meta: Meta<typeof Hide> = {
 	title: 'Hide',
 	component: Hide,
 	argTypes: {
@@ -16,7 +16,9 @@ export default {
 	},
 };
 
-const Template: Story = (args: HideProps) => (
+export default meta;
+
+const Template: StoryFn<typeof Hide> = (args: HideProps) => (
 	<Hide {...args}>
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliud igitur esse
 		censet gaudere, aliud non dolere. Quid turpius quam sapientis vitam ex
@@ -28,7 +30,7 @@ const Template: Story = (args: HideProps) => (
 
 // *****************************************************************************
 
-export const HiddenFromTabletAtMobile = Template.bind({});
+export const HiddenFromTabletAtMobile: StoryFn<typeof Hide> = Template.bind({});
 HiddenFromTabletAtMobile.args = {
 	from: 'tablet',
 };
@@ -41,7 +43,7 @@ HiddenFromTabletAtMobile.parameters = {
 
 // *****************************************************************************
 
-export const HiddenFromTabletAtTablet = Template.bind({});
+export const HiddenFromTabletAtTablet: StoryFn<typeof Hide> = Template.bind({});
 HiddenFromTabletAtTablet.args = {
 	from: 'tablet',
 };
@@ -54,7 +56,9 @@ HiddenFromTabletAtTablet.parameters = {
 
 // *****************************************************************************
 
-export const HiddenUntilTabletAtMobile = Template.bind({});
+export const HiddenUntilTabletAtMobile: StoryFn<typeof Hide> = Template.bind(
+	{},
+);
 HiddenUntilTabletAtMobile.args = {
 	until: 'tablet',
 };
@@ -67,7 +71,9 @@ HiddenUntilTabletAtMobile.parameters = {
 
 // *****************************************************************************
 
-export const HiddenUntilTabletAtTablet = Template.bind({});
+export const HiddenUntilTabletAtTablet: StoryFn<typeof Hide> = Template.bind(
+	{},
+);
 HiddenUntilTabletAtTablet.args = {
 	until: 'tablet',
 };

--- a/libs/@guardian/source-react-components/src/icons/Icons.stories.tsx
+++ b/libs/@guardian/source-react-components/src/icons/Icons.stories.tsx
@@ -1,7 +1,5 @@
 import { css } from '@emotion/react';
-import type { Story } from '@storybook/react';
-// These types are the right types, but don't work with Storybook v6 which uses Emotion v10
-// import type { Args, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { SvgAlertPhone } from '../../vendor/icons/SvgAlertPhone';
 import { SvgAlertRound } from '../../vendor/icons/SvgAlertRound';
 import { SvgAlertTriangle } from '../../vendor/icons/SvgAlertTriangle';
@@ -257,18 +255,21 @@ const widePaymentIcons = {
 	SvgDirectDebitWide,
 };
 
-export default {
-	title: 'Icons',
-};
-
-// *****************************************************************************
-
 type IconChromaticStoryArgs = {
 	size: IconSize;
 	icons: Array<React.FunctionComponent<IconProps>>;
 	isAnnouncedByScreenReader: boolean;
 };
-const Template: Story<IconChromaticStoryArgs> = (
+
+const meta: Meta<IconChromaticStoryArgs> = {
+	title: 'Icons',
+};
+
+export default meta;
+
+// *****************************************************************************
+
+const Template: StoryFn<IconChromaticStoryArgs> = (
 	args: IconChromaticStoryArgs,
 ) => {
 	const icons = args.icons.map((Icon, index) => (
@@ -284,7 +285,8 @@ const Template: Story<IconChromaticStoryArgs> = (
 
 // *****************************************************************************
 
-export const XsmallIconsDefaultTheme = Template.bind({});
+export const XsmallIconsDefaultTheme: StoryFn<IconChromaticStoryArgs> =
+	Template.bind({});
 XsmallIconsDefaultTheme.args = {
 	size: 'xsmall',
 	isAnnouncedByScreenReader: true,
@@ -293,7 +295,8 @@ XsmallIconsDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const SmallIconsDefaultTheme = Template.bind({});
+export const SmallIconsDefaultTheme: StoryFn<IconChromaticStoryArgs> =
+	Template.bind({});
 SmallIconsDefaultTheme.args = {
 	size: 'small',
 	isAnnouncedByScreenReader: true,
@@ -302,7 +305,8 @@ SmallIconsDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const MediumIconsDefaultTheme = Template.bind({});
+export const MediumIconsDefaultTheme: StoryFn<IconChromaticStoryArgs> =
+	Template.bind({});
 MediumIconsDefaultTheme.args = {
 	size: 'medium',
 	isAnnouncedByScreenReader: true,
@@ -311,7 +315,8 @@ MediumIconsDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const MediumIconsBrandTheme = Template.bind({});
+export const MediumIconsBrandTheme: StoryFn<IconChromaticStoryArgs> =
+	Template.bind({});
 MediumIconsBrandTheme.args = {
 	size: 'medium',
 	isAnnouncedByScreenReader: true,
@@ -323,7 +328,7 @@ MediumIconsBrandTheme.parameters = {
 	},
 };
 MediumIconsBrandTheme.decorators = [
-	(Story: Story) => (
+	(Story: StoryFn) => (
 		<div
 			css={css`
 				svg {
@@ -338,7 +343,8 @@ MediumIconsBrandTheme.decorators = [
 
 // *****************************************************************************
 
-export const PaymentIconsDefaultTheme = Template.bind({});
+export const PaymentIconsDefaultTheme: StoryFn<IconChromaticStoryArgs> =
+	Template.bind({});
 PaymentIconsDefaultTheme.args = {
 	size: 'medium',
 	isAnnouncedByScreenReader: true,
@@ -347,7 +353,8 @@ PaymentIconsDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const WidePaymentIconsDefaultTheme = Template.bind({});
+export const WidePaymentIconsDefaultTheme: StoryFn<IconChromaticStoryArgs> =
+	Template.bind({});
 WidePaymentIconsDefaultTheme.args = {
 	size: 'medium',
 	isAnnouncedByScreenReader: true,

--- a/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
+++ b/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
@@ -1,13 +1,15 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { InlineProps } from './Inline';
 import { Inline } from './Inline';
 
-export default {
+const meta: Meta<typeof Inline> = {
 	title: 'Inline',
 	component: Inline,
 };
 
-const Template: Story = (args: InlineProps) => (
+export default meta;
+
+const Template: StoryFn<typeof Inline> = (args: InlineProps) => (
 	<Inline {...args}>
 		{args.children ?? (
 			<>
@@ -19,74 +21,74 @@ const Template: Story = (args: InlineProps) => (
 	</Inline>
 );
 
-export const NoSpace = Template.bind({});
+export const NoSpace: StoryFn<typeof Inline> = Template.bind({});
 
 // *****************************************************************************
 
-export const Space1 = Template.bind({});
+export const Space1: StoryFn<typeof Inline> = Template.bind({});
 Space1.args = {
 	space: 1,
 };
 
 // *****************************************************************************
 
-export const Space2 = Template.bind({});
+export const Space2: StoryFn<typeof Inline> = Template.bind({});
 Space2.args = {
 	space: 2,
 };
 
 // *****************************************************************************
 
-export const Space3 = Template.bind({});
+export const Space3: StoryFn<typeof Inline> = Template.bind({});
 Space3.args = {
 	space: 3,
 };
 
 // *****************************************************************************
 
-export const Space4 = Template.bind({});
+export const Space4: StoryFn<typeof Inline> = Template.bind({});
 Space4.args = {
 	space: 4,
 };
 
 // *****************************************************************************
 
-export const Space5 = Template.bind({});
+export const Space5: StoryFn<typeof Inline> = Template.bind({});
 Space5.args = {
 	space: 5,
 };
 
 // *****************************************************************************
 
-export const Space6 = Template.bind({});
+export const Space6: StoryFn<typeof Inline> = Template.bind({});
 Space6.args = {
 	space: 6,
 };
 
 // *****************************************************************************
 
-export const Space9 = Template.bind({});
+export const Space9: StoryFn<typeof Inline> = Template.bind({});
 Space9.args = {
 	space: 9,
 };
 
 // *****************************************************************************
 
-export const Space12 = Template.bind({});
+export const Space12: StoryFn<typeof Inline> = Template.bind({});
 Space12.args = {
 	space: 12,
 };
 
 // *****************************************************************************
 
-export const Space24 = Template.bind({});
+export const Space24: StoryFn<typeof Inline> = Template.bind({});
 Space24.args = {
 	space: 24,
 };
 
 // *****************************************************************************
 
-export const LotsOfItems = Template.bind({});
+export const LotsOfItems: StoryFn<typeof Inline> = Template.bind({});
 LotsOfItems.args = {
 	children: [
 		<div key={1}>[Item 1]</div>,

--- a/libs/@guardian/source-react-components/src/label/Label.stories.tsx
+++ b/libs/@guardian/source-react-components/src/label/Label.stories.tsx
@@ -1,11 +1,9 @@
-import type { Story } from '@storybook/react';
-// These types are the right types, but don't work with Storybook v6 which uses Emotion v10
-// import type { Args, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Label } from './Label';
 import { labelThemeBrand } from './theme';
 import type { LabelProps } from './types';
 
-export default {
+const meta: Meta<typeof Label> = {
 	title: 'Label',
 	args: {
 		text: 'Email',
@@ -15,7 +13,9 @@ export default {
 	component: Label,
 };
 
-const Template: Story<LabelProps> = (args: LabelProps) => (
+export default meta;
+
+const Template: StoryFn<typeof Label> = (args: LabelProps) => (
 	<Label {...args}>
 		<input type="email" />
 	</Label>
@@ -23,32 +23,37 @@ const Template: Story<LabelProps> = (args: LabelProps) => (
 
 // *****************************************************************************
 
-export const DefaultDefaultTheme = Template.bind({});
+export const DefaultDefaultTheme: StoryFn<typeof Label> = Template.bind({});
 
 // *****************************************************************************
 
-export const WithSupportingTextDefaultTheme = Template.bind({});
+export const WithSupportingTextDefaultTheme: StoryFn<typeof Label> =
+	Template.bind({});
 WithSupportingTextDefaultTheme.args = {
 	supporting: 'alex@example.com',
 };
 
 // *****************************************************************************
 
-export const WithOptionalDefaultTheme = Template.bind({});
+export const WithOptionalDefaultTheme: StoryFn<typeof Label> = Template.bind(
+	{},
+);
 WithOptionalDefaultTheme.args = {
 	optional: true,
 };
 
 // *****************************************************************************
 
-export const WithHiddenLabelDefaultTheme = Template.bind({});
+export const WithHiddenLabelDefaultTheme: StoryFn<typeof Label> = Template.bind(
+	{},
+);
 WithHiddenLabelDefaultTheme.args = {
 	hideLabel: true,
 };
 
 // *****************************************************************************
 
-export const DefaultBrandTheme = Template.bind({});
+export const DefaultBrandTheme: StoryFn<typeof Label> = Template.bind({});
 DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -58,7 +63,8 @@ DefaultBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const WithSupportingTextBrandTheme = Template.bind({});
+export const WithSupportingTextBrandTheme: StoryFn<typeof Label> =
+	Template.bind({});
 WithSupportingTextBrandTheme.args = {
 	supporting: 'alex@example.com',
 };
@@ -71,7 +77,7 @@ WithSupportingTextBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const WithOptionalBrandTheme = Template.bind({});
+export const WithOptionalBrandTheme: StoryFn<typeof Label> = Template.bind({});
 WithOptionalBrandTheme.args = {
 	optional: true,
 };
@@ -84,7 +90,8 @@ WithOptionalBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const WithHiddenLabelThemeBrandTheme = Template.bind({});
+export const WithHiddenLabelThemeBrandTheme: StoryFn<typeof Label> =
+	Template.bind({});
 WithHiddenLabelThemeBrandTheme.args = {
 	hideLabel: true,
 };

--- a/libs/@guardian/source-react-components/src/label/Legend.stories.tsx
+++ b/libs/@guardian/source-react-components/src/label/Legend.stories.tsx
@@ -1,11 +1,9 @@
-import type { Story } from '@storybook/react';
-// These types are the right types, but don't work with Storybook v6 which uses Emotion v10
-// import type { Args, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Legend } from './Legend';
 import { labelThemeBrand } from './theme';
 import type { LegendProps } from './types';
 
-export default {
+const meta: Meta<typeof Legend> = {
 	title: 'Legend',
 	args: {
 		text: 'Email',
@@ -31,7 +29,9 @@ export default {
 	component: Legend,
 };
 
-const Template: Story<LegendProps> = (args: LegendProps) => (
+export default meta;
+
+const Template: StoryFn<typeof Legend> = (args: LegendProps) => (
 	<fieldset>
 		<Legend {...args} />
 	</fieldset>
@@ -39,39 +39,44 @@ const Template: Story<LegendProps> = (args: LegendProps) => (
 
 // *****************************************************************************
 
-export const DefaultDefaultTheme = Template.bind({});
+export const DefaultDefaultTheme: StoryFn<typeof Legend> = Template.bind({});
 
 // *****************************************************************************
 
-export const WithSupportingTextDefaultTheme = Template.bind({});
+export const WithSupportingTextDefaultTheme: StoryFn<typeof Legend> =
+	Template.bind({});
 WithSupportingTextDefaultTheme.args = {
 	supporting: 'text',
 };
 
 // *****************************************************************************
 
-export const WithSupportingComponentDefaultTheme = Template.bind({});
+export const WithSupportingComponentDefaultTheme: StoryFn<typeof Legend> =
+	Template.bind({});
 WithSupportingComponentDefaultTheme.args = {
 	supporting: 'component',
 };
 
 // *****************************************************************************
 
-export const WithOptionalDefaultTheme = Template.bind({});
+export const WithOptionalDefaultTheme: StoryFn<typeof Legend> = Template.bind(
+	{},
+);
 WithOptionalDefaultTheme.args = {
 	optional: true,
 };
 
 // *****************************************************************************
 
-export const WithHiddenLabelDefaultTheme = Template.bind({});
+export const WithHiddenLabelDefaultTheme: StoryFn<typeof Legend> =
+	Template.bind({});
 WithHiddenLabelDefaultTheme.args = {
 	hideLabel: true,
 };
 
 // *****************************************************************************
 
-export const DefaultBrandTheme = Template.bind({});
+export const DefaultBrandTheme: StoryFn<typeof Legend> = Template.bind({});
 DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -81,7 +86,8 @@ DefaultBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const WithSupportingTextBrandTheme = Template.bind({});
+export const WithSupportingTextBrandTheme: StoryFn<typeof Legend> =
+	Template.bind({});
 WithSupportingTextBrandTheme.args = {
 	supporting: 'text',
 };
@@ -94,7 +100,8 @@ WithSupportingTextBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const WithSupportingComponentBrandTheme = Template.bind({});
+export const WithSupportingComponentBrandTheme: StoryFn<typeof Legend> =
+	Template.bind({});
 WithSupportingComponentBrandTheme.args = {
 	supporting: 'component',
 };
@@ -107,7 +114,7 @@ WithSupportingComponentBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const WithOptionalBrandTheme = Template.bind({});
+export const WithOptionalBrandTheme: StoryFn<typeof Legend> = Template.bind({});
 WithOptionalBrandTheme.args = {
 	optional: true,
 };
@@ -120,7 +127,9 @@ WithOptionalBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const WithHiddenLabelBrandTheme = Template.bind({});
+export const WithHiddenLabelBrandTheme: StoryFn<typeof Legend> = Template.bind(
+	{},
+);
 WithHiddenLabelBrandTheme.args = {
 	hideLabel: true,
 };

--- a/libs/@guardian/source-react-components/src/link/ButtonLink.stories.tsx
+++ b/libs/@guardian/source-react-components/src/link/ButtonLink.stories.tsx
@@ -1,9 +1,9 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { SvgExternal } from '../../vendor/icons/SvgExternal';
 import type { ButtonLinkProps } from './ButtonLink';
 import { ButtonLink } from './ButtonLink';
 
-export default {
+const meta: Meta<typeof ButtonLink> = {
 	title: 'ButtonLink',
 	component: ButtonLink,
 	args: {
@@ -23,37 +23,44 @@ export default {
 	},
 };
 
-const Template: Story = (args: ButtonLinkProps) => (
+export default meta;
+
+const Template: StoryFn<typeof ButtonLink> = (args: ButtonLinkProps) => (
 	<ButtonLink {...args}>Return to home page</ButtonLink>
 );
 
-export const PrimaryButtonLinkDefaultTheme = Template.bind({});
+export const PrimaryButtonLinkDefaultTheme: StoryFn<typeof ButtonLink> =
+	Template.bind({});
 PrimaryButtonLinkDefaultTheme.args = {
-	icon: 'undefined',
+	icon: undefined,
 };
 
 // *****************************************************************************
 
-export const SecondaryButtonLinkDefaultTheme = Template.bind({});
+export const SecondaryButtonLinkDefaultTheme: StoryFn<typeof ButtonLink> =
+	Template.bind({});
 SecondaryButtonLinkDefaultTheme.args = {
 	priority: 'secondary',
-	icon: 'undefined',
+	icon: undefined,
 };
 
 // *****************************************************************************
 
-export const PrimaryIconButtonLinkDefaultTheme = Template.bind({});
+export const PrimaryIconButtonLinkDefaultTheme: StoryFn<typeof ButtonLink> =
+	Template.bind({});
 
 // *****************************************************************************
 
-export const SecondaryIconButtonLinkDefaultTheme = Template.bind({});
+export const SecondaryIconButtonLinkDefaultTheme: StoryFn<typeof ButtonLink> =
+	Template.bind({});
 SecondaryIconButtonLinkDefaultTheme.args = {
 	priority: 'secondary',
 };
 
 // *****************************************************************************
 
-export const RightIconButtonLinkDefaultTheme = Template.bind({});
+export const RightIconButtonLinkDefaultTheme: StoryFn<typeof ButtonLink> =
+	Template.bind({});
 RightIconButtonLinkDefaultTheme.args = {
 	iconSide: 'right',
 };

--- a/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
@@ -1,12 +1,9 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Radio } from './Radio';
 import type { RadioProps } from './Radio';
 import { radioThemeBrand } from './theme';
 
-// These types are the right types, but don't work with Storybook v6 which uses Emotion v10
-// import type { Args, Story } from '@storybook/react';
-
-export default {
+const meta: Meta<typeof Radio> = {
 	title: 'Radio',
 	component: Radio,
 	argTypes: {
@@ -32,13 +29,17 @@ export default {
 	},
 };
 
-const Template: Story = (args: RadioProps) => <Radio {...args} />;
+export default meta;
 
-export const DefaultDefaultTheme = Template.bind({});
+const Template: StoryFn<typeof Radio> = (args: RadioProps) => (
+	<Radio {...args} />
+);
+
+export const DefaultDefaultTheme: StoryFn<typeof Radio> = Template.bind({});
 
 // *****************************************************************************
 
-export const DefaultBrandTheme = Template.bind({});
+export const DefaultBrandTheme: StoryFn<typeof Radio> = Template.bind({});
 DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -48,14 +49,18 @@ DefaultBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const SupportingTextDefaultTheme = Template.bind({});
+export const SupportingTextDefaultTheme: StoryFn<typeof Radio> = Template.bind(
+	{},
+);
 SupportingTextDefaultTheme.args = {
 	supporting: 'Hex colour code: #ff0000',
 };
 
 // *****************************************************************************
 
-export const SupportingTextBrandTheme = Template.bind({});
+export const SupportingTextBrandTheme: StoryFn<typeof Radio> = Template.bind(
+	{},
+);
 SupportingTextBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -68,7 +73,8 @@ SupportingTextBrandTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingTextOnlyDefaultTheme = Template.bind({});
+export const SupportingTextOnlyDefaultTheme: StoryFn<typeof Radio> =
+	Template.bind({});
 SupportingTextOnlyDefaultTheme.args = {
 	supporting: 'Hex colour code: #ff0000',
 	label: null,
@@ -76,7 +82,8 @@ SupportingTextOnlyDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingTextOnlyBrandTheme = Template.bind({});
+export const SupportingTextOnlyBrandTheme: StoryFn<typeof Radio> =
+	Template.bind({});
 SupportingTextOnlyBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -90,7 +97,7 @@ SupportingTextOnlyBrandTheme.args = {
 
 // *****************************************************************************
 
-export const UnlabelledDefaultTheme = Template.bind({});
+export const UnlabelledDefaultTheme: StoryFn<typeof Radio> = Template.bind({});
 UnlabelledDefaultTheme.args = {
 	label: undefined,
 };

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
@@ -1,16 +1,13 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Radio } from './Radio';
 import RadioStories from './Radio.stories';
 import type { RadioGroupProps } from './RadioGroup';
 import { RadioGroup } from './RadioGroup';
 import { radioThemeBrand } from './theme';
-// These types are the right types, but don't work with Storybook v6 which uses Emotion v10
-// import type { Args, Story } from '@storybook/react';
 
-export default {
+const meta: Meta<typeof RadioGroup> = {
 	title: 'RadioGroup',
 	component: RadioGroup,
-	subcomponents: { Radio },
 	args: {
 		name: 'colours',
 		label: 'Select your preferred colour',
@@ -32,6 +29,8 @@ export default {
 	},
 };
 
+export default meta;
+
 const Image = () => (
 	<img
 		style={{ padding: `8px 0` }}
@@ -40,18 +39,20 @@ const Image = () => (
 	/>
 );
 
-const Template: Story = (args: RadioGroupProps) => (
+const Template: StoryFn<typeof RadioGroup> = (args: RadioGroupProps) => (
 	<RadioGroup {...args}>
 		<Radio {...RadioStories.args} key="radio-1" />
 		<Radio label="Blue" value="blue" key="radio-2" />
 	</RadioGroup>
 );
 
-export const DefaultDefaultTheme = Template.bind({});
+export const DefaultDefaultTheme: StoryFn<typeof RadioGroup> = Template.bind(
+	{},
+);
 
 // *****************************************************************************
 
-export const DefaultBrandTheme = Template.bind({});
+export const DefaultBrandTheme: StoryFn<typeof RadioGroup> = Template.bind({});
 DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -61,28 +62,33 @@ DefaultBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const HorizontalDefaultTheme = Template.bind({});
+export const HorizontalDefaultTheme: StoryFn<typeof RadioGroup> = Template.bind(
+	{},
+);
 HorizontalDefaultTheme.args = {
 	orientation: 'horizontal',
 };
 
 // *****************************************************************************
 
-export const VisuallyHideLegendDefaultTheme = Template.bind({});
+export const VisuallyHideLegendDefaultTheme: StoryFn<typeof RadioGroup> =
+	Template.bind({});
 VisuallyHideLegendDefaultTheme.args = {
 	hideLabel: true,
 };
 
 // *****************************************************************************
 
-export const SupportingTextDefaultTheme = Template.bind({});
+export const SupportingTextDefaultTheme: StoryFn<typeof RadioGroup> =
+	Template.bind({});
 SupportingTextDefaultTheme.args = {
 	supporting: 'You can always change it later',
 };
 
 // *****************************************************************************
 
-export const SupportingTextBrandTheme = Template.bind({});
+export const SupportingTextBrandTheme: StoryFn<typeof RadioGroup> =
+	Template.bind({});
 SupportingTextBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -95,21 +101,22 @@ SupportingTextBrandTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingMediaDefaultTheme = Template.bind({});
+export const SupportingMediaDefaultTheme: StoryFn<typeof RadioGroup> =
+	Template.bind({});
 SupportingMediaDefaultTheme.args = {
 	supporting: <Image />,
 };
 
 // *****************************************************************************
 
-export const ErrorDefaultTheme = Template.bind({});
+export const ErrorDefaultTheme: StoryFn<typeof RadioGroup> = Template.bind({});
 ErrorDefaultTheme.args = {
 	error: 'The selected colour is out of stock',
 };
 
 // *****************************************************************************
 
-export const ErrorBrandTheme = Template.bind({});
+export const ErrorBrandTheme: StoryFn<typeof RadioGroup> = Template.bind({});
 ErrorBrandTheme.args = {
 	error: 'The selected colour is out of stock',
 };
@@ -122,7 +129,8 @@ ErrorBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const SupportingMediaWithErrorDefaultTheme = Template.bind({});
+export const SupportingMediaWithErrorDefaultTheme: StoryFn<typeof RadioGroup> =
+	Template.bind({});
 SupportingMediaWithErrorDefaultTheme.args = {
 	error: 'Please select a colour',
 	supporting: <Image />,

--- a/libs/@guardian/source-react-components/src/select/Select.stories.tsx
+++ b/libs/@guardian/source-react-components/src/select/Select.stories.tsx
@@ -1,12 +1,11 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Option } from './Option';
 import type { SelectProps } from './Select';
 import { Select } from './Select';
 
-export default {
+const meta: Meta<typeof Select> = {
 	title: 'Select',
 	component: Select,
-	subcomponents: { Option },
 	argTypes: {
 		error: {
 			options: ['undefined', 'error'],
@@ -36,7 +35,9 @@ export default {
 	},
 };
 
-const Template: Story<SelectProps> = (args: SelectProps) => (
+export default meta;
+
+const Template: StoryFn<typeof Select> = (args: SelectProps) => (
 	<Select {...args}>
 		<Option value="">Select a state</Option>
 		<Option value="al">Alabama</Option>
@@ -46,46 +47,52 @@ const Template: Story<SelectProps> = (args: SelectProps) => (
 
 // *****************************************************************************
 
-export const DefaultDefaultTheme = Template.bind({});
+export const DefaultDefaultTheme: StoryFn<typeof Select> = Template.bind({});
 
 // *****************************************************************************
 
-export const VisuallyHideLabelDefaultTheme = Template.bind({});
+export const VisuallyHideLabelDefaultTheme: StoryFn<typeof Select> =
+	Template.bind({});
 VisuallyHideLabelDefaultTheme.args = {
 	hideLabel: true,
 };
 
 // *****************************************************************************
 
-export const OptionalDefaultTheme = Template.bind({});
+export const OptionalDefaultTheme: StoryFn<typeof Select> = Template.bind({});
 OptionalDefaultTheme.args = {
 	optional: true,
 };
 
 // *****************************************************************************
 
-export const ErrorWithMessageDefaultTheme = Template.bind({});
+export const ErrorWithMessageDefaultTheme: StoryFn<typeof Select> =
+	Template.bind({});
 ErrorWithMessageDefaultTheme.args = {
 	error: 'error',
 };
 
 // *****************************************************************************
 
-export const SuccessWithMessageDefaultTheme = Template.bind({});
+export const SuccessWithMessageDefaultTheme: StoryFn<typeof Select> =
+	Template.bind({});
 SuccessWithMessageDefaultTheme.args = {
 	success: 'success',
 };
 
 // *****************************************************************************
 
-export const SupportingTextDefaultTheme = Template.bind({});
+export const SupportingTextDefaultTheme: StoryFn<typeof Select> = Template.bind(
+	{},
+);
 SupportingTextDefaultTheme.args = {
 	supporting: 'Leave blank if you are not within the US',
 };
 
 // *****************************************************************************
 
-export const SupportingSuccessTextDefaultTheme = Template.bind({});
+export const SupportingSuccessTextDefaultTheme: StoryFn<typeof Select> =
+	Template.bind({});
 SupportingSuccessTextDefaultTheme.args = {
 	supporting: 'Leave blank if you are not within the US',
 
@@ -94,7 +101,8 @@ SupportingSuccessTextDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingErrorTextDefaultTheme = Template.bind({});
+export const SupportingErrorTextDefaultTheme: StoryFn<typeof Select> =
+	Template.bind({});
 SupportingErrorTextDefaultTheme.args = {
 	supporting: 'Leave blank if you are not within the US',
 	error:

--- a/libs/@guardian/source-react-components/src/stack/Stack.stories.tsx
+++ b/libs/@guardian/source-react-components/src/stack/Stack.stories.tsx
@@ -1,13 +1,15 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { StackProps } from './Stack';
 import { Stack } from './Stack';
 
-export default {
+const meta: Meta<typeof Stack> = {
 	title: 'Stack',
 	component: Stack,
 };
 
-const Template: Story = (args: StackProps) => (
+export default meta;
+
+const Template: StoryFn<typeof Stack> = (args: StackProps) => (
 	<Stack {...args}>
 		<div>Item 1</div>
 		<div>Item 2</div>
@@ -15,67 +17,67 @@ const Template: Story = (args: StackProps) => (
 	</Stack>
 );
 
-export const Default = Template.bind({});
+export const Default: StoryFn<typeof Stack> = Template.bind({});
 
 // *****************************************************************************
 
-export const Space1 = Template.bind({});
+export const Space1: StoryFn<typeof Stack> = Template.bind({});
 Space1.args = {
 	space: 1,
 };
 
 // *****************************************************************************
 
-export const Space2 = Template.bind({});
+export const Space2: StoryFn<typeof Stack> = Template.bind({});
 Space2.args = {
 	space: 2,
 };
 
 // *****************************************************************************
 
-export const Space3 = Template.bind({});
+export const Space3: StoryFn<typeof Stack> = Template.bind({});
 Space3.args = {
 	space: 3,
 };
 
 // *****************************************************************************
 
-export const Space4 = Template.bind({});
+export const Space4: StoryFn<typeof Stack> = Template.bind({});
 Space4.args = {
 	space: 4,
 };
 
 // *****************************************************************************
 
-export const Space5 = Template.bind({});
+export const Space5: StoryFn<typeof Stack> = Template.bind({});
 Space5.args = {
 	space: 5,
 };
 
 // *****************************************************************************
 
-export const Space6 = Template.bind({});
+export const Space6: StoryFn<typeof Stack> = Template.bind({});
 Space6.args = {
 	space: 6,
 };
 
 // *****************************************************************************
 
-export const Space9 = Template.bind({});
+export const Space9: StoryFn<typeof Stack> = Template.bind({});
 Space9.args = {
 	space: 9,
 };
 
 // *****************************************************************************
 
-export const Space12 = Template.bind({});
+export const Space12: StoryFn<typeof Stack> = Template.bind({});
 Space12.args = {
 	space: 12,
 };
 
 // *****************************************************************************
 
-export const Space24 = Template.bind({});
+export const Space24: StoryFn<typeof Stack> = Template.bind({});
 Space24.args = {
 	space: 24,
 };

--- a/libs/@guardian/source-react-components/src/text-area/TextArea.stories.tsx
+++ b/libs/@guardian/source-react-components/src/text-area/TextArea.stories.tsx
@@ -1,9 +1,9 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import type { TextAreaProps } from './TextArea';
 import { TextArea } from './TextArea';
 
-export default {
+const meta: Meta<typeof TextArea> = {
 	title: 'TextArea',
 	component: TextArea,
 	argTypes: {
@@ -34,7 +34,9 @@ export default {
 	},
 };
 
-const Template: Story<TextAreaProps> = (args: TextAreaProps) => {
+export default meta;
+
+const Template: StoryFn<typeof TextArea> = (args: TextAreaProps) => {
 	const [value, setValue] = useState(args.value);
 
 	const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
@@ -45,32 +47,34 @@ const Template: Story<TextAreaProps> = (args: TextAreaProps) => {
 
 // *****************************************************************************
 
-export const DefaultDefaultTheme = Template.bind({});
+export const DefaultDefaultTheme: StoryFn<typeof TextArea> = Template.bind({});
 
 // *****************************************************************************
 
-export const WithRowsDefaultTheme = Template.bind({});
+export const WithRowsDefaultTheme: StoryFn<typeof TextArea> = Template.bind({});
 WithRowsDefaultTheme.args = {
 	rows: 10,
 };
 
 // *****************************************************************************
 
-export const OptionalDefaultTheme = Template.bind({});
+export const OptionalDefaultTheme: StoryFn<typeof TextArea> = Template.bind({});
 OptionalDefaultTheme.args = {
 	optional: true,
 };
 
 // *****************************************************************************
 
-export const VisuallyHideLabelDefaultTheme = Template.bind({});
+export const VisuallyHideLabelDefaultTheme: StoryFn<typeof TextArea> =
+	Template.bind({});
 VisuallyHideLabelDefaultTheme.args = {
 	hideLabel: true,
 };
 
 // *****************************************************************************
 
-export const SupportingTextDefaultTheme = Template.bind({});
+export const SupportingTextDefaultTheme: StoryFn<typeof TextArea> =
+	Template.bind({});
 SupportingTextDefaultTheme.args = {
 	supporting:
 		'Please keep comments respectful and abide by the community guidelines.',
@@ -78,28 +82,31 @@ SupportingTextDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const ErrorWithMessageDefaultTheme = Template.bind({});
+export const ErrorWithMessageDefaultTheme: StoryFn<typeof TextArea> =
+	Template.bind({});
 ErrorWithMessageDefaultTheme.args = {
 	error: 'error',
 };
 
 // *****************************************************************************
 
-export const SuccessWithMessageDefaultTheme = Template.bind({});
+export const SuccessWithMessageDefaultTheme: StoryFn<typeof TextArea> =
+	Template.bind({});
 SuccessWithMessageDefaultTheme.args = {
 	success: 'success',
 };
 
 // *****************************************************************************
 
-export const WithMaxLengthDefaultTheme = Template.bind({});
+export const WithMaxLengthDefaultTheme: StoryFn<typeof TextArea> =
+	Template.bind({});
 WithMaxLengthDefaultTheme.args = {
 	maxLength: 10,
 };
 
 // *****************************************************************************
 
-export const WithDefaultValue = Template.bind({});
+export const WithDefaultValue: StoryFn<typeof TextArea> = Template.bind({});
 WithDefaultValue.args = {
 	value: 'This is a value passed in as a prop',
 };

--- a/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
+++ b/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
@@ -1,9 +1,9 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import { TextInput } from './TextInput';
 import type { TextInputProps } from './TextInput';
 
-export default {
+const meta: Meta<typeof TextInput> = {
 	title: 'TextInput',
 	component: TextInput,
 	args: {
@@ -35,7 +35,9 @@ export default {
 	},
 };
 
-const Template: Story<TextInputProps> = (args: TextInputProps) => {
+export default meta;
+
+const Template: StoryFn<typeof TextInput> = (args: TextInputProps) => {
 	const [state, setState] = useState('');
 	return (
 		<TextInput
@@ -46,32 +48,37 @@ const Template: Story<TextInputProps> = (args: TextInputProps) => {
 	);
 };
 
-export const DefaultDefaultTheme = Template.bind({});
+export const DefaultDefaultTheme: StoryFn<typeof TextInput> = Template.bind({});
 
 // *****************************************************************************
 
-export const OptionalDefaultTheme = Template.bind({});
+export const OptionalDefaultTheme: StoryFn<typeof TextInput> = Template.bind(
+	{},
+);
 OptionalDefaultTheme.args = {
 	optional: true,
 };
 
 // *****************************************************************************
 
-export const HideLabelDefaultTheme = Template.bind({});
+export const HideLabelDefaultTheme: StoryFn<typeof TextInput> = Template.bind(
+	{},
+);
 HideLabelDefaultTheme.args = {
 	hideLabel: true,
 };
 
 // *****************************************************************************
 
-export const SupportingTextDefaultTheme = Template.bind({});
+export const SupportingTextDefaultTheme: StoryFn<typeof TextInput> =
+	Template.bind({});
 SupportingTextDefaultTheme.args = {
 	supporting: 'alex@example.com',
 };
 
 // *****************************************************************************
 
-export const Width30DefaultTheme = Template.bind({});
+export const Width30DefaultTheme: StoryFn<typeof TextInput> = Template.bind({});
 Width30DefaultTheme.args = {
 	width: 30,
 	label: 'First name',
@@ -79,7 +86,7 @@ Width30DefaultTheme.args = {
 
 // *****************************************************************************
 
-export const Width10DefaultTheme = Template.bind({});
+export const Width10DefaultTheme: StoryFn<typeof TextInput> = Template.bind({});
 Width10DefaultTheme.args = {
 	width: 10,
 	label: 'Postcode',
@@ -87,7 +94,7 @@ Width10DefaultTheme.args = {
 
 // *****************************************************************************
 
-export const Width4DefaultTheme = Template.bind({});
+export const Width4DefaultTheme: StoryFn<typeof TextInput> = Template.bind({});
 Width4DefaultTheme.args = {
 	width: 4,
 	label: 'Year of birth',
@@ -95,21 +102,25 @@ Width4DefaultTheme.args = {
 
 // *****************************************************************************
 
-export const ErrorWithMessageDefaultTheme = Template.bind({});
+export const ErrorWithMessageDefaultTheme: StoryFn<typeof TextInput> =
+	Template.bind({});
 ErrorWithMessageDefaultTheme.args = {
 	error: 'error',
 };
 
 // *****************************************************************************
 
-export const SuccessWithMessageDefaultTheme = Template.bind({});
+export const SuccessWithMessageDefaultTheme: StoryFn<typeof TextInput> =
+	Template.bind({});
 SuccessWithMessageDefaultTheme.args = {
 	success: 'success',
 };
 
 // *****************************************************************************
 
-export const ConstraintDefaultTheme = Template.bind({});
+export const ConstraintDefaultTheme: StoryFn<typeof TextInput> = Template.bind(
+	{},
+);
 ConstraintDefaultTheme.args = {
 	label: 'Phone number',
 	pattern: '[0-9]{1,11}',

--- a/libs/@guardian/source-react-components/src/tiles/Tiles.stories.tsx
+++ b/libs/@guardian/source-react-components/src/tiles/Tiles.stories.tsx
@@ -1,17 +1,19 @@
 import { breakpoints } from '@guardian/source-foundations';
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { TilesProps } from './Tiles';
 import { Tiles } from './Tiles';
 
-export default {
+const meta: Meta<typeof Tiles> = {
 	title: 'Tiles',
 	component: Tiles,
 	args: {
-		columns: '2',
+		columns: 2,
 	},
 };
 
-const Template: Story<TilesProps> = (args: TilesProps) => (
+export default meta;
+
+const Template: StoryFn<typeof Tiles> = (args: TilesProps) => (
 	<Tiles {...args}>
 		<div>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut faucibus nibh
@@ -43,35 +45,36 @@ const Template: Story<TilesProps> = (args: TilesProps) => (
 	</Tiles>
 );
 
-export const Columns2 = Template.bind({});
+export const Columns2: StoryFn<typeof Tiles> = Template.bind({});
 Columns2.args = {
 	columns: 2,
 };
 
 // *****************************************************************************
 
-export const Columns3 = Template.bind({});
+export const Columns3: StoryFn<typeof Tiles> = Template.bind({});
 Columns3.args = {
 	columns: 3,
 };
 
 // *****************************************************************************
 
-export const Columns4 = Template.bind({});
+export const Columns4: StoryFn<typeof Tiles> = Template.bind({});
 Columns4.args = {
 	columns: 4,
 };
 
 // *****************************************************************************
 
-export const Columns5 = Template.bind({});
+export const Columns5: StoryFn<typeof Tiles> = Template.bind({});
 Columns5.args = {
 	columns: 5,
 };
 
 // *****************************************************************************
 
-export const Columns5CollapseUntilTabletAtMobile = Template.bind({});
+export const Columns5CollapseUntilTabletAtMobile: StoryFn<typeof Tiles> =
+	Template.bind({});
 Columns5CollapseUntilTabletAtMobile.args = {
 	columns: 5,
 	collapseUntil: 'tablet',
@@ -85,7 +88,8 @@ Columns5CollapseUntilTabletAtMobile.parameters = {
 
 // *****************************************************************************
 
-export const Columns5CollapseUntilTabletAtTablet = Template.bind({});
+export const Columns5CollapseUntilTabletAtTablet: StoryFn<typeof Tiles> =
+	Template.bind({});
 Columns5CollapseUntilTabletAtTablet.args = {
 	columns: 5,
 	collapseUntil: 'tablet',

--- a/libs/@guardian/source-react-components/src/user-feedback/InlineError.stories.tsx
+++ b/libs/@guardian/source-react-components/src/user-feedback/InlineError.stories.tsx
@@ -1,26 +1,31 @@
 import { breakpoints } from '@guardian/source-foundations';
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { InlineError } from './InlineError';
 import { userFeedbackThemeBrand } from './theme';
 import type { UserFeedbackProps } from './types';
 
-export default {
+const meta: Meta<typeof InlineError> = {
 	title: 'InlineError',
 	component: InlineError,
 };
 
-const Template: Story<UserFeedbackProps> = ({
+export default meta;
+
+const Template: StoryFn<typeof InlineError> = ({
 	children,
 	...args
 }: UserFeedbackProps) => (
 	<InlineError {...args}>{children ?? 'Please enter your name'}</InlineError>
 );
 
-export const InlineErrorDefaultTheme = Template.bind({});
+export const InlineErrorDefaultTheme: StoryFn<typeof InlineError> =
+	Template.bind({});
 
 // *****************************************************************************
 
-export const InlineErrorBrandTheme = Template.bind({});
+export const InlineErrorBrandTheme: StoryFn<typeof InlineError> = Template.bind(
+	{},
+);
 InlineErrorBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
@@ -30,7 +35,8 @@ InlineErrorBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const LongInlineErrorDefaultThemeMobile = Template.bind({});
+export const LongInlineErrorDefaultThemeMobile: StoryFn<typeof InlineError> =
+	Template.bind({});
 LongInlineErrorDefaultThemeMobile.parameters = {
 	viewport: { defaultViewport: 'mobileMedium' },
 	chromatic: {

--- a/libs/@guardian/source-react-components/src/user-feedback/InlineSuccess.stories.tsx
+++ b/libs/@guardian/source-react-components/src/user-feedback/InlineSuccess.stories.tsx
@@ -1,22 +1,26 @@
-import type { Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { InlineSuccess } from './InlineSuccess';
 import { userFeedbackThemeBrand } from './theme';
 import type { UserFeedbackProps } from './types';
 
-export default {
+const meta: Meta<typeof InlineSuccess> = {
 	title: 'InlineSuccess',
 	component: InlineSuccess,
 };
 
-const Template: Story<UserFeedbackProps> = (args: UserFeedbackProps) => (
+export default meta;
+
+const Template: StoryFn<typeof InlineSuccess> = (args: UserFeedbackProps) => (
 	<InlineSuccess {...args}>Your voucher code is valid</InlineSuccess>
 );
 
-export const InlineSuccessDefaultTheme = Template.bind({});
+export const InlineSuccessDefaultTheme: StoryFn<typeof InlineSuccess> =
+	Template.bind({});
 
 // *****************************************************************************
 
-export const InlineSuccessBrandTheme = Template.bind({});
+export const InlineSuccessBrandTheme: StoryFn<typeof InlineSuccess> =
+	Template.bind({});
 InlineSuccessBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',


### PR DESCRIPTION
## What are you changing?

- Updates type annotations in Source Storybook stories.

## Why?

- All of the stories have a number of type errors. Whilst these (mostly) don't prevent the stories from running or rendering in Chromatic, the errors create a lot of visual noise in the code editor and can cause confusion when working on them.
