### PR TITLE
Simplify workflows that use labels

### DIFF
--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -11,31 +11,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  check-label:
-    runs-on: ubuntu-latest
-    outputs:
-      has-label: ${{ steps.label-check.outputs.has-label }}
-    steps:
-      - name: Check for Canary label on PR
-        id: label-check
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const labels = await github.rest.issues
-              .listLabelsOnIssue({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-              })
-            .then(({ data }) => data);
-            const hasLabel = labels.some(
-              (label) => label.name === '🐥 Canaries',
-            );
-            core.setOutput('has-label', hasLabel.toString());
-
   release:
-    needs: check-label
-    if: needs.check-label.outputs.has-label == 'true'
+    if: contains(github.event.pull_request.labels.*.name, '🐥 Canaries')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/chromatic-label-helper.yml
+++ b/.github/workflows/chromatic-label-helper.yml
@@ -19,29 +19,15 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const labels = await github.rest.issues
-              .listLabelsOnIssue({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-              })
-              .then(({ data }) => data);
-
-            const hasChromaticLabel = labels.some(
-              (label) => label.name === 'run-chromatic',
-            );
-
-            if (!hasChromaticLabel) {
-              const commentLines = [
-                "> [!TIP]",
-                "> Once this PR is ready to go, add the `run_chromatic` label to run the Chromatic tests.",
-                ">",
-                "> This saves us a lot of money by not running the tests before we need them.",
-              ];
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: commentLines.join('\n'),
-              });
-            }
+            const comment = [
+              "> [!TIP]",
+              "> Once this PR is ready to go, add the `run_chromatic` label to run the Chromatic tests.",
+              ">",
+              "> _This saves us a lot of money by not running the tests before we need them._",
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment,
+            });


### PR DESCRIPTION
## What are you changing?

- simplify the checking for hte canaries label (uses the same method as the chromatic check)
- removes the check for a chromatic label before commenting on a new PR

## Why?

- chromatic check only runs on new PRs, so they wont' be labelled anyway
