### PR TITLE
Reduce `xsmall` button text size

### DIFF
--- a/.changeset/nine-owls-pay.md
+++ b/.changeset/nine-owls-pay.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': minor
+---
+
+Reduces text size of `xsmall` buttons to `14px`.

--- a/libs/@guardian/source-react-components/src/button/styles.ts
+++ b/libs/@guardian/source-react-components/src/button/styles.ts
@@ -29,6 +29,7 @@ const button = css`
 	transition: ${transitions.medium};
 	text-decoration: none;
 	white-space: nowrap;
+	vertical-align: middle;
 
 	:disabled {
 		cursor: not-allowed;

--- a/libs/@guardian/source-react-components/src/button/styles.ts
+++ b/libs/@guardian/source-react-components/src/button/styles.ts
@@ -124,17 +124,13 @@ const subdued = (
 	the button label is vertically centred visually.
 	TODO: find a more scalable solution to this (see https://css-tricks.com/how-to-tame-line-height-in-css/)
 */
-const fontSpacingVerticalOffset = css`
-	padding-bottom: 2px;
-`;
-
 const defaultSize = css`
 	${textSans.medium({ fontWeight: 'bold' })};
 	height: ${height.ctaMedium}px;
 	min-height: ${height.ctaMedium}px;
 	padding: 0 ${space[5]}px;
 	border-radius: ${height.ctaMedium}px;
-	${fontSpacingVerticalOffset};
+	padding-bottom: 2px;
 `;
 
 const smallSize = css`
@@ -143,16 +139,16 @@ const smallSize = css`
 	min-height: ${height.ctaSmall}px;
 	padding: 0 ${space[4]}px;
 	border-radius: ${height.ctaSmall}px;
-	${fontSpacingVerticalOffset};
+	padding-bottom: 2px;
 `;
 
 const xsmallSize = css`
-	${textSans.small({ fontWeight: 'bold' })};
+	${textSans.xsmall({ fontWeight: 'bold' })};
 	height: ${height.ctaXsmall}px;
 	min-height: ${height.ctaXsmall}px;
 	padding: 0 ${space[3]}px;
 	border-radius: ${height.ctaXsmall}px;
-	${fontSpacingVerticalOffset};
+	padding-bottom: 1px;
 `;
 
 const iconDefault = css`


### PR DESCRIPTION
## What are you changing?

- Reduces text size of `xsmall` button to `14px` (`textSans.xsmall`).
- Removes extra spacing that was being added to outside of `xsmall` buttons if they included a left-aligned icon. 

## Screenshots

### Before

<img width="147" alt="Screenshot 2024-01-22 at 17 07 29" src="https://github.com/guardian/csnx/assets/1166188/6cb016ee-0597-4713-8fb9-373325bb568b">


### After

<img width="145" alt="Screenshot 2024-01-22 at 17 05 31" src="https://github.com/guardian/csnx/assets/1166188/15360da5-c6f7-4dd9-a451-059d7a4a2735">
