### PR TITLE
Adjust `AgeWarning` spacing, icon size and alignment

### DIFF
--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
@@ -55,7 +55,7 @@ const ageWarningStyles = (
 const iconStyles = (isSmall: boolean): SerializedStyles => css`
 	position: relative;
 	top: 1px;
-	width: ${isSmall ? '11px' : '15px'};
+	width: ${isSmall ? '11px' : '14px'};
 	height: auto;
 `;
 

--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
@@ -2,8 +2,8 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import {
-	from,
 	palette,
+	space,
 	textSans,
 	visuallyHidden,
 } from '@guardian/source-foundations';
@@ -45,19 +45,18 @@ const ageWarningStyles = (
 		font-weight: bold;
 	}
 
-	padding: ${isSmall ? '3px 5px' : '6px 10px'};
-
-	${from.mobileLandscape} {
-		padding-left: ${isSmall ? '6px' : '12px'};
-	}
-
-	${from.leftCol} {
-		padding-left: ${isSmall ? '5px' : '10px'};
-	}
+	padding: ${isSmall ? `3px ${space[1]}px` : `6px ${space[2]}px`};
 
 	${darkModeCss(supportsDarkMode)`
 		background-color: ${palette.brandAlt[200]};
-    `}
+	`}
+`;
+
+const iconStyles = (isSmall: boolean): SerializedStyles => css`
+	position: relative;
+	top: 1px;
+	width: ${isSmall ? '11px' : '15px'};
+	height: auto;
 `;
 
 const ageWarningScreenReader = css`
@@ -65,7 +64,7 @@ const ageWarningScreenReader = css`
 `;
 
 const prefixStyle = css`
-	padding-left: 2px;
+	padding-left: ${space[1]}px;
 `;
 
 const ensureOldText = (age: string): string =>
@@ -87,7 +86,7 @@ export const AgeWarning = ({
 
 	return (
 		<div css={ageWarningStyles(isSmall, supportsDarkMode)} aria-hidden="true">
-			<svg width="11" height="11" viewBox="0 0 11 11">
+			<svg css={iconStyles(isSmall)} viewBox="0 0 11 11">
 				<path d="M5.4 0C2.4 0 0 2.4 0 5.4s2.4 5.4 5.4 5.4 5.4-2.4 5.4-5.4S8.4 0 5.4 0zm3 6.8H4.7V1.7h.7L6 5.4l2.4.6v.8z"></path>
 			</svg>
 			<span css={prefixStyle}>{warningPrefix}</span>


### PR DESCRIPTION
## What are you changing?

- Adjusts spacing around text and between icon for medium and small sizes.
- Increases size of icon for default, medium size and aligns with text.

## Screenshots

### Before

<img width="327" alt="Screenshot 2024-01-26 at 16 16 38" src="https://github.com/guardian/csnx/assets/1166188/5c949394-9350-4d70-a257-2f7b47e8770b">
<img width="230" alt="Screenshot 2024-01-26 at 16 16 50" src="https://github.com/guardian/csnx/assets/1166188/6c233573-4137-4e9e-925e-f118bc3e75e2">

### After

<img width="327" alt="Screenshot 2024-01-26 at 16 17 06" src="https://github.com/guardian/csnx/assets/1166188/d0fc9f0c-6acb-4b80-a2f8-88235ad71b69">
<img width="230" alt="Screenshot 2024-01-26 at 16 22 13" src="https://github.com/guardian/csnx/assets/1166188/e07328e1-6da7-438d-bb21-de2304b44416">
