### PR TITLE
Make media queries’ `max-width` much closer to the breakpoint value

### DIFF
--- a/.changeset/cyan-trainers-brush.md
+++ b/.changeset/cyan-trainers-brush.md
@@ -1,0 +1,10 @@
+---
+'@guardian/source-foundations': patch
+---
+
+Make media queries `max-width` much closer to the breakpoint value.
+
+As media queries can report fractional values, they can currently fall between entire pixels.
+For example, `479.5px` is matching neither `max-width: 479px` nor `min-width: 480px`
+
+The media range syntax would be more expressive, but [support is still sparse at ~80%](https://caniuse.com/css-media-range-syntax).

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Root-level tasks are defined in the [`Makefile`](./Makefile).
 - `make validate` _makes sure absolutely everything is working_
 
 You can also run individual project's Nx targets by running `make <target>`. <details><summary>Nx targets</summary>
+
 - `make csnx:build-storybook`
 - `make csnx:composed-storybooks`
 - `make csnx:project-storybooks`

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Root-level tasks are defined in the [`Makefile`](./Makefile).
 - `make validate` _makes sure absolutely everything is working_
 
 You can also run individual project's Nx targets by running `make <target>`. <details><summary>Nx targets</summary>
-
 - `make csnx:build-storybook`
 - `make csnx:composed-storybooks`
 - `make csnx:project-storybooks`

--- a/libs/@guardian/source-foundations/src/mq/mq.test.ts
+++ b/libs/@guardian/source-foundations/src/mq/mq.test.ts
@@ -11,7 +11,9 @@ it('from should return a min-width media query', () => {
 it('until should return a max-width media query', () => {
 	const max: Breakpoint = 'wide';
 
-	expect(until[max]).toBe(`@media (max-width: ${`${breakpoints[max] - 1}px`})`);
+	expect(until[max]).toBe(
+		`@media (max-width: ${`${breakpoints[max] - 0.0001}px`})`,
+	);
 });
 
 it('between should return a media query with min- and max-width', () => {
@@ -20,7 +22,7 @@ it('between should return a media query with min- and max-width', () => {
 
 	expect(between[min].and[max]).toBe(
 		`@media (min-width: ${`${breakpoints[min]}px`}) and (max-width: ${`${
-			breakpoints[max] - 1
+			breakpoints[max] - 0.0001
 		}px`})`,
 	);
 });

--- a/libs/@guardian/source-foundations/src/mq/mq.test.ts
+++ b/libs/@guardian/source-foundations/src/mq/mq.test.ts
@@ -12,7 +12,7 @@ it('until should return a max-width media query', () => {
 	const max: Breakpoint = 'wide';
 
 	expect(until[max]).toBe(
-		`@media (max-width: ${`${breakpoints[max] - 0.0001}px`})`,
+		`@media (max-width: ${`${breakpoints[max] - 0.1}px`})`,
 	);
 });
 
@@ -22,7 +22,7 @@ it('between should return a media query with min- and max-width', () => {
 
 	expect(between[min].and[max]).toBe(
 		`@media (min-width: ${`${breakpoints[min]}px`}) and (max-width: ${`${
-			breakpoints[max] - 0.0001
+			breakpoints[max] - 0.1
 		}px`})`,
 	);
 });

--- a/libs/@guardian/source-foundations/src/mq/mq.ts
+++ b/libs/@guardian/source-foundations/src/mq/mq.ts
@@ -8,10 +8,12 @@ export type BreakpointMap = {
 const minWidth = (from: number): string => `@media (min-width: ${`${from}px`})`;
 
 const maxWidth = (until: number): string =>
-	`@media (max-width: ${`${until - 1}px`})`;
+	`@media (max-width: ${`${until - 0.0001}px`})`;
 
 const minWidthMaxWidth = (from: number, until: number): string =>
-	`@media (min-width: ${`${from}px`}) and (max-width: ${`${until - 1}px`})`;
+	`@media (min-width: ${`${from}px`}) and (max-width: ${`${
+		until - 0.0001
+	}px`})`;
 
 /**
  * [Storybook](https://guardian.github.io/csnx/?path=/docs/source-foundations_media-queries--page#from)

--- a/libs/@guardian/source-foundations/src/mq/mq.ts
+++ b/libs/@guardian/source-foundations/src/mq/mq.ts
@@ -14,7 +14,7 @@ export type BreakpointMap = {
  *
  * [1]: https://caniuse.com/css-media-range-syntax
  */
-const smidgen = 0.0001;
+const smidgen = 0.1;
 
 const minWidth = (from: number): string => `@media (min-width: ${`${from}px`})`;
 

--- a/libs/@guardian/source-foundations/src/mq/mq.ts
+++ b/libs/@guardian/source-foundations/src/mq/mq.ts
@@ -5,15 +5,24 @@ export type BreakpointMap = {
 	[key in Breakpoint]: string;
 };
 
+/**
+ * Making this value much smaller than `1px` prevents
+ * media queries falling between entire pixel values.
+ *
+ * When the [range syntax is well supported][1],
+ * it may be a more expressive approach.
+ *
+ * [1]: https://caniuse.com/css-media-range-syntax
+ */
+const smidgen = 0.0001;
+
 const minWidth = (from: number): string => `@media (min-width: ${`${from}px`})`;
 
 const maxWidth = (until: number): string =>
-	`@media (max-width: ${`${until - 0.0001}px`})`;
+	`@media (max-width: ${`${until - smidgen}px`})`;
 
 const minWidthMaxWidth = (from: number, until: number): string =>
-	`@media (min-width: ${`${from}px`}) and (max-width: ${`${
-		until - 0.0001
-	}px`})`;
+	`@media (min-width: ${`${from}px`}) and (max-width: ${`${until - smidgen}px`})`;
 
 /**
  * [Storybook](https://guardian.github.io/csnx/?path=/docs/source-foundations_media-queries--page#from)


### PR DESCRIPTION
## What are you changing?

- Make media queries’ max-width much closer to the value, just 0.001px shy.
- Live demonstration: https://codepen.io/mxdvl/pen/XWGZmMm

## Why?

- As media queries can report fractional values, they fall between entire pixels. For example, `479.5px` is matching neither `max-width: 479px` nor `min-width: 480px`
- https://github.com/guardian/dotcom-rendering/issues/10195
- The media range syntax would be more expressive, but [support is sparse at ~80%](https://caniuse.com/css-media-range-syntax)
