### PR TITLE
add canary release workflow

### DIFF
--- a/.changeset/violet-seahorses-burn.md
+++ b/.changeset/violet-seahorses-burn.md
@@ -1,0 +1,6 @@
+---
+'@guardian/libs': patch
+'@guardian/source': patch
+---
+
+noop - testing beta releases

--- a/.github/workflows/beta-releases.yml
+++ b/.github/workflows/beta-releases.yml
@@ -1,0 +1,88 @@
+name: Publish Beta Versions
+
+# This workflow is triggered on a label being added to a PR, and will publish a beta version of the bundle to npm
+# Use `yarn changeset add` to add a new change
+# This action will release the changeset as a pre-release, and add a comment to the PR with the version number
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-beta:
+    if: github.event.label.name == 'trigger beta release 🐣'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # This makes Actions fetch all Git history so that Changesets can
+          # generate changelogs with the correct commits
+          fetch-depth: 0
+
+      - uses: nrwl/nx-set-shas@v4
+      - uses: pnpm/action-setup@v2.4.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm nx run-many --target=build --all=true
+
+      # The Nx convention is to build projects to a root `dist` directory
+      # (outside their source directories), but changesets uses pnpm's workspace
+      # to look for the source directory of candidate packages when trying to
+      # publish.
+      #
+      # Therefore, after building the packages we are going to publish, we will
+      # rewrite the pnpm workspace file to point to the root `dist` directory
+      # instead.
+      #
+      # This will allow changesets to find the newly built assets to publish.
+      #
+      # Inspired by this article:
+      # https://dev.to/jmcdo29/automating-your-package-deployment-in-an-nx-monorepo-with-changeset-4em8
+      - name: Prepare workspace for publishing
+        run: echo -e "packages:\n  - 'dist/libs/**'" > pnpm-workspace.yaml
+
+      # This is a workaround for bug in changesets where it throws if you tell
+      # it ignore a package it cannot find. We're ignoring @csnx/* packages to
+      # stop it trying to create release PRs for them, which works fine. But at
+      # this point in the lifecycle, we don't build any @csnx/* packages, so it
+      # throws an error looking for them in `dist/libs` (see above) to ignore.
+      - name: Create fake @csnx package (workaround for changesets bug)
+        run: mkdir -p dist/libs/@csnx/null && echo -e "{\"name\":\"@csnx/null\",\"private\":true}" > dist/libs/@csnx/null/package.json
+
+      - name: Version
+        run: pnpm changeset version --snapshot beta
+
+      - name: Release
+        uses: changesets/action@v1
+        id: changeset
+        with:
+          publish: pnpm changeset publish --no-git-tag --snapshot beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - uses: actions/github-script@v6
+        if: steps.changeset.outputs.published == 'true'
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const publishedPackages = ${{ steps.changeset.outputs.publishedPackages }};
+            const version = publishedPackages[0].version;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: [
+                `> [!TIP]`,
+                `> 🐣 The following beta versions were published to NPM:`,
+                `>`,
+                ...publishedPackages.map((pkg) => `> - [\`${pkg.name}@${pkg.version}\`](https://www.npmjs.com/package/${pkg.name}/v/${pkg.version})`),
+              ].join('\n')
+            })

--- a/.github/workflows/beta-releases.yml
+++ b/.github/workflows/beta-releases.yml
@@ -56,11 +56,13 @@ jobs:
       - name: Create fake @csnx package (workaround for changesets bug)
         run: mkdir -p dist/libs/@csnx/null && echo -e "{\"name\":\"@csnx/null\",\"private\":true}" > dist/libs/@csnx/null/package.json
 
+      - name: Version
+        run: pnpm changeset version --snapshot beta
+
       - name: Release
         uses: changesets/action@v1
         id: publish-betas
         with:
-          version: pnpm changeset version --snapshot beta
           publish: pnpm changeset publish --no-git-tag --snapshot beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/beta-releases.yml
+++ b/.github/workflows/beta-releases.yml
@@ -63,13 +63,16 @@ jobs:
         uses: changesets/action@v1
         id: publish-betas
         with:
-          publish: pnpm changeset publish --no-git-tag --snapshot beta
+          # currently, you have to tag releases in git to get the action output to appear
+          # https://github.com/changesets/action/issues/141
+          # publish: pnpm changeset publish --no-git-tag --snapshot beta
+          publish: pnpm changeset publish --snapshot beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: actions/github-script@v6
-        # if: steps.publish-betas.outputs.published == 'true'
+        if: steps.publish-betas.outputs.published == 'true'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/beta-releases.yml
+++ b/.github/workflows/beta-releases.yml
@@ -82,7 +82,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: [
-                `> [!TIP]`,
+                `> [!NOTE]`,
                 `> 🐣 The following beta versions were published to NPM:`,
                 `>`,
                 ...publishedPackages.map((pkg) => `> - [\`${pkg.name}@${pkg.version}\`](https://www.npmjs.com/package/${pkg.name}/v/${pkg.version})`),

--- a/.github/workflows/beta-releases.yml
+++ b/.github/workflows/beta-releases.yml
@@ -56,25 +56,22 @@ jobs:
       - name: Create fake @csnx package (workaround for changesets bug)
         run: mkdir -p dist/libs/@csnx/null && echo -e "{\"name\":\"@csnx/null\",\"private\":true}" > dist/libs/@csnx/null/package.json
 
-      - name: Version
-        run: pnpm changeset version --snapshot beta
-
       - name: Release
         uses: changesets/action@v1
-        id: changeset
+        id: publish-betas
         with:
+          version: pnpm changeset version --snapshot beta
           publish: pnpm changeset publish --no-git-tag --snapshot beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: actions/github-script@v6
-        if: steps.changeset.outputs.published == 'true'
+        # if: steps.publish-betas.outputs.published == 'true'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const publishedPackages = ${{ steps.changeset.outputs.publishedPackages }};
-            const version = publishedPackages[0].version;
+            const publishedPackages = ${{ steps.publish-betas.outputs.publishedPackages }};
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/beta-releases.yml
+++ b/.github/workflows/beta-releases.yml
@@ -66,7 +66,7 @@ jobs:
           # currently, you have to tag releases in git to get the action output to appear
           # https://github.com/changesets/action/issues/141
           # publish: pnpm changeset publish --no-git-tag --snapshot beta
-          publish: pnpm changeset publish --snapshot beta
+          publish: pnpm changeset publish --tag beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -11,8 +11,31 @@ permissions:
   pull-requests: write
 
 jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    outputs:
+      has-label: ${{ steps.label-check.outputs.has-label }}
+    steps:
+      - name: Check for Canary label on PR
+        id: label-check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = await github.rest.issues
+              .listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              })
+            .then(({ data }) => data);
+            const hasLabel = labels.some(
+              (label) => label.name === '🐥 Canaries',
+            );
+            core.setOutput('has-label', hasLabel.toString());
+
   release:
-    if: github.event.label.name == '🐥 Canaries'
+    needs: check-label
+    if: needs.check-label.outputs.has-label == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -1,8 +1,7 @@
-name: Publish Beta Versions
+name: Publish Canaries
 
-# This workflow is triggered on a label being added to a PR, and will publish a beta version of the bundle to npm
-# Use `yarn changeset add` to add a new change
-# This action will release the changeset as a pre-release, and add a comment to the PR with the version number
+# This workflow is triggered on a label being added to a PR, and will publish a canary versions of all packages with waiting changesets to npm.
+# Use `make changeset` to add a new changeset.
 on:
   pull_request:
     types: [labeled]
@@ -12,8 +11,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  release-beta:
-    if: github.event.label.name == 'trigger beta release 🐣'
+  release:
+    if: github.event.label.name == '🐥 Canaries '
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,34 +56,35 @@ jobs:
         run: mkdir -p dist/libs/@csnx/null && echo -e "{\"name\":\"@csnx/null\",\"private\":true}" > dist/libs/@csnx/null/package.json
 
       - name: Version
-        run: pnpm changeset version --snapshot beta
+        run: pnpm changeset version --snapshot canary
 
       - name: Release
         uses: changesets/action@v1
-        id: publish-betas
+        id: publish-canary
         with:
           # currently, you have to tag releases in git to get the action output to appear
           # https://github.com/changesets/action/issues/141
-          # publish: pnpm changeset publish --no-git-tag --snapshot beta
-          publish: pnpm changeset publish --tag beta
+          # publish: pnpm changeset publish --no-git-tag --snapshot canary
+          publish: pnpm changeset publish --tag canary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: actions/github-script@v6
-        if: steps.publish-betas.outputs.published == 'true'
+        if: steps.publish-canary.outputs.published == 'true'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const publishedPackages = ${{ steps.publish-betas.outputs.publishedPackages }};
+            const publishedPackages = ${{ steps.publish-canary.outputs.publishedPackages }};
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: [
                 `> [!NOTE]`,
-                `> 🐣 The following beta versions were published to NPM:`,
+                `> The following canaries were published to NPM:`,
                 `>`,
                 ...publishedPackages.map((pkg) => `> - [\`${pkg.name}@${pkg.version}\`](https://www.npmjs.com/package/${pkg.name}/v/${pkg.version})`),
+                '🐥'
               ].join('\n')
             })

--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -85,6 +85,7 @@ jobs:
                 `> The following canaries were published to NPM:`,
                 `>`,
                 ...publishedPackages.map((pkg) => `> - [\`${pkg.name}@${pkg.version}\`](https://www.npmjs.com/package/${pkg.name}/v/${pkg.version})`),
+                '',
                 '🐥'
               ].join('\n')
             })

--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -4,7 +4,7 @@ name: Publish Canaries
 # Use `make changeset` to add a new changeset.
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, synchronize]
 
 permissions:
   contents: write
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release:
-    if: github.event.label.name == '🐥 Canaries '
+    if: github.event.label.name == '🐥 Canaries'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What are you changing?

- testing canary release flow

## Why?

- so we can test packages in external consumer codebases
