### PR TITLE
Revert "Removed csnx/* from the changesets config.json"

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
 	"bumpVersionsWithWorkspaceProtocolOnly": true,
+	"ignore": ["@csnx/*"],
 	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
 		"onlyUpdatePeerDependentsWhenOutOfRange": true
 	}


### PR DESCRIPTION
Reverts guardian/csnx#1014

internal packages should be included in changesets changes