### PR TITLE
Require unit tests where jest is configured

### DIFF
--- a/libs/@guardian/ab-core/project.json
+++ b/libs/@guardian/ab-core/project.json
@@ -42,7 +42,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/ab-core"],
 			"options": {
 				"jestConfig": "libs/@guardian/ab-core/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
 			}
 		},
@@ -51,7 +51,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/ab-core"],
 			"options": {
 				"jestConfig": "libs/@guardian/ab-core/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		}

--- a/libs/@guardian/ab-react/project.json
+++ b/libs/@guardian/ab-react/project.json
@@ -48,7 +48,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/ab-react"],
 			"options": {
 				"jestConfig": "libs/@guardian/ab-react/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
 			}
 		},
@@ -57,7 +57,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/ab-react"],
 			"options": {
 				"jestConfig": "libs/@guardian/ab-react/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		}

--- a/libs/@guardian/core-web-vitals/project.json
+++ b/libs/@guardian/core-web-vitals/project.json
@@ -42,7 +42,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/core-web-vitals"],
 			"options": {
 				"jestConfig": "libs/@guardian/core-web-vitals/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
 			}
 		},
@@ -51,7 +51,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/core-web-vitals"],
 			"options": {
 				"jestConfig": "libs/@guardian/core-web-vitals/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		}

--- a/libs/@guardian/eslint-plugin-source-foundations/project.json
+++ b/libs/@guardian/eslint-plugin-source-foundations/project.json
@@ -50,7 +50,7 @@
 			],
 			"options": {
 				"jestConfig": "libs/@guardian/eslint-plugin-source-foundations/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
 			}
 		},
@@ -61,7 +61,7 @@
 			],
 			"options": {
 				"jestConfig": "libs/@guardian/eslint-plugin-source-foundations/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		}

--- a/libs/@guardian/eslint-plugin-source-react-components/project.json
+++ b/libs/@guardian/eslint-plugin-source-react-components/project.json
@@ -50,7 +50,7 @@
 			],
 			"options": {
 				"jestConfig": "libs/@guardian/eslint-plugin-source-react-components/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
 			}
 		},
@@ -61,7 +61,7 @@
 			],
 			"options": {
 				"jestConfig": "libs/@guardian/eslint-plugin-source-react-components/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		}

--- a/libs/@guardian/identity-auth-frontend/project.json
+++ b/libs/@guardian/identity-auth-frontend/project.json
@@ -46,7 +46,7 @@
 			],
 			"options": {
 				"jestConfig": "libs/@guardian/identity-auth-frontend/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
 			}
 		},
@@ -57,7 +57,7 @@
 			],
 			"options": {
 				"jestConfig": "libs/@guardian/identity-auth-frontend/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		}

--- a/libs/@guardian/identity-auth/project.json
+++ b/libs/@guardian/identity-auth/project.json
@@ -42,7 +42,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/identity-auth"],
 			"options": {
 				"jestConfig": "libs/@guardian/identity-auth/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
 			}
 		},
@@ -51,7 +51,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/identity-auth"],
 			"options": {
 				"jestConfig": "libs/@guardian/identity-auth/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		}

--- a/libs/@guardian/libs/project.json
+++ b/libs/@guardian/libs/project.json
@@ -42,7 +42,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/libs"],
 			"options": {
 				"jestConfig": "libs/@guardian/libs/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.js"]
 			}
 		},
@@ -51,7 +51,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/libs"],
 			"options": {
 				"jestConfig": "libs/@guardian/libs/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		}

--- a/libs/@guardian/newsletter-types/project.json
+++ b/libs/@guardian/newsletter-types/project.json
@@ -42,7 +42,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/newsletter-types"],
 			"options": {
 				"jestConfig": "libs/@guardian/newsletter-types/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		}

--- a/libs/@guardian/source-foundations/project.json
+++ b/libs/@guardian/source-foundations/project.json
@@ -42,7 +42,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/source-foundations"],
 			"options": {
 				"jestConfig": "libs/@guardian/source-foundations/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
 			}
 		},
@@ -51,7 +51,7 @@
 			"outputs": ["{workspaceRoot}/coverage/libs/@guardian/source-foundations"],
 			"options": {
 				"jestConfig": "libs/@guardian/source-foundations/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		},

--- a/libs/@guardian/source-react-components-development-kitchen/project.json
+++ b/libs/@guardian/source-react-components-development-kitchen/project.json
@@ -52,7 +52,7 @@
 			],
 			"options": {
 				"jestConfig": "libs/@guardian/source-react-components-development-kitchen/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
 			}
 		},
@@ -63,7 +63,7 @@
 			],
 			"options": {
 				"jestConfig": "libs/@guardian/source-react-components-development-kitchen/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		},

--- a/libs/@guardian/source-react-components/project.json
+++ b/libs/@guardian/source-react-components/project.json
@@ -46,7 +46,7 @@
 			],
 			"options": {
 				"jestConfig": "libs/@guardian/source-react-components/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"setupFilesAfterEnv": ["./jest.e2e.setup.ts"]
 			}
 		},
@@ -57,7 +57,7 @@
 			],
 			"options": {
 				"jestConfig": "libs/@guardian/source-react-components/jest.config.ts",
-				"passWithNoTests": true,
+				"passWithNoTests": false,
 				"watch": true
 			}
 		},


### PR DESCRIPTION
## What are you changing?

- stops projects having no tests

## Why?

- if we've configured jest, we should us it
