### PR TITLE
Add `theme` prop support to Text Area 

### DIFF
--- a/libs/@guardian/source-react-components/src/text-area/TextArea.stories.tsx
+++ b/libs/@guardian/source-react-components/src/text-area/TextArea.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import type { TextAreaProps } from './TextArea';
 import { TextArea } from './TextArea';
+import { palette } from '@guardian/source-foundations';
 
 const meta: Meta<typeof TextArea> = {
 	title: 'TextArea',
@@ -174,6 +175,20 @@ export const SuccessWithMessageSmallDefaultTheme: StoryFn<typeof TextArea> =
 SuccessWithMessageSmallDefaultTheme.args = {
 	success: 'success',
 	size: 'small',
+};
+
+// *****************************************************************************
+
+export const ErrorWithMessageCustomTheme: StoryFn<typeof TextArea> =
+	Template.bind({});
+ErrorWithMessageCustomTheme.args = {
+	error: 'error',
+	theme: {
+		textLabel: palette.lifestyle[100],
+		textError: palette.lifestyle[300],
+		borderError: palette.lifestyle[300],
+		background: palette.lifestyle[800],
+	},
 };
 
 // *****************************************************************************

--- a/libs/@guardian/source-react-components/src/text-area/TextArea.tsx
+++ b/libs/@guardian/source-react-components/src/text-area/TextArea.tsx
@@ -15,6 +15,7 @@ import {
 	widthFluid,
 } from './styles';
 import { InputSize } from '../@types/InputSize';
+import { ThemeTextArea, themeTextArea } from './theme';
 
 export interface TextAreaProps
 	extends Omit<InputHTMLAttributes<HTMLTextAreaElement>, 'size'>,
@@ -59,6 +60,10 @@ export interface TextAreaProps
 	 * Specify the number of rows the component should display by default.
 	 */
 	rows?: number;
+	/**
+	 * Partial or complete theme to override text area's colour palette
+	 */
+	theme?: Partial<ThemeTextArea>;
 }
 
 /**
@@ -82,6 +87,7 @@ export const TextArea = ({
 	rows = 3,
 	className,
 	value,
+	theme,
 	...props
 }: TextAreaProps): EmotionJSX.Element => {
 	const textAreaId = id ?? generateSourceId();
@@ -98,6 +104,7 @@ export const TextArea = ({
 
 		return undefined;
 	};
+	const mergedTheme = { ...themeTextArea, ...theme };
 
 	return (
 		<>
@@ -105,20 +112,29 @@ export const TextArea = ({
 				text={labelText}
 				supporting={supporting}
 				optional={!!optional}
+				theme={theme}
 				size={size}
 				hideLabel={hideLabel}
 				htmlFor={textAreaId}
 			>
 				{error && (
 					<div css={inlineMessageMargin}>
-						<InlineError id={descriptionId(textAreaId)} size={size}>
+						<InlineError
+							id={descriptionId(textAreaId)}
+							theme={theme}
+							size={size}
+						>
 							{error}
 						</InlineError>
 					</div>
 				)}
 				{!error && success && (
 					<div css={inlineMessageMargin}>
-						<InlineSuccess id={descriptionId(textAreaId)} size={size}>
+						<InlineSuccess
+							id={descriptionId(textAreaId)}
+							theme={theme}
+							size={size}
+						>
 							{success}
 						</InlineSuccess>
 					</div>
@@ -127,10 +143,10 @@ export const TextArea = ({
 			<textarea
 				css={[
 					widthFluid,
-					textArea(size),
+					textArea(mergedTheme, size),
 					supporting ? supportingTextMargin : labelMargin,
-					error ? errorInput : '',
-					!error && success ? successInput : '',
+					error ? errorInput(mergedTheme) : '',
+					!error && success ? successInput(mergedTheme) : '',
 					cssOverrides,
 				]}
 				id={textAreaId}

--- a/libs/@guardian/source-react-components/src/text-area/styles.ts
+++ b/libs/@guardian/source-react-components/src/text-area/styles.ts
@@ -1,12 +1,8 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import {
-	focusHalo,
-	palette,
-	space,
-	textSans,
-} from '@guardian/source-foundations';
+import { focusHalo, space, textSans } from '@guardian/source-foundations';
 import type { InputSize } from '../@types/InputSize';
+import type { ThemeTextArea } from './theme';
 
 const textAreaSize: {
 	[key in InputSize]: string;
@@ -15,26 +11,29 @@ const textAreaSize: {
 	small: textSans.xsmall(),
 };
 
-export const errorInput = css`
-	border: 2px solid ${palette.error[400]};
+export const errorInput = (textArea: ThemeTextArea): SerializedStyles => css`
+	border: 2px solid ${textArea.borderError};
 	border-radius: 4px;
-	color: ${palette.neutral[7]};
+	color: ${textArea.textError};
 	margin-top: 0;
 `;
 
-export const successInput = css`
-	border: 2px solid ${palette.success[400]};
+export const successInput = (textArea: ThemeTextArea): SerializedStyles => css`
+	border: 2px solid ${textArea.borderSuccess};
 	border-radius: 4px;
-	color: ${palette.success[400]};
+	color: ${textArea.textSuccess};
 	margin-top: 0;
 `;
 
-export const textArea = (size: InputSize): SerializedStyles => css`
+export const textArea = (
+	textArea: ThemeTextArea,
+	size: InputSize,
+): SerializedStyles => css`
 	box-sizing: border-box;
 	${textAreaSize[size]};
-	color: ${palette.neutral[7]};
-	background-color: ${palette.neutral[100]};
-	border: 1px solid ${palette.neutral[46]};
+	color: ${textArea.text};
+	background-color: ${textArea.background};
+	border: 1px solid ${textArea.border};
 	border-radius: 4px;
 	padding: ${space[2]}px ${space[2]}px 0 ${space[2]}px;
 
@@ -54,7 +53,7 @@ export const textArea = (size: InputSize): SerializedStyles => css`
 		component: https://reactjs.org/docs/forms.html#controlled-components
 		*/
 		.src-has-value {
-			${errorInput}
+			${errorInput(textArea)}
 		}
 	}
 `;

--- a/libs/@guardian/source-react-components/src/text-area/theme.ts
+++ b/libs/@guardian/source-react-components/src/text-area/theme.ts
@@ -1,0 +1,27 @@
+import { palette } from '@guardian/source-foundations';
+
+export type ThemeTextArea = {
+	text: string;
+	textLabel: string;
+	textOptional: string;
+	textSupporting: string;
+	textError: string;
+	textSuccess: string;
+	background: string;
+	border: string;
+	borderError: string;
+	borderSuccess: string;
+};
+
+export const themeTextArea: ThemeTextArea = {
+	text: palette.neutral[7],
+	textLabel: palette.neutral[7],
+	textOptional: palette.neutral[46],
+	textSupporting: palette.neutral[46],
+	textError: palette.neutral[7],
+	textSuccess: palette.success[400],
+	background: palette.neutral[100],
+	border: palette.neutral[46],
+	borderError: palette.error[400],
+	borderSuccess: palette.success[400],
+};


### PR DESCRIPTION
## What are you changing?

- Adds support for theming via `theme` prop to `TextArea` component.
- This component does not have any existing support for theming via `ThemeProvider`.
