### PR TITLE
Enable changeset `bumpVersionsWithWorkspaceProtocolOnly` option again

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"bumpVersionsWithWorkspaceProtocolOnly": false,
+	"bumpVersionsWithWorkspaceProtocolOnly": true,
 	"ignore": ["@csnx/*"],
 	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
 		"onlyUpdatePeerDependentsWhenOutOfRange": true


### PR DESCRIPTION
## What are you changing?

- Enable changesets `bumpVersionsWithWorkspaceProtocolOnly` option, reverting change in #1120

## Why?

- Whilst enabling this option gives us the behaviour we want in terms of bumping dependencies and peer dependencies it does not update the lock file at the same file causing the build to fail when merged.
- We may be able to update the lock file with an action that's triggered by a package release PR, but in the meantime it seems safest to revert to the existing behaviour that we're familiar with. 
