### PR TITLE
Update `@guardian/eslint-plugin-source-react-components` dependencies

### DIFF
--- a/.changeset/hungry-trainers-divide.md
+++ b/.changeset/hungry-trainers-divide.md
@@ -1,0 +1,6 @@
+---
+'@guardian/eslint-plugin-source-react-components': major
+---
+
+- Updated dependencies
+  - @guardian/source-react-components@20.0.0

--- a/libs/@guardian/eslint-plugin-source-react-components/package.json
+++ b/libs/@guardian/eslint-plugin-source-react-components/package.json
@@ -10,7 +10,7 @@
 		"@emotion/react": "11.11.1",
 		"@guardian/libs": "16.0.0",
 		"@guardian/source-foundations": "14.0.0",
-		"@guardian/source-react-components": "18.0.0",
+		"@guardian/source-react-components": "20.0.0",
 		"@types/eslint": "8.56.1",
 		"@types/estree": "1.0.5",
 		"eslint": "8.56.0",
@@ -20,7 +20,7 @@
 	},
 	"peerDependencies": {
 		"@guardian/libs": "^16.0.0",
-		"@guardian/source-react-components": "^18.0.0",
+		"@guardian/source-react-components": "^20.0.0",
 		"eslint": "^8.56.0",
 		"react": "^18.2.0",
 		"tslib": "^2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,8 +385,8 @@ importers:
         specifier: 14.0.0
         version: 14.0.0(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components':
-        specifier: 18.0.0
-        version: 18.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 20.0.0
+        version: 20.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@types/eslint':
         specifier: 8.56.1
         version: 8.56.1
@@ -425,7 +425,7 @@ importers:
     devDependencies:
       '@guardian/identity-auth':
         specifier: 2.0.1
-        version: link:../identity-auth
+        version: 2.0.1(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/libs':
         specifier: 16.0.0
         version: 16.0.0(tslib@2.6.2)(typescript@5.3.3)
@@ -655,7 +655,7 @@ importers:
         version: 14.0.0(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components':
         specifier: 20.0.0
-        version: link:../source-react-components
+        version: 20.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@types/react':
         specifier: 18.2.11
         version: 18.2.11
@@ -3712,6 +3712,21 @@ packages:
       typescript: 5.3.3
     dev: true
 
+  /@guardian/identity-auth@2.0.1(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-5EQB3LWDLxDaTKk/RHBGwoGy5mT90ZEa56XzrBStfyFi2FYma9bCvGdEEcOPmf3tLhdVxh93ikuooPveq76siA==}
+    peerDependencies:
+      '@guardian/libs': ^16.0.0
+      tslib: ^2.6.2
+      typescript: ~5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@guardian/libs': 16.0.0(tslib@2.6.2)(typescript@5.3.3)
+      tslib: 2.6.2
+      typescript: 5.3.3
+    dev: true
+
   /@guardian/libs@16.0.0(tslib@2.6.2)(typescript@5.3.3):
     resolution: {integrity: sha512-2i9cN6htXnvABIGhfqJGb9Bh/DdQOayUjb5ruqBGTiXEeDBHztctdVsi7+rPfMlwyPxQ+0qYLhM19f6J94vvhQ==}
     peerDependencies:
@@ -3740,8 +3755,8 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /@guardian/source-react-components@18.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3):
-    resolution: {integrity: sha512-7mt6RDmViRdUKUlU8OaswIsYnR+yFEt5iYbRhmXB+A0XjiTeLYP8EHKmazISRlGXTZjjG701WgY5witaShI1YA==}
+  /@guardian/source-react-components@20.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-HHCMuNKalWSMaCyryKJbnrWJzzyLxBQccSexD6QAYCdZW0cKwemhGYWz+7GQ6JsblZDYvjRGpg5Zcs+fhFrqjQ==}
     peerDependencies:
       '@emotion/react': ^11.11.1
       '@guardian/source-foundations': ^14.0.0


### PR DESCRIPTION
## What are you changing?

- Update `@guardian/eslint-plugin-source-react-components` dependencies to use latest version of `@guardian/source-react-components`.
