### PR TITLE
use => in storage for functions

### DIFF
--- a/.changeset/unlucky-toes-argue.md
+++ b/.changeset/unlucky-toes-argue.md
@@ -1,0 +1,5 @@
+---
+"@guardian/libs": patch
+---
+
+use `=>` to always bind storage methods to their parent scope

--- a/.changeset/unlucky-toes-argue.md
+++ b/.changeset/unlucky-toes-argue.md
@@ -1,5 +1,5 @@
 ---
-"@guardian/libs": patch
+'@guardian/libs': patch
 ---
 
 use `=>` to always bind storage methods to their parent scope

--- a/libs/@guardian/libs/src/storage/storage.ts
+++ b/libs/@guardian/libs/src/storage/storage.ts
@@ -20,9 +20,7 @@ class StorageFactory {
 	/**
 	 * Check whether storage is available.
 	 */
-	isAvailable = (): boolean => {
-		return Boolean(this.#storage);
-	};
+	isAvailable = (): boolean => Boolean(this.#storage);
 
 	/**
 	 * Retrieve an item from storage.
@@ -57,44 +55,33 @@ class StorageFactory {
 	 * @param value - the data to save
 	 * @param expires - optional date on which this data will expire
 	 */
-	set = (
-		key: string,
-		value: unknown,
-		expires?: string | number | Date,
-	): void => {
-		return this.#storage?.setItem(
+	set = (key: string, value: unknown, expires?: string | number | Date): void =>
+		this.#storage?.setItem(
 			key,
 			JSON.stringify({
 				value,
 				expires: expires ? new Date(expires) : undefined,
 			}),
 		);
-	};
 
 	/**
 	 * Remove an item from storage.
 	 *
 	 * @param key - the name of the item
 	 */
-	remove = (key: string): void => {
-		return this.#storage?.removeItem(key);
-	};
+	remove = (key: string): void => this.#storage?.removeItem(key);
 
 	/**
 	 * Removes all items from storage.
 	 */
-	clear = (): void => {
-		return this.#storage?.clear();
-	};
+	clear = (): void => this.#storage?.clear();
 
 	/**
 	 * Retrieve an item from storage in its raw state.
 	 *
 	 * @param key - the name of the item
 	 */
-	getRaw = (key: string): string | null => {
-		return this.#storage?.getItem(key) ?? null;
-	};
+	getRaw = (key: string): string | null => this.#storage?.getItem(key) ?? null;
 
 	/**
 	 * Save a raw value to storage.
@@ -102,9 +89,8 @@ class StorageFactory {
 	 * @param key - the name of the item
 	 * @param value - the data to save
 	 */
-	setRaw = (key: string, value: string): void => {
-		return this.#storage?.setItem(key, value);
-	};
+	setRaw = (key: string, value: string): void =>
+		this.#storage?.setItem(key, value);
 
 	/**
 	 * Get key by index.
@@ -119,18 +105,14 @@ class StorageFactory {
 	 * order of insertion).
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Storage/key
 	 */
-	key = (index: number): string | null => {
-		return this.#storage?.key(index) ?? null;
-	};
+	key = (index: number): string | null => this.#storage?.key(index) ?? null;
 
 	/**
 	 * Get the number of items in storage.
 	 * @returns the number of items in storage, or `null` if storage is
 	 * 	not available.
 	 */
-	length = (): number | null => {
-		return this.#storage?.length ?? null;
-	};
+	length = (): number | null => this.#storage?.length ?? null;
 }
 
 /**

--- a/libs/@guardian/libs/src/storage/storage.ts
+++ b/libs/@guardian/libs/src/storage/storage.ts
@@ -20,16 +20,16 @@ class StorageFactory {
 	/**
 	 * Check whether storage is available.
 	 */
-	isAvailable(): boolean {
+	isAvailable = (): boolean => {
 		return Boolean(this.#storage);
-	}
+	};
 
 	/**
 	 * Retrieve an item from storage.
 	 *
 	 * @param key - the name of the item
 	 */
-	get(key: string): unknown {
+	get = (key: string): unknown => {
 		try {
 			const data: unknown = JSON.parse(this.#storage?.getItem(key) ?? '');
 			if (!isObject(data)) return null;
@@ -48,7 +48,7 @@ class StorageFactory {
 		} catch (e) {
 			return null;
 		}
-	}
+	};
 
 	/**
 	 * Save a value to storage.
@@ -57,7 +57,11 @@ class StorageFactory {
 	 * @param value - the data to save
 	 * @param expires - optional date on which this data will expire
 	 */
-	set(key: string, value: unknown, expires?: string | number | Date): void {
+	set = (
+		key: string,
+		value: unknown,
+		expires?: string | number | Date,
+	): void => {
 		return this.#storage?.setItem(
 			key,
 			JSON.stringify({
@@ -65,32 +69,32 @@ class StorageFactory {
 				expires: expires ? new Date(expires) : undefined,
 			}),
 		);
-	}
+	};
 
 	/**
 	 * Remove an item from storage.
 	 *
 	 * @param key - the name of the item
 	 */
-	remove(key: string): void {
+	remove = (key: string): void => {
 		return this.#storage?.removeItem(key);
-	}
+	};
 
 	/**
 	 * Removes all items from storage.
 	 */
-	clear(): void {
+	clear = (): void => {
 		return this.#storage?.clear();
-	}
+	};
 
 	/**
 	 * Retrieve an item from storage in its raw state.
 	 *
 	 * @param key - the name of the item
 	 */
-	getRaw(key: string): string | null {
+	getRaw = (key: string): string | null => {
 		return this.#storage?.getItem(key) ?? null;
-	}
+	};
 
 	/**
 	 * Save a raw value to storage.
@@ -98,9 +102,9 @@ class StorageFactory {
 	 * @param key - the name of the item
 	 * @param value - the data to save
 	 */
-	setRaw(key: string, value: string): void {
+	setRaw = (key: string, value: string): void => {
 		return this.#storage?.setItem(key, value);
-	}
+	};
 
 	/**
 	 * Get key by index.
@@ -115,18 +119,18 @@ class StorageFactory {
 	 * order of insertion).
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Storage/key
 	 */
-	key(index: number): string | null {
+	key = (index: number): string | null => {
 		return this.#storage?.key(index) ?? null;
-	}
+	};
 
 	/**
 	 * Get the number of items in storage.
 	 * @returns the number of items in storage, or `null` if storage is
 	 * 	not available.
 	 */
-	length(): number | null {
+	length = (): number | null => {
 		return this.#storage?.length ?? null;
-	}
+	};
 }
 
 /**


### PR DESCRIPTION
## What are you changing?

- storage uses `=>` notation

## Why?

This change eliminates the following when moving the cmp into libs:

```ts
// libs/@guardian/libs/src/consent-management-platform/vendorDataManager.test.ts
vendorStorageIds.permutive.localStorage.forEach((name) => {
	expect(storage.local.remove).toHaveBeenCalledWith(name);
});
```

leads to the following type error that will be eliminated by this PR:

```
@typescript-eslint/no-unsafe-return
         88:11  error  Avoid referencing unbound methods which may cause unintentional scoping of `this`.
       If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead 
```

