### PR TITLE
Add canary release workflow 🐥

### DIFF
--- a/.changeset/nice-walls-eat.md
+++ b/.changeset/nice-walls-eat.md
@@ -1,5 +1,0 @@
----
-'@guardian/libs': patch
----
-
-noop to test canary release workflow

--- a/.changeset/nice-walls-eat.md
+++ b/.changeset/nice-walls-eat.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': patch
+---
+
+noop to test canary release workflow

--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -1,0 +1,114 @@
+name: Publish Canaries
+
+# This workflow is triggered on a label being added to a PR, and will publish a canary versions of all packages with waiting changesets to npm.
+# Use `make changeset` to add a new changeset.
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    outputs:
+      has-label: ${{ steps.label-check.outputs.has-label }}
+    steps:
+      - name: Check for Canary label on PR
+        id: label-check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = await github.rest.issues
+              .listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              })
+            .then(({ data }) => data);
+            const hasLabel = labels.some(
+              (label) => label.name === '🐥 Canaries',
+            );
+            core.setOutput('has-label', hasLabel.toString());
+
+  release:
+    needs: check-label
+    if: needs.check-label.outputs.has-label == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # This makes Actions fetch all Git history so that Changesets can
+          # generate changelogs with the correct commits
+          fetch-depth: 0
+
+      - uses: nrwl/nx-set-shas@v4
+      - uses: pnpm/action-setup@v2.4.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm nx run-many --target=build --all=true
+
+      # The Nx convention is to build projects to a root `dist` directory
+      # (outside their source directories), but changesets uses pnpm's workspace
+      # to look for the source directory of candidate packages when trying to
+      # publish.
+      #
+      # Therefore, after building the packages we are going to publish, we will
+      # rewrite the pnpm workspace file to point to the root `dist` directory
+      # instead.
+      #
+      # This will allow changesets to find the newly built assets to publish.
+      #
+      # Inspired by this article:
+      # https://dev.to/jmcdo29/automating-your-package-deployment-in-an-nx-monorepo-with-changeset-4em8
+      - name: Prepare workspace for publishing
+        run: echo -e "packages:\n  - 'dist/libs/**'" > pnpm-workspace.yaml
+
+      # This is a workaround for bug in changesets where it throws if you tell
+      # it ignore a package it cannot find. We're ignoring @csnx/* packages to
+      # stop it trying to create release PRs for them, which works fine. But at
+      # this point in the lifecycle, we don't build any @csnx/* packages, so it
+      # throws an error looking for them in `dist/libs` (see above) to ignore.
+      - name: Create fake @csnx package (workaround for changesets bug)
+        run: mkdir -p dist/libs/@csnx/null && echo -e "{\"name\":\"@csnx/null\",\"private\":true}" > dist/libs/@csnx/null/package.json
+
+      - name: Version
+        run: pnpm changeset version --snapshot canary
+
+      - name: Release
+        uses: changesets/action@v1
+        id: publish-canary
+        with:
+          # currently, you have to tag releases in git to get the action output to appear
+          # https://github.com/changesets/action/issues/141
+          # publish: pnpm changeset publish --no-git-tag --snapshot canary
+          publish: pnpm changeset publish --tag canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - uses: actions/github-script@v6
+        if: steps.publish-canary.outputs.published == 'true'
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const publishedPackages = ${{ steps.publish-canary.outputs.publishedPackages }};
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: [
+                `> [!NOTE]`,
+                `> The following canaries were published to NPM:`,
+                `>`,
+                ...publishedPackages.map((pkg) => `> - [\`${pkg.name}@${pkg.version}\`](https://www.npmjs.com/package/${pkg.name}/v/${pkg.version})`),
+                '',
+                '🐥'
+              ].join('\n')
+            })


### PR DESCRIPTION
## What are you changing?

Adds a canary release option to PRs.

## Why?

So we can test packages in external consumer codebases (@guardian/transparency-consent do this a lot, so it's needed for #1128).

## How does it work?

It is based heavily on similar workflows in https://github.com/guardian/commercial/pull/797 and https://github.com/guardian/consent-management-platform/pull/849 (but with some slight differences):

1. adding the `🐥 Canaries` label to a PR will trigger the release of canary versions of all packages with waiting changesets[^1]
2. while the label is present, pushing changes to the PR head branch will also release a new set of canaries (so you don't have to remove and add it continually)
3. removing the label will stop new releases (until you add it back)

## Demo

You can see it running on this PR from https://github.com/guardian/csnx/pull/1178#event-11736477830 onwards.

[^1]: This is maybe not expected, but also it's not obvious how you'd get round this. How do you know which package with unreleased changes the user wants to test? It feels like overkill but I think it kind of makes sense. 