### PR TITLE
Add generic theme merging function

### DIFF
--- a/libs/@guardian/source-react-components/src/radio/Radio.tsx
+++ b/libs/@guardian/source-react-components/src/radio/Radio.tsx
@@ -12,7 +12,8 @@ import {
 	radioContainer,
 	supportingText,
 } from './styles';
-import { ThemeRadio, themeRadio, transformOldProviderTheme } from './theme';
+import { ThemeRadio, themeRadio, transformProviderTheme } from './theme';
+import { mergeThemes } from '../utils/themes';
 
 export interface RadioProps
 	extends InputHTMLAttributes<HTMLInputElement>,
@@ -79,13 +80,13 @@ export const Radio = ({
 		return !!defaultChecked;
 	};
 
-	const combineThemes = (providerTheme: Theme['radio']): ThemeRadio => {
-		return {
-			...themeRadio,
-			...transformOldProviderTheme(providerTheme),
-			...theme,
-		};
-	};
+	const mergedTheme = (providerTheme: Theme) =>
+		mergeThemes<ThemeRadio, Theme['radio']>(
+			themeRadio,
+			theme,
+			providerTheme.radio,
+			transformProviderTheme,
+		);
 
 	const LabelText = ({
 		hasSupportingText,
@@ -98,7 +99,7 @@ export const Radio = ({
 			<div
 				css={(providerTheme: Theme) => [
 					hasSupportingText ? labelTextWithSupportingText : '',
-					labelText(combineThemes(providerTheme.radio)),
+					labelText(mergedTheme(providerTheme)),
 				]}
 			>
 				{children}
@@ -110,7 +111,7 @@ export const Radio = ({
 		return (
 			<div
 				css={(providerTheme: Theme) =>
-					supportingText(combineThemes(providerTheme.radio))
+					supportingText(mergedTheme(providerTheme))
 				}
 			>
 				{children}
@@ -123,7 +124,7 @@ export const Radio = ({
 			id={radioId}
 			type="radio"
 			css={(providerTheme: Theme) => [
-				radio(combineThemes(providerTheme.radio)),
+				radio(mergedTheme(providerTheme)),
 				cssOverrides,
 			]}
 			value={value}
@@ -136,7 +137,7 @@ export const Radio = ({
 	const labelledRadioControl = (
 		<div
 			css={(providerTheme: Theme) => [
-				radioContainer(combineThemes(providerTheme.radio)),
+				radioContainer(mergedTheme(providerTheme)),
 				supporting ? labelWithSupportingText : '',
 			]}
 		>

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.tsx
@@ -9,7 +9,8 @@ import { Legend } from '../label/Legend';
 import { Stack } from '../stack/Stack';
 import { InlineError } from '../user-feedback/InlineError';
 import { fieldset } from './styles';
-import { ThemeRadio, themeRadio, transformOldProviderTheme } from './theme';
+import { ThemeRadio, themeRadio, transformProviderTheme } from './theme';
+import { mergeThemes } from '../utils/themes';
 
 type Orientation = 'vertical' | 'horizontal';
 
@@ -96,20 +97,20 @@ export const RadioGroup = ({
 		</>
 	);
 
-	const combineThemes = (providerTheme: Theme['radio']): ThemeRadio => {
-		return {
-			...themeRadio,
-			...transformOldProviderTheme(providerTheme),
-			...theme,
-		};
-	};
+	const mergedTheme = (providerTheme: Theme) =>
+		mergeThemes<ThemeRadio, Theme['radio']>(
+			themeRadio,
+			theme,
+			providerTheme.radio,
+			transformProviderTheme,
+		);
 
 	return (
 		<fieldset
 			aria-invalid={!!error}
 			id={groupId}
 			css={(providerTheme: Theme) => [
-				fieldset(combineThemes(providerTheme.radio)),
+				fieldset(mergedTheme(providerTheme)),
 				cssOverrides,
 			]}
 			{...props}

--- a/libs/@guardian/source-react-components/src/radio/theme.ts
+++ b/libs/@guardian/source-react-components/src/radio/theme.ts
@@ -39,7 +39,7 @@ export const themeRadioBrand: ThemeRadio = {
 	textSupporting: palette.brand[800],
 };
 
-export const transformOldProviderTheme = (
+export const transformProviderTheme = (
 	providerTheme: Theme['radio'],
 ): Partial<ThemeRadio> => {
 	const transformedTheme: Partial<ThemeRadio> = {};

--- a/libs/@guardian/source-react-components/src/utils/themes.test.ts
+++ b/libs/@guardian/source-react-components/src/utils/themes.test.ts
@@ -1,0 +1,86 @@
+import { mergeThemes } from './themes';
+
+type ThemeNew = {
+	text: string;
+	border: string;
+	highlight: string;
+};
+
+const themeDefault = {
+	text: 'black',
+	border: 'red',
+	highlight: 'hotpink',
+};
+
+const providerTheme = {
+	text: 'black',
+	border: 'green',
+};
+
+type ProviderTheme = typeof providerTheme | undefined;
+
+export const transformProviderTheme = (
+	providerTheme: ProviderTheme,
+): Partial<ThemeNew> => {
+	const transformedTheme: Partial<ThemeNew> = {};
+
+	if (providerTheme?.border) {
+		transformedTheme.highlight = providerTheme.border;
+	}
+	return { ...transformedTheme, ...providerTheme };
+};
+
+describe('mergeThemes', () => {
+	it('returns default theme untouched if no theme overrides or provider theme', () => {
+		const mergedTheme = mergeThemes<ThemeNew, ProviderTheme>(
+			themeDefault,
+			undefined,
+			undefined,
+		);
+		expect(mergedTheme).toStrictEqual({
+			text: 'black',
+			border: 'red',
+			highlight: 'hotpink',
+		});
+	});
+
+	it('merges theme provider theme with default theme', () => {
+		const mergedTheme = mergeThemes<ThemeNew, ProviderTheme>(
+			themeDefault,
+			undefined,
+			providerTheme,
+		);
+		expect(mergedTheme).toStrictEqual({
+			text: 'black',
+			border: 'green',
+			highlight: 'hotpink',
+		});
+	});
+
+	it('transforms and merges theme provider theme with default theme', () => {
+		const mergedTheme = mergeThemes<ThemeNew, ProviderTheme>(
+			themeDefault,
+			undefined,
+			providerTheme,
+			transformProviderTheme,
+		);
+		expect(mergedTheme).toStrictEqual({
+			text: 'black',
+			border: 'green',
+			highlight: 'green',
+		});
+	});
+
+	it('merges theme overrides with default theme', () => {
+		const mergedTheme = mergeThemes<ThemeNew, ProviderTheme>(
+			themeDefault,
+			{ highlight: 'yellow' },
+			undefined,
+		);
+		expect(mergedTheme).toStrictEqual({
+			text: 'black',
+			border: 'red',
+			highlight: 'yellow',
+		});
+	});
+});

--- a/libs/@guardian/source-react-components/src/utils/themes.ts
+++ b/libs/@guardian/source-react-components/src/utils/themes.ts
@@ -1,0 +1,16 @@
+/**
+ * Combine values from default theme with theme overrides from `theme` prop
+ * and deprecated `ThemeProvider` themes. Optionally pass `ThemeProvider` theme
+ * though transform function to map theme keys from old to new format.
+ */
+
+export const mergeThemes = <ComponentTheme, ProviderTheme>(
+	defaultTheme: ComponentTheme,
+	themeOverrides: Partial<ComponentTheme> | undefined,
+	providerTheme: ProviderTheme,
+	transform?: (providerTheme: ProviderTheme) => Partial<ComponentTheme>,
+): ComponentTheme => ({
+	...defaultTheme,
+	...(transform ? transform(providerTheme) : {}),
+	...themeOverrides,
+});

--- a/libs/@guardian/source-react-components/src/utils/themes.ts
+++ b/libs/@guardian/source-react-components/src/utils/themes.ts
@@ -11,6 +11,6 @@ export const mergeThemes = <ComponentTheme, ProviderTheme>(
 	transform?: (providerTheme: ProviderTheme) => Partial<ComponentTheme>,
 ): ComponentTheme => ({
 	...defaultTheme,
-	...(transform ? transform(providerTheme) : {}),
+	...(transform ? transform(providerTheme) : providerTheme),
 	...themeOverrides,
 });


### PR DESCRIPTION
## What are you changing?

- Adds generic `mergeThemes` function to merge values from new default themes, deprecated `ThemeProvider` themes and theme overrides, optionally passing `ThemeProvider` themes through a transform function to map old token names to new ones.

## Why?

- This logic is duplicated in every component now to support the new `theme` prop alongside the now deprecated `ThemeProvider` themes. Having it in a central place will make removal of the deprecated themes and transform functions simpler.
