### PR TITLE
Use new `recommended-type-checked` config name

### DIFF
--- a/.changeset/young-lions-camp.md
+++ b/.changeset/young-lions-camp.md
@@ -1,0 +1,7 @@
+---
+'@guardian/eslint-config-typescript': patch
+---
+
+Use new `recommended-type-checked` config name.
+
+https://typescript-eslint.io/linting/configs/#recommended-configurations

--- a/libs/@guardian/eslint-config-typescript/index.js
+++ b/libs/@guardian/eslint-config-typescript/index.js
@@ -10,7 +10,7 @@ module.exports = {
 		'@guardian/eslint-config',
 		'plugin:@typescript-eslint/eslint-recommended',
 		'plugin:@typescript-eslint/recommended',
-		'plugin:@typescript-eslint/recommended-requiring-type-checking',
+		'plugin:@typescript-eslint/recommended-type-checked',
 		'plugin:import/typescript',
 	],
 	settings: {

--- a/nx.json
+++ b/nx.json
@@ -52,12 +52,17 @@
 		}
 	},
 	"namedInputs": {
-		"default": ["{projectRoot}/**/*", "sharedGlobals"],
+		"default": ["{projectRoot}/**/*", "sharedGlobals", "internalTools"],
 		"sharedGlobals": [
 			"{workspaceRoot}/**/tsconfig*.json",
-			"{workspaceRoot}/tools/nx-plugins/**/*",
 			"{workspaceRoot}/.storybook/main.js",
-			"{workspaceRoot}/.nvmrc"
+			"{workspaceRoot}/.nvmrc",
+			"{workspaceRoot}/.eslintrc.*"
+		],
+		"internalTools": [
+			"{workspaceRoot}/libs/@guardian/eslint-*/**/*",
+			"{workspaceRoot}/libs/@guardian/tsconfig/**/*",
+			"{workspaceRoot}/tools/nx-plugins/**/*"
 		],
 		"production": ["default"]
 	}


### PR DESCRIPTION
## What are you changing?

- updates to use `typescript-eslint@v6` [`recommended-type-checked`](https://typescript-eslint.io/linting/configs/#recommended-configurations) config name

## Why?

- the old one is deprecated (spotted in https://github.com/guardian/csnx/pull/1134#issuecomment-1932095821)
