### PR TITLE
Add `theme` prop support to Text Input

### DIFF
--- a/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
+++ b/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import { TextInput } from './TextInput';
 import type { TextInputProps } from './TextInput';
+import { palette } from '@guardian/source-foundations';
 
 const meta: Meta<typeof TextInput> = {
 	title: 'TextInput',
@@ -223,6 +224,18 @@ ConstraintSmallDefaultTheme.args = {
 	title: '11 digit phone number',
 	type: 'tel',
 	size: 'small',
+};
+// *****************************************************************************
+
+export const ErrorWithMessageCustomTheme: StoryFn<typeof TextInput> =
+	Template.bind({});
+ErrorWithMessageCustomTheme.args = {
+	error: 'error',
+	theme: {
+		textError: palette.lifestyle[300],
+		borderError: palette.lifestyle[300],
+		background: palette.lifestyle[800],
+	},
 };
 
 // *****************************************************************************

--- a/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
+++ b/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
@@ -232,6 +232,7 @@ export const ErrorWithMessageCustomTheme: StoryFn<typeof TextInput> =
 ErrorWithMessageCustomTheme.args = {
 	error: 'error',
 	theme: {
+		textLabel: palette.lifestyle[100],
 		textError: palette.lifestyle[300],
 		borderError: palette.lifestyle[300],
 		background: palette.lifestyle[800],

--- a/libs/@guardian/source-react-components/src/text-input/TextInput.tsx
+++ b/libs/@guardian/source-react-components/src/text-input/TextInput.tsx
@@ -20,6 +20,12 @@ import {
 	widthFluid,
 } from './styles';
 import type { InputSize } from '../@types/InputSize';
+import {
+	ThemeTextInput,
+	themeTextInput,
+	transformProviderTheme,
+} from './theme';
+import { mergeThemes } from '../utils/themes';
 
 export type Width = 30 | 10 | 4;
 
@@ -75,6 +81,10 @@ export interface TextInputProps
 	 * _Note: if you pass the `value` prop, you MUST also pass an `onChange` handler, or the field will be rendered as read-only_
 	 */
 	value?: string;
+	/**
+	 * Partial or complete theme to override text input's colour palette
+	 */
+	theme?: Partial<ThemeTextInput>;
 }
 
 /**
@@ -97,10 +107,18 @@ export const TextInput = ({
 	width,
 	error,
 	success,
+	theme,
 	cssOverrides,
 	...props
 }: TextInputProps): EmotionJSX.Element => {
 	const textInputId = id ?? generateSourceId();
+	const mergedTheme = (providerTheme: Theme) =>
+		mergeThemes<ThemeTextInput, Theme['textInput']>(
+			themeTextInput,
+			theme,
+			providerTheme.textInput,
+			transformProviderTheme,
+		);
 	return (
 		<>
 			<Label
@@ -127,12 +145,12 @@ export const TextInput = ({
 				)}
 			</Label>
 			<input
-				css={(theme: Theme) => [
+				css={(providerTheme: Theme) => [
 					width ? widths[width] : widthFluid,
-					textInput(theme.textInput, size),
+					textInput(mergedTheme(providerTheme), size),
 					supporting ? supportingTextMargin : labelMargin,
-					error ? errorInput(theme.textInput) : '',
-					!error && success ? successInput(theme.textInput) : '',
+					error ? errorInput(mergedTheme(providerTheme)) : '',
+					!error && success ? successInput(mergedTheme(providerTheme)) : '',
 					cssOverrides,
 				]}
 				type="text"

--- a/libs/@guardian/source-react-components/src/text-input/TextInput.tsx
+++ b/libs/@guardian/source-react-components/src/text-input/TextInput.tsx
@@ -126,19 +126,28 @@ export const TextInput = ({
 				optional={!!optional}
 				hideLabel={hideLabel}
 				supporting={supporting}
+				theme={theme}
 				size={size}
 				htmlFor={textInputId}
 			>
 				{error && (
 					<div css={inlineMessageMargin}>
-						<InlineError id={descriptionId(textInputId)} size={size}>
+						<InlineError
+							id={descriptionId(textInputId)}
+							theme={theme}
+							size={size}
+						>
 							{error}
 						</InlineError>
 					</div>
 				)}
 				{!error && success && (
 					<div css={inlineMessageMargin}>
-						<InlineSuccess id={descriptionId(textInputId)} size={size}>
+						<InlineSuccess
+							id={descriptionId(textInputId)}
+							theme={theme}
+							size={size}
+						>
 							{success}
 						</InlineSuccess>
 					</div>

--- a/libs/@guardian/source-react-components/src/text-input/styles.ts
+++ b/libs/@guardian/source-react-components/src/text-input/styles.ts
@@ -2,7 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { focusHalo, size, space, textSans } from '@guardian/source-foundations';
 import type { InputSize } from '../@types/InputSize';
-import { textInputThemeDefault } from './theme';
+import type { ThemeTextInput } from './theme';
 
 const inputSizeMedium = css`
 	${textSans.medium()};
@@ -21,9 +21,7 @@ const inputSize: {
 	small: inputSizeSmall,
 };
 
-export const errorInput = (
-	textInput = textInputThemeDefault.textInput,
-): SerializedStyles => css`
+export const errorInput = (textInput: ThemeTextInput): SerializedStyles => css`
 	border: 2px solid ${textInput.borderError};
 	border-radius: 4px;
 	color: ${textInput.textError};
@@ -31,7 +29,7 @@ export const errorInput = (
 `;
 
 export const successInput = (
-	textInput = textInputThemeDefault.textInput,
+	textInput: ThemeTextInput,
 ): SerializedStyles => css`
 	border: 2px solid ${textInput.borderSuccess};
 	border-radius: 4px;
@@ -40,13 +38,13 @@ export const successInput = (
 `;
 
 export const textInput = (
-	textInput = textInputThemeDefault.textInput,
+	textInput: ThemeTextInput,
 	size: InputSize,
 ): SerializedStyles => css`
 	box-sizing: border-box;
 	${inputSize[size]};
-	color: ${textInput.textUserInput};
-	background-color: ${textInput.backgroundInput};
+	color: ${textInput.text};
+	background-color: ${textInput.background};
 	border: 1px solid ${textInput.border};
 	border-radius: 4px;
 	padding: 0 ${space[2]}px;

--- a/libs/@guardian/source-react-components/src/text-input/theme.ts
+++ b/libs/@guardian/source-react-components/src/text-input/theme.ts
@@ -4,6 +4,9 @@ import { userFeedbackThemeDefault } from '../user-feedback/theme';
 
 export type ThemeTextInput = {
 	text: string;
+	textLabel: string;
+	textOptional: string;
+	textSupporting: string;
 	textError: string;
 	textSuccess: string;
 	background: string;
@@ -14,6 +17,9 @@ export type ThemeTextInput = {
 
 export const themeTextInput: ThemeTextInput = {
 	text: palette.neutral[7],
+	textLabel: palette.neutral[7],
+	textOptional: palette.neutral[46],
+	textSupporting: palette.neutral[46],
 	textError: palette.neutral[7],
 	textSuccess: palette.success[400],
 	background: palette.neutral[100],

--- a/libs/@guardian/source-react-components/src/text-input/theme.ts
+++ b/libs/@guardian/source-react-components/src/text-input/theme.ts
@@ -1,5 +1,41 @@
 import { palette } from '@guardian/source-foundations';
+import type { Theme } from '../@types/Theme';
 import { userFeedbackThemeDefault } from '../user-feedback/theme';
+
+export type ThemeTextInput = {
+	text: string;
+	textError: string;
+	textSuccess: string;
+	background: string;
+	border: string;
+	borderError: string;
+	borderSuccess: string;
+};
+
+export const themeTextInput: ThemeTextInput = {
+	text: palette.neutral[7],
+	textError: palette.neutral[7],
+	textSuccess: palette.success[400],
+	background: palette.neutral[100],
+	border: palette.neutral[46],
+	borderError: palette.error[400],
+	borderSuccess: palette.success[400],
+};
+
+export const transformProviderTheme = (
+	providerTheme: Theme['textInput'],
+): Partial<ThemeTextInput> => {
+	const transformedTheme: Partial<ThemeTextInput> = {};
+	if (providerTheme?.textUserInput) {
+		transformedTheme.text = providerTheme.textUserInput;
+	}
+	if (providerTheme?.backgroundInput) {
+		transformedTheme.background = providerTheme.backgroundInput;
+	}
+	return { ...transformedTheme, ...providerTheme };
+};
+
+/** @deprecated Use `themeTextInput` and component `theme` prop instead of emotion's `ThemeProvider` */
 
 export const textInputThemeDefault = {
 	textInput: {


### PR DESCRIPTION
## What are you changing?

- Adds support for `theme` prop and updated theme format to `TextInput` component and deprecates use of existing themes and ThemeProvider.
