### PR TITLE
Allow changesets to bump dependencies

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"bumpVersionsWithWorkspaceProtocolOnly": true,
+	"bumpVersionsWithWorkspaceProtocolOnly": false,
 	"ignore": ["@csnx/*"],
 	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
 		"onlyUpdatePeerDependentsWhenOutOfRange": true


### PR DESCRIPTION
## What are you changing?

Disables `bumpVersionsWithWorkspaceProtocolOnly` option in changesets config

## Why?

When updating multiple packages at once changesets only bumps package versions, but does not update dependencies on other packages in the same release with the new version numbers.

For example, `@guardian/source-react-components-development-kitchen` has a dependency on `@guardian/source-react-components`. If a changeset includes an update for both of these packages their version numbers will be bumped as expected, but the dev and peer dependencies in `@guardian/source-react-components-development-kitchen` will not be updated to reflect `@guardian/source-react-components`'s new version number.

With `bumpVersionsWithWorkspaceProtocolOnly` enabled changesets will only update these dependencies if they're using the `workspace:` protocol and leave any being fetched from the registry untouched.

Disabling this option allows changesets to update these dependencies:

<img width="550" alt="Screenshot 2024-01-29 at 13 00 20" src="https://github.com/guardian/csnx/assets/1166188/f79cbb22-a7ca-44c9-9f8c-c30f911dca17">
