### PR TITLE
Fix numeric storage `expires`

### DIFF
--- a/.changeset/funny-jars-pump.md
+++ b/.changeset/funny-jars-pump.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': patch
+---
+
+Make Storage handle numeric expiry value

--- a/libs/@guardian/libs/src/storage/storage.test.ts
+++ b/libs/@guardian/libs/src/storage/storage.test.ts
@@ -78,8 +78,16 @@ describe.each([
 		expect(implementation.get('thisDoesNotExist')).toBeNull();
 	});
 
-	it(`does not return an expired item`, () => {
+	it(`does not return an expired item with ISO date string`, () => {
 		implementation.set('iAmExpired', 'data', new Date('1901-01-01'));
+		expect(implementation.get('iAmExpired')).toBeNull();
+
+		// check it's been deleted too
+		expect(native.getItem('iAmExpired')).toBeNull();
+	});
+
+	it(`does not return an expired item with numeric value (millis since epoch)`, () => {
+		implementation.set('iAmExpired', 'data', new Date('1901-01-01').getTime());
 		expect(implementation.get('iAmExpired')).toBeNull();
 
 		// check it's been deleted too

--- a/libs/@guardian/libs/src/storage/storage.test.ts
+++ b/libs/@guardian/libs/src/storage/storage.test.ts
@@ -78,7 +78,7 @@ describe.each([
 		expect(implementation.get('thisDoesNotExist')).toBeNull();
 	});
 
-	it(`does not return an expired item with ISO date string`, () => {
+	it(`does not return an expired item with expiry as Date object`, () => {
 		implementation.set('iAmExpired', 'data', new Date('1901-01-01'));
 		expect(implementation.get('iAmExpired')).toBeNull();
 
@@ -86,8 +86,16 @@ describe.each([
 		expect(native.getItem('iAmExpired')).toBeNull();
 	});
 
-	it(`does not return an expired item with numeric value (millis since epoch)`, () => {
+	it(`does not return an expired item with expiry as numeric value (millis since epoch)`, () => {
 		implementation.set('iAmExpired', 'data', new Date('1901-01-01').getTime());
+		expect(implementation.get('iAmExpired')).toBeNull();
+
+		// check it's been deleted too
+		expect(native.getItem('iAmExpired')).toBeNull();
+	});
+
+	it(`does not return an expired item with expiry as ISO date string`, () => {
+		implementation.set('iAmExpired', 'data', '1901-01-01T00:00:00.000Z');
 		expect(implementation.get('iAmExpired')).toBeNull();
 
 		// check it's been deleted too

--- a/libs/@guardian/libs/src/storage/storage.ts
+++ b/libs/@guardian/libs/src/storage/storage.ts
@@ -36,7 +36,10 @@ class StorageFactory {
 			const { value, expires } = data;
 
 			// is this item has passed its sell-by-date, remove it
-			if ((isString(expires) || typeof expires == 'number') && new Date() > new Date(expires)) {
+			if (
+				(isString(expires) || typeof expires == 'number') &&
+				new Date() > new Date(expires)
+			) {
 				this.remove(key);
 				return null;
 			}

--- a/libs/@guardian/libs/src/storage/storage.ts
+++ b/libs/@guardian/libs/src/storage/storage.ts
@@ -36,7 +36,7 @@ class StorageFactory {
 			const { value, expires } = data;
 
 			// is this item has passed its sell-by-date, remove it
-			if (isString(expires) && new Date() > new Date(expires)) {
+			if ((isString(expires) || typeof expires == 'number') && new Date() > new Date(expires)) {
 				this.remove(key);
 				return null;
 			}

--- a/libs/@guardian/libs/src/storage/storage.ts
+++ b/libs/@guardian/libs/src/storage/storage.ts
@@ -62,7 +62,7 @@ class StorageFactory {
 			key,
 			JSON.stringify({
 				value,
-				expires,
+				expires: expires ? new Date(expires) : undefined,
 			}),
 		);
 	}

--- a/libs/@guardian/libs/src/storage/storage.ts
+++ b/libs/@guardian/libs/src/storage/storage.ts
@@ -37,7 +37,7 @@ class StorageFactory {
 
 			// is this item has passed its sell-by-date, remove it
 			if (
-				(isString(expires) || typeof expires == 'number') &&
+				(isString(expires) || typeof expires === 'number') &&
 				new Date() > new Date(expires)
 			) {
 				this.remove(key);


### PR DESCRIPTION
## What are you changing?
Currently if you give `set` a numeric expiry then the item is never expired.

For consistency I've also changed `set` to always add the expiry as a datetime string. But we need `get` to handle numeric values to fix any browsers that currently have that in their local storage