### PR TITLE
Update README to show new location for husky config

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,3 @@
-#!/bin/sh
-
-. "$(dirname "$0")/_/husky.sh"
-
 # make sure we're using the correct version of node,
 # but not on CI:
 # https://typicode.github.io/husky/#/?id=with-env-variables

--- a/README.md
+++ b/README.md
@@ -248,4 +248,4 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && nvm use
 ```
 
-See https://typicode.github.io/husky/#/?id=command-not-found for more info.
+See https://typicode.github.io/husky/how-to.html for more info.

--- a/README.md
+++ b/README.md
@@ -210,12 +210,15 @@ This will create a "changeset": a `.md` file containing the release information.
 
 ### Unable to commit
 
-If you get a `command not found` error or a message saying you're using the wrong version of Node when commiting using a GUI (VSCode, GitHub desktop etc), add a `~/.huskyrc` file and load your Node version manager there.
+> [!IMPORTANT]
+> The ~/.huskyrc file has moved to ~/.config/husky/init.sh
+
+If you get a `command not found` error or a message saying you're using the wrong version of Node when commiting using a GUI (VSCode, GitHub desktop etc), add a `~/.config/husky/init.sh` file and load your Node version manager there.
 
 For example, if you use [`fnm`](https://github.com/Schniz/fnm):
 
 ```sh
-# ~/.huskyrc
+# ~/.config/husky/init.sh
 eval "$(fnm env)"
 fnm use
 ```
@@ -223,24 +226,24 @@ fnm use
 Or for [`asdf`](https://asdf-vm.com/):
 
 ```sh
-# ~/.huskyrc (installed with git)
+# ~/.config/husky/init.sh (installed with git)
 . $HOME/.asdf/asdf.sh
 ```
 
 ```sh
-# ~/.huskyrc (installed with brew on intel macs)
+# ~/.config/husky/init.sh (installed with brew on intel macs)
 . /usr/local/opt/asdf/libexec/asdf.sh
 ```
 
 ```sh
-# ~/.huskyrc (installed with brew on apple silicon)
+# ~/.config/husky/init.sh (installed with brew on apple silicon)
 . /opt/homebrew/opt/asdf/asdf.sh
 ```
 
 Or for [`nvm`](https://github.com/nvm-sh/nvm):
 
 ```sh
-# ~/.huskyrc
+# ~/.config/husky/init.sh
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && nvm use
 ```


### PR DESCRIPTION
## What are you changing?

- With the updated version of husky in csnx the ~/.huskyrc file needs to be moved to ./config/husky/init.sh 
- In new version the below lines can be removed 

```
#!/bin/sh

. "$(dirname "$0")/_/husky.sh"
```
## Why?

- New version of husky https://github.com/typicode/husky/releases/tag/v9.0.1 
