### PR TITLE
Add `storybookBaseDir` to Chromatic workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           projectToken: ${{ secrets[matrix.token] }}
           token: ${{ secrets.GITHUB_TOKEN }}
           storybookBuildDir: 'dist/storybook/libs/@guardian/${{ matrix.lib }}'
+          storybookBaseDir: 'dist/storybook/libs/@guardian/${{ matrix.lib }}'
           exitOnceUploaded: true
           onlyChanged: '!(main)' # turbosnap on non-main branches
           skip: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'gu-changesets-release-pr[bot]' }}


### PR DESCRIPTION
## What are you changing?

- adding a `storybookBaseDir` to the Chromatic workflow.

## Why?

- each of the individual storybooks is nested within `libs/@guardian/[projectName]`, we need to tell chromatic where to find these. 
- Many thanks to Reuben at Chromatic for suggesting this fix.
