### PR TITLE
identity-auth-frontend: update `@guardian/identity-auth` to `2.0.1`

### DIFF
--- a/.changeset/lucky-spoons-buy.md
+++ b/.changeset/lucky-spoons-buy.md
@@ -1,0 +1,5 @@
+---
+'@guardian/identity-auth-frontend': major
+---
+
+Update `identity-auth` to `2.0.1` to fix sign out bug

--- a/libs/@guardian/identity-auth-frontend/package.json
+++ b/libs/@guardian/identity-auth-frontend/package.json
@@ -6,14 +6,14 @@
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"devDependencies": {
-		"@guardian/identity-auth": "2.0.0",
+		"@guardian/identity-auth": "2.0.1",
 		"@guardian/libs": "16.0.0",
 		"jest-fetch-mock": "3.0.3",
 		"tslib": "2.6.2",
 		"typescript": "5.3.3"
 	},
 	"peerDependencies": {
-		"@guardian/identity-auth": "^2.0.0",
+		"@guardian/identity-auth": "^2.0.1",
 		"@guardian/libs": "^16.0.0",
 		"tslib": "^2.6.2",
 		"typescript": "~5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,8 +424,8 @@ importers:
   libs/@guardian/identity-auth-frontend:
     devDependencies:
       '@guardian/identity-auth':
-        specifier: 2.0.0
-        version: 2.0.0(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 2.0.1
+        version: link:../identity-auth
       '@guardian/libs':
         specifier: 16.0.0
         version: 16.0.0(tslib@2.6.2)(typescript@5.3.3)
@@ -3639,21 +3639,6 @@ packages:
       typescript:
         optional: true
     dependencies:
-      tslib: 2.6.2
-      typescript: 5.3.3
-    dev: true
-
-  /@guardian/identity-auth@2.0.0(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3):
-    resolution: {integrity: sha512-lLO+O8ZMcUJ1e55+K+HN1eCKCMsZp/p10Yu7SRcDc69ohvLzMH6sCIXinj1eI+I2222tVAKFC0F3XRPAbPI/Wg==}
-    peerDependencies:
-      '@guardian/libs': ^16.0.0
-      tslib: ^2.6.2
-      typescript: ~5.3.3
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@guardian/libs': 16.0.0(tslib@2.6.2)(typescript@5.3.3)
       tslib: 2.6.2
       typescript: 5.3.3
     dev: true


### PR DESCRIPTION
## What are you changing?

- Updated `identity-auth` dependency in `identity-auth-frontend`

## Why?

- We introduced a bug fix to the identity-auth library to fix a sign out bug in #1071
- So we need to keep this library up to date with it
