### PR TITLE
Add `theme` prop support to Radio buttons

### DIFF
--- a/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { Radio } from './Radio';
 import type { RadioProps } from './Radio';
 import { themeRadioBrand } from './theme';
+import { palette } from '@guardian/source-foundations';
 
 const meta: Meta<typeof Radio> = {
 	title: 'Radio',
@@ -102,4 +103,17 @@ SupportingTextOnlyBrandTheme.args = {
 export const UnlabelledDefaultTheme: StoryFn<typeof Radio> = Template.bind({});
 UnlabelledDefaultTheme.args = {
 	label: undefined,
+};
+
+// *****************************************************************************
+
+export const CustomTheme: StoryFn<typeof Radio> = Template.bind({});
+CustomTheme.args = {
+	theme: {
+		fillUnselected: palette.lifestyle[500],
+		fillSelected: palette.lifestyle[400],
+		borderSelected: palette.lifestyle[300],
+		borderHover: palette.lifestyle[400],
+		textLabel: palette.lifestyle[400],
+	},
 };

--- a/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react';
 import { Radio } from './Radio';
 import type { RadioProps } from './Radio';
-import { radioThemeBrand } from './theme';
+import { themeRadioBrand } from './theme';
 
 const meta: Meta<typeof Radio> = {
 	title: 'Radio',
@@ -44,7 +44,9 @@ DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: radioThemeBrand,
+};
+DefaultBrandTheme.args = {
+	theme: themeRadioBrand,
 };
 
 // *****************************************************************************
@@ -65,10 +67,10 @@ SupportingTextBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: radioThemeBrand,
 };
 SupportingTextBrandTheme.args = {
 	supporting: 'Hex colour code: #ff0000',
+	theme: themeRadioBrand,
 };
 
 // *****************************************************************************
@@ -88,11 +90,11 @@ SupportingTextOnlyBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: radioThemeBrand,
 };
 SupportingTextOnlyBrandTheme.args = {
 	supporting: 'Hex colour code: #ff0000',
 	label: null,
+	theme: themeRadioBrand,
 };
 
 // *****************************************************************************

--- a/libs/@guardian/source-react-components/src/radio/Radio.tsx
+++ b/libs/@guardian/source-react-components/src/radio/Radio.tsx
@@ -12,7 +12,7 @@ import {
 	radioContainer,
 	supportingText,
 } from './styles';
-import { ThemeRadio, themeRadio } from './theme';
+import { ThemeRadio, themeRadio, transformOldProviderTheme } from './theme';
 
 export interface RadioProps
 	extends InputHTMLAttributes<HTMLInputElement>,
@@ -77,23 +77,6 @@ export const Radio = ({
 		}
 
 		return !!defaultChecked;
-	};
-
-	const transformOldProviderTheme = (
-		providerTheme: Theme['radio'],
-	): Partial<ThemeRadio> => {
-		const transformedTheme: Partial<ThemeRadio> = {};
-
-		if (providerTheme?.backgroundChecked) {
-			transformedTheme.fillSelected = providerTheme.backgroundChecked;
-		}
-		if (providerTheme?.border) {
-			transformedTheme.borderUnselected = providerTheme.border;
-		}
-		if (providerTheme?.textLabelSupporting) {
-			transformedTheme.textLabel = providerTheme.textLabelSupporting;
-		}
-		return { ...transformedTheme, ...providerTheme };
 	};
 
 	const combineThemes = (providerTheme: Theme['radio']): ThemeRadio => {

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
@@ -3,7 +3,7 @@ import { Radio } from './Radio';
 import RadioStories from './Radio.stories';
 import type { RadioGroupProps } from './RadioGroup';
 import { RadioGroup } from './RadioGroup';
-import { radioThemeBrand } from './theme';
+import { themeRadioBrand } from './theme';
 
 const meta: Meta<typeof RadioGroup> = {
 	title: 'RadioGroup',
@@ -41,8 +41,8 @@ const Image = () => (
 
 const Template: StoryFn<typeof RadioGroup> = (args: RadioGroupProps) => (
 	<RadioGroup {...args}>
-		<Radio {...RadioStories.args} key="radio-1" />
-		<Radio label="Blue" value="blue" key="radio-2" />
+		<Radio {...RadioStories.args} theme={args.theme} key="radio-1" />
+		<Radio label="Blue" value="blue" theme={args.theme} key="radio-2" />
 	</RadioGroup>
 );
 
@@ -57,7 +57,9 @@ DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: radioThemeBrand,
+};
+DefaultBrandTheme.args = {
+	theme: themeRadioBrand,
 };
 
 // *****************************************************************************
@@ -93,10 +95,10 @@ SupportingTextBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: radioThemeBrand,
 };
 SupportingTextBrandTheme.args = {
 	supporting: 'You can always change it later',
+	theme: themeRadioBrand,
 };
 
 // *****************************************************************************
@@ -119,12 +121,12 @@ ErrorDefaultTheme.args = {
 export const ErrorBrandTheme: StoryFn<typeof RadioGroup> = Template.bind({});
 ErrorBrandTheme.args = {
 	error: 'The selected colour is out of stock',
+	theme: themeRadioBrand,
 };
 ErrorBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: radioThemeBrand,
 };
 
 // *****************************************************************************

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.tsx
@@ -9,6 +9,7 @@ import { Legend } from '../label/Legend';
 import { Stack } from '../stack/Stack';
 import { InlineError } from '../user-feedback/InlineError';
 import { fieldset } from './styles';
+import { ThemeRadio, themeRadio, transformOldProviderTheme } from './theme';
 
 type Orientation = 'vertical' | 'horizontal';
 
@@ -36,6 +37,10 @@ export interface RadioGroupProps
 	 * If passed, error styling should applies to this radio group. The string appears as an inline error message.
 	 */
 	error?: string;
+	/**
+	 * Partial or complete theme to override radio button's colour palette
+	 */
+	theme?: Partial<ThemeRadio>;
 }
 
 /**
@@ -58,6 +63,7 @@ export const RadioGroup = ({
 	error,
 	cssOverrides,
 	children,
+	theme,
 	...props
 }: RadioGroupProps): EmotionJSX.Element => {
 	const groupId = id ?? generateSourceId();
@@ -90,11 +96,22 @@ export const RadioGroup = ({
 		</>
 	);
 
+	const combineThemes = (providerTheme: Theme['radio']): ThemeRadio => {
+		return {
+			...themeRadio,
+			...transformOldProviderTheme(providerTheme),
+			...theme,
+		};
+	};
+
 	return (
 		<fieldset
 			aria-invalid={!!error}
 			id={groupId}
-			css={(theme: Theme) => [fieldset(theme.radio), cssOverrides]}
+			css={(providerTheme: Theme) => [
+				fieldset(combineThemes(providerTheme.radio)),
+				cssOverrides,
+			]}
 			{...props}
 		>
 			{legend}

--- a/libs/@guardian/source-react-components/src/radio/styles.ts
+++ b/libs/@guardian/source-react-components/src/radio/styles.ts
@@ -66,7 +66,7 @@ export const radio = (radio: ThemeRadio): SerializedStyles => css`
 	color: ${radio.borderUnselected};
 
 	&:checked {
-		border: 2px solid currentColor;
+		border: 2px solid ${radio.borderSelected};
 		color: ${radio.fillSelected};
 	}
 
@@ -82,7 +82,7 @@ export const radio = (radio: ThemeRadio): SerializedStyles => css`
 	*/
 	@supports (${appearance}) {
 		appearance: none;
-		background-color: transparent;
+		background-color: ${radio.fillUnselected};
 
 		&:after {
 			background: currentColor;

--- a/libs/@guardian/source-react-components/src/radio/styles.ts
+++ b/libs/@guardian/source-react-components/src/radio/styles.ts
@@ -10,11 +10,9 @@ import {
 	transitions,
 	width,
 } from '@guardian/source-foundations';
-import { radioThemeDefault } from './theme';
+import { ThemeRadio } from './theme';
 
-export const fieldset = (
-	radio = radioThemeDefault.radio,
-): SerializedStyles => css`
+export const fieldset = (radio: ThemeRadio): SerializedStyles => css`
 	${resets.fieldset};
 
 	&[aria-invalid='true'] input {
@@ -27,9 +25,7 @@ export const fieldset = (
 	}
 `;
 
-export const radioContainer = (
-	radio = radioThemeDefault.radio,
-): SerializedStyles => css`
+export const radioContainer = (radio: ThemeRadio): SerializedStyles => css`
 	position: relative;
 	display: flex;
 	align-items: center;
@@ -52,7 +48,7 @@ export const labelWithSupportingText = css`
 	margin-bottom: ${space[3]}px;
 `;
 
-export const radio = (radio = radioThemeDefault.radio): SerializedStyles => css`
+export const radio = (radio: ThemeRadio): SerializedStyles => css`
 	flex: 0 0 auto;
 	cursor: pointer;
 	box-sizing: border-box;
@@ -67,11 +63,11 @@ export const radio = (radio = radioThemeDefault.radio): SerializedStyles => css`
 	transition: box-shadow ${transitions.short};
 	transition-delay: 0.08s;
 
-	color: ${radio.border};
+	color: ${radio.borderUnselected};
 
 	&:checked {
 		border: 2px solid currentColor;
-		color: ${radio.backgroundChecked};
+		color: ${radio.fillSelected};
 	}
 
 	&:focus {
@@ -110,9 +106,7 @@ export const radio = (radio = radioThemeDefault.radio): SerializedStyles => css`
 	}
 `;
 
-export const labelText = (
-	radio = radioThemeDefault.radio,
-): SerializedStyles => css`
+export const labelText = (radio: ThemeRadio): SerializedStyles => css`
 	${textSans.medium()};
 	color: ${radio.textLabel};
 	width: 100%;
@@ -127,9 +121,7 @@ export const labelTextWithSupportingText = css`
 	}
 `;
 
-export const supportingText = (
-	radio = radioThemeDefault.radio,
-): SerializedStyles => css`
+export const supportingText = (radio: ThemeRadio): SerializedStyles => css`
 	${textSans.small()};
-	color: ${radio.textLabelSupporting};
+	color: ${radio.textSupporting};
 `;

--- a/libs/@guardian/source-react-components/src/radio/styles.ts
+++ b/libs/@guardian/source-react-components/src/radio/styles.ts
@@ -10,7 +10,7 @@ import {
 	transitions,
 	width,
 } from '@guardian/source-foundations';
-import { ThemeRadio } from './theme';
+import type { ThemeRadio } from './theme';
 
 export const fieldset = (radio: ThemeRadio): SerializedStyles => css`
 	${resets.fieldset};

--- a/libs/@guardian/source-react-components/src/radio/theme.ts
+++ b/libs/@guardian/source-react-components/src/radio/theme.ts
@@ -1,4 +1,5 @@
 import { palette } from '@guardian/source-foundations';
+import type { Theme } from '../@types/Theme';
 import { labelThemeBrand, labelThemeDefault } from '../label/theme';
 import {
 	userFeedbackThemeBrand,
@@ -36,6 +37,23 @@ export const themeRadioBrand: ThemeRadio = {
 	fillUnselected: 'transparent',
 	textLabel: palette.neutral[100],
 	textSupporting: palette.brand[800],
+};
+
+export const transformOldProviderTheme = (
+	providerTheme: Theme['radio'],
+): Partial<ThemeRadio> => {
+	const transformedTheme: Partial<ThemeRadio> = {};
+
+	if (providerTheme?.backgroundChecked) {
+		transformedTheme.fillSelected = providerTheme.backgroundChecked;
+	}
+	if (providerTheme?.border) {
+		transformedTheme.borderUnselected = providerTheme.border;
+	}
+	if (providerTheme?.textLabelSupporting) {
+		transformedTheme.textLabel = providerTheme.textLabelSupporting;
+	}
+	return { ...transformedTheme, ...providerTheme };
 };
 
 /** @deprecated Use `themeRadio` and component `theme` prop instead of emotion's `ThemeProvider` */

--- a/libs/@guardian/source-react-components/src/radio/theme.ts
+++ b/libs/@guardian/source-react-components/src/radio/theme.ts
@@ -46,6 +46,7 @@ export const transformOldProviderTheme = (
 
 	if (providerTheme?.backgroundChecked) {
 		transformedTheme.fillSelected = providerTheme.backgroundChecked;
+		transformedTheme.borderSelected = providerTheme.backgroundChecked;
 	}
 	if (providerTheme?.border) {
 		transformedTheme.borderUnselected = providerTheme.border;

--- a/libs/@guardian/source-react-components/src/radio/theme.ts
+++ b/libs/@guardian/source-react-components/src/radio/theme.ts
@@ -5,6 +5,41 @@ import {
 	userFeedbackThemeDefault,
 } from '../user-feedback/theme';
 
+export type ThemeRadio = {
+	borderSelected: string;
+	borderUnselected: string;
+	borderHover: string;
+	borderError: string;
+	fillSelected: string;
+	fillUnselected: string;
+	textLabel: string;
+	textSupporting: string;
+};
+
+export const themeRadio: ThemeRadio = {
+	borderSelected: palette.brand[500],
+	borderUnselected: palette.neutral[46],
+	borderHover: palette.brand[500],
+	borderError: palette.error[400],
+	fillSelected: palette.brand[500],
+	fillUnselected: 'transparent',
+	textLabel: palette.neutral[7],
+	textSupporting: palette.neutral[46],
+};
+
+export const themeRadioBrand: ThemeRadio = {
+	borderSelected: palette.neutral[100],
+	borderUnselected: palette.brand[800],
+	borderHover: palette.neutral[100],
+	borderError: palette.error[500],
+	fillSelected: palette.neutral[100],
+	fillUnselected: 'transparent',
+	textLabel: palette.neutral[100],
+	textSupporting: palette.brand[800],
+};
+
+/** @deprecated Use `themeRadio` and component `theme` prop instead of emotion's `ThemeProvider` */
+
 export const radioThemeDefault = {
 	radio: {
 		borderHover: palette.focus[400],
@@ -17,6 +52,8 @@ export const radioThemeDefault = {
 	...labelThemeDefault,
 	...userFeedbackThemeDefault,
 };
+
+/** @deprecated Use `themeRadioBrand` and component `theme` prop instead of emotion's `ThemeProvider` */
 
 export const radioThemeBrand = {
 	radio: {


### PR DESCRIPTION
## What are you changing?

- Adds support for `theme` prop and updated theme format, deprecating use of existing themes and `ThemeProvider`.
- Theming has been added to the `Radio` and `RadioGroup` components.
- The `transformOldProviderTheme` method that translates existing themes to the new format has been moved to the `theme` module so that it can be used by both components without having to duplicate the code.

## Additional information

Brand themed Radio groups currently have an incorrectly coloured label as the `Legend` component has not yet been updated with `theme` prop support.
