### PR TITLE
Make `@guardian/transparency-consent` codeowners of CMP stuff

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 # By default all files are owned by these teams:
 * 																@guardian/client-side-infra
 
-/.changeset/ 													@guardian/client-side-infra @guardian/dotcom-platform @guardian/commercial-dev @guardian/identity @guardian/source
+/.changeset/ 													@guardian/client-side-infra @guardian/dotcom-platform @guardian/commercial-dev @guardian/identity @guardian/source @guardian/transparency-consent
 
 /libs/@guardian/source-foundations/ 							@guardian/client-side-infra @guardian/source
 /libs/@guardian/source-react-components/ 						@guardian/client-side-infra @guardian/source
@@ -17,7 +17,10 @@
 /libs/@guardian/eslint-plugin-source-react-components/ 			@guardian/client-side-infra @guardian/source
 
 /libs/@guardian/browserlist-config/  							@guardian/client-side-infra @guardian/dotcom-platform
+
 /libs/@guardian/libs/ 											@guardian/client-side-infra @guardian/apps-rendering @guardian/dotcom-platform
+/libs/@guardian/libs/src/consent-management-platform/ 			@guardian/client-side-infra @guardian/transparency-consent
+
 /libs/@guardian/identity-auth-frontend/ 						@guardian/client-side-infra @guardian/dotcom-platform @guardian/commercial-dev @guardian/identity
 
 /libs/@guardian/identity-auth/ 									@guardian/client-side-infra @guardian/identity


### PR DESCRIPTION
## What are you changing?

- adds @guardian/transparency-consent to CODEOWNERS, for all CMP code

## Why?

- so they have visibility and sign-off of changes to the CMP
