### PR TITLE
Rationalise workflows a little

### DIFF
--- a/.github/actions/prepare-for-changesets/action.yml
+++ b/.github/actions/prepare-for-changesets/action.yml
@@ -1,0 +1,31 @@
+name: 'Prepare Nx project for changesets'
+description: 'Sets things up so that changesets can run alongside Nx'
+
+runs:
+  using: 'composite'
+  steps:
+    # The Nx convention is to build projects to a root `dist` directory
+    # (outside their source directories), but changesets uses pnpm's workspace
+    # to look for the source directory of candidate packages when trying to
+    # publish.
+    #
+    # Therefore, after building the packages we are going to publish, we will
+    # rewrite the pnpm workspace file to point to the root `dist` directory
+    # instead.
+    #
+    # This will allow changesets to find the newly built assets to publish.
+    #
+    # Inspired by this article:
+    # https://dev.to/jmcdo29/automating-your-package-deployment-in-an-nx-monorepo-with-changeset-4em8
+    - name: Prepare workspace for publishing
+      run: echo -e "packages:\n  - 'dist/libs/**'" > pnpm-workspace.yaml
+      shell: bash
+
+    # This is a workaround for bug in changesets where it throws if you tell
+    # it ignore a package it cannot find. We're ignoring @csnx/* packages to
+    # stop it trying to create release PRs for them, which works fine. But at
+    # this point in the lifecycle, we don't build any @csnx/* packages, so it
+    # throws an error looking for them in `dist/libs` (see above) to ignore.
+    - name: Create fake @csnx package (workaround for changesets bug)
+      run: mkdir -p dist/libs/@csnx/null && echo -e "{\"name\":\"@csnx/null\",\"private\":true}" > dist/libs/@csnx/null/package.json
+      shell: bash

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -1,0 +1,16 @@
+name: 'Setup Environment'
+description: 'Sets up Node.js environment and installs dependencies'
+
+runs:
+  using: 'composite'
+  steps:
+    - run: corepack enable
+      shell: bash
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'pnpm'
+
+    - run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -31,29 +31,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm nx run-many --target=build --all=true
 
-      # The Nx convention is to build projects to a root `dist` directory
-      # (outside their source directories), but changesets uses pnpm's workspace
-      # to look for the source directory of candidate packages when trying to
-      # publish.
-      #
-      # Therefore, after building the packages we are going to publish, we will
-      # rewrite the pnpm workspace file to point to the root `dist` directory
-      # instead.
-      #
-      # This will allow changesets to find the newly built assets to publish.
-      #
-      # Inspired by this article:
-      # https://dev.to/jmcdo29/automating-your-package-deployment-in-an-nx-monorepo-with-changeset-4em8
-      - name: Prepare workspace for publishing
-        run: echo -e "packages:\n  - 'dist/libs/**'" > pnpm-workspace.yaml
-
-      # This is a workaround for bug in changesets where it throws if you tell
-      # it ignore a package it cannot find. We're ignoring @csnx/* packages to
-      # stop it trying to create release PRs for them, which works fine. But at
-      # this point in the lifecycle, we don't build any @csnx/* packages, so it
-      # throws an error looking for them in `dist/libs` (see above) to ignore.
-      - name: Create fake @csnx package (workaround for changesets bug)
-        run: mkdir -p dist/libs/@csnx/null && echo -e "{\"name\":\"@csnx/null\",\"private\":true}" > dist/libs/@csnx/null/package.json
+      - name: Prepare Nx project for changesets
+        uses: ./.github/actions/prepare-for-changesets
 
       - name: Version
         run: pnpm changeset version --snapshot canary

--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -22,13 +22,8 @@ jobs:
           fetch-depth: 0
 
       - uses: nrwl/nx-set-shas@v4
-      - uses: pnpm/action-setup@v2.4.0
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+      - uses: ./.github/actions/setup-node-env
 
-      - run: pnpm install --frozen-lockfile
       - run: pnpm nx run-many --target=build --all=true
 
       - name: Prepare Nx project for changesets

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -25,13 +25,8 @@ jobs:
           fetch-depth: 0
 
       - uses: nrwl/nx-set-shas@v4
-      - uses: pnpm/action-setup@v2.4.0
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+      - uses: ./.github/actions/setup-node-env
 
-      - run: pnpm install --frozen-lockfile
       # - run: pnpm nx affected --target=build
       - run: pnpm nx run-many --target=build --all=true
 

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,22 +1,23 @@
 name: Manage Changesets
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [CI]
+    branches: [main]
+    types: [completed]
 
 permissions:
   contents: write
   pull-requests: write
 
-env:
-  NX_BRANCH: ${{ github.event.pull_request.head.ref }}
-  NX_RUN_GROUP: ${{ github.run_id }}
-
 jobs:
   changesets-version:
     name: Manage Changesets Pull Request
     runs-on: ubuntu-latest
+
+    # only run if CI is successful
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,7 +28,6 @@ jobs:
       - uses: nrwl/nx-set-shas@v4
       - uses: ./.github/actions/setup-node-env
 
-      # - run: pnpm nx affected --target=build
       - run: pnpm nx run-many --target=build --all=true
 
       - name: Prepare Nx project for changesets

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -35,29 +35,8 @@ jobs:
       # - run: pnpm nx affected --target=build
       - run: pnpm nx run-many --target=build --all=true
 
-      # The Nx convention is to build projects to a root `dist` directory
-      # (outside their source directories), but changesets uses pnpm's workspace
-      # to look for the source directory of candidate packages when trying to
-      # publish.
-      #
-      # Therefore, after building the packages we are going to publish, we will
-      # rewrite the pnpm workspace file to point to the root `dist` directory
-      # instead.
-      #
-      # This will allow changesets to find the newly built assets to publish.
-      #
-      # Inspired by this article:
-      # https://dev.to/jmcdo29/automating-your-package-deployment-in-an-nx-monorepo-with-changeset-4em8
-      - name: Prepare workspace for publishing
-        run: echo -e "packages:\n  - 'dist/libs/**'" > pnpm-workspace.yaml
-
-      # This is a workaround for bug in changesets where it throws if you tell
-      # it ignore a package it cannot find. We're ignoring @csnx/* packages to
-      # stop it trying to create release PRs for them, which works fine. But at
-      # this point in the lifecycle, we don't build any @csnx/* packages, so it
-      # throws an error looking for them in `dist/libs` (see above) to ignore.
-      - name: Create fake @csnx package (workaround for changesets bug)
-        run: mkdir -p dist/libs/@csnx/null && echo -e "{\"name\":\"@csnx/null\",\"private\":true}" > dist/libs/@csnx/null/package.json
+      - name: Prepare Nx project for changesets
+        uses: ./.github/actions/prepare-for-changesets
 
       # down to business...
       - name: Use GitHub App Token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # enables use to use the cache in actions/setup-node
-      - uses: pnpm/action-setup@v2.4.0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
       - uses: nrwl/nx-set-shas@v4
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-env
 
       - run: make ${{ matrix.task }}
 
@@ -72,15 +63,7 @@ jobs:
         with:
           fetch-depth: 0 # for chromatic to work
 
-      # enables use to use the cache in actions/setup-node
-      - uses: pnpm/action-setup@v2.4.0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-env
 
       # This will just retrieve the output created in `validate` from Nx's build
       # cache. It's simpler than using github actions cache.

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -18,8 +18,12 @@ on:
     types: [completed]
 
 jobs:
-  on-success: # only run if CI is successful
+  publish-storybook:
     runs-on: ubuntu-latest
+
+    # only run if CI is successful
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -26,15 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # enables use to use the cache in actions/setup-node
-      - uses: pnpm/action-setup@v2.4.0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-env
 
       - name: Build root storybook
         run: pnpm nx run csnx:build-storybook


### PR DESCRIPTION
## What are you changing?

- moves the changesets and node/pnpm setup stuff to a new action
- makes sure storybook and packages are only published from `main` if CI succeeds

## Why?

- make it easier to read actions, and keep things in sync
- we shouldn't be releasing anything if `main` fails
