### PR TITLE
Update custom theme examples for consistency and realism

### DIFF
--- a/libs/@guardian/source-react-components/src/accordion/Accordion.stories.tsx
+++ b/libs/@guardian/source-react-components/src/accordion/Accordion.stories.tsx
@@ -39,24 +39,37 @@ WithoutCTALabelsDefaultTheme.args = {
 	hideToggleLabel: true,
 };
 
+// *****************************************************************************
+
 export const WithCTALabelsCustomTheme: StoryFn<typeof Accordion> =
 	Template.bind({});
 WithCTALabelsCustomTheme.args = {
 	theme: {
-		border: palette.news['550'],
-		text: palette.opinion['400'],
-		label: palette.news['400'],
-		ctaText: palette.neutral[7],
+		border: palette.neutral[60],
+		text: palette.neutral[86],
+		label: palette.neutral[86],
+		ctaText: palette.neutral[86],
 	},
 };
+WithCTALabelsCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
+	},
+};
+// *****************************************************************************
 
 export const WithoutCTALabelsCustomTheme: StoryFn<typeof Accordion> =
 	Template.bind({});
 WithoutCTALabelsCustomTheme.args = {
 	hideToggleLabel: true,
 	theme: {
-		border: palette.news['550'],
-		text: palette.neutral['0'],
-		label: palette.news['400'],
+		border: palette.neutral[60],
+		text: palette.neutral[86],
+		label: palette.neutral[86],
+	},
+};
+WithoutCTALabelsCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };

--- a/libs/@guardian/source-react-components/src/button/Button.stories.tsx
+++ b/libs/@guardian/source-react-components/src/button/Button.stories.tsx
@@ -411,11 +411,18 @@ IsLoadingLabelHidden.args = {
 	hideLabel: true,
 };
 
-export const CustomThemeButton: StoryFn<typeof Button> = Template.bind({});
-CustomThemeButton.args = {
+// *****************************************************************************
+
+export const CustomTheme: StoryFn<typeof Button> = Template.bind({});
+CustomTheme.args = {
 	theme: {
-		backgroundPrimary: palette.news[100],
-		backgroundPrimaryHover: palette.news[200],
-		textPrimary: palette.opinion[400],
+		textPrimary: palette.brand[400],
+		backgroundPrimary: palette.brandAlt[400],
+		backgroundPrimaryHover: palette.brandAlt[200],
+	},
+};
+CustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };

--- a/libs/@guardian/source-react-components/src/button/LinkButton.stories.tsx
+++ b/libs/@guardian/source-react-components/src/button/LinkButton.stories.tsx
@@ -194,8 +194,13 @@ PrimaryPriorityCustomTheme.args = {
 	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
 	icon: 'arrow',
 	theme: {
-		backgroundPrimary: palette.opinion['500'],
-		backgroundPrimaryHover: palette.opinion['600'],
-		textPrimary: palette.neutral['0'],
+		textPrimary: palette.brand[400],
+		backgroundPrimary: palette.brandAlt[400],
+		backgroundPrimaryHover: palette.brandAlt[200],
+	},
+};
+PrimaryPriorityCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };

--- a/libs/@guardian/source-react-components/src/checkbox/Checkbox.stories.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/Checkbox.stories.tsx
@@ -114,13 +114,21 @@ UnlabelledDefaultTheme.args = {
 	'aria-label': 'Checkbox',
 };
 
-export const CustomTheme: StoryFn<CheckboxProps> = Template.bind({});
-CustomTheme.args = {
+// *****************************************************************************
+
+export const DefaultCustomTheme: StoryFn<CheckboxProps> = Template.bind({});
+DefaultCustomTheme.args = {
 	theme: {
-		fillUnselected: palette.neutral[0],
-		fillSelected: palette.lifestyle[500],
-		borderSelected: palette.lifestyle[500],
-		borderHover: palette.lifestyle[400],
-		textLabel: palette.lifestyle[400],
+		fillSelected: palette.brand[800],
+		fillUnselected: palette.neutral[20],
+		borderSelected: palette.brand[800],
+		borderUnselected: palette.neutral[60],
+		borderHover: palette.brand[800],
+		textLabel: palette.neutral[86],
+	},
+};
+DefaultCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };

--- a/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
@@ -3,9 +3,12 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import { Checkbox } from './Checkbox';
 import CheckboxStories from './Checkbox.stories';
-import type { CheckboxGroupProps } from './CheckboxGroup';
 import { CheckboxGroup } from './CheckboxGroup';
-import { themeCheckboxBrand } from './theme';
+import {
+	ThemeCheckbox,
+	themeCheckboxBrand,
+	themeCheckboxGroupBrand,
+} from './theme';
 
 const meta: Meta<typeof CheckboxGroup> = {
 	title: 'CheckboxGroup',
@@ -22,13 +25,22 @@ const meta: Meta<typeof CheckboxGroup> = {
 
 export default meta;
 
-const Template: StoryFn<typeof CheckboxGroup> = (args: CheckboxGroupProps) => {
+type CheckboxGroupPropsAndChildTheme = React.ComponentProps<
+	typeof CheckboxGroup
+> & {
+	themeChild?: Partial<ThemeCheckbox>;
+};
+
+const Template: StoryFn<CheckboxGroupPropsAndChildTheme> = (
+	args: CheckboxGroupPropsAndChildTheme,
+) => {
 	const [checked, setChecked] = useState(CheckboxStories.args?.checked);
 
 	return (
 		<CheckboxGroup {...args}>
 			<Checkbox
 				{...CheckboxStories.args}
+				theme={args.themeChild}
 				checked={checked}
 				onChange={(e) => setChecked(e.target.checked)}
 			/>
@@ -36,25 +48,26 @@ const Template: StoryFn<typeof CheckboxGroup> = (args: CheckboxGroupProps) => {
 	);
 };
 
-export const DefaultDefaultTheme: StoryFn<typeof CheckboxGroup> = Template.bind(
-	{},
-);
+export const DefaultDefaultTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
+	Template.bind({});
 
 // *****************************************************************************
 
-export const DefaultBrandTheme: StoryFn<typeof CheckboxGroup> = Template.bind(
-	{},
-);
+export const DefaultBrandTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
+	Template.bind({});
 DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: themeCheckboxBrand,
+};
+DefaultBrandTheme.args = {
+	theme: themeCheckboxGroupBrand,
+	themeChild: themeCheckboxBrand,
 };
 
 // *****************************************************************************
 
-export const VisuallyHideLegendDefaultTheme: StoryFn<typeof CheckboxGroup> =
+export const VisuallyHideLegendDefaultTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
 	Template.bind({});
 VisuallyHideLegendDefaultTheme.args = {
 	hideLabel: true,
@@ -62,21 +75,22 @@ VisuallyHideLegendDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const VisuallyHideLegendBrandTheme: StoryFn<typeof CheckboxGroup> =
+export const VisuallyHideLegendBrandTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
 	Template.bind({});
 VisuallyHideLegendBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: themeCheckboxBrand,
 };
 VisuallyHideLegendBrandTheme.args = {
 	hideLabel: true,
+	theme: themeCheckboxGroupBrand,
+	themeChild: themeCheckboxBrand,
 };
 
 // *****************************************************************************
 
-export const SupportingTextDefaultTheme: StoryFn<typeof CheckboxGroup> =
+export const SupportingTextDefaultTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
 	Template.bind({});
 SupportingTextDefaultTheme.args = {
 	supporting: 'Pick the issues and topics that interest you',
@@ -84,7 +98,7 @@ SupportingTextDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const OptionalDefaultTheme: StoryFn<typeof CheckboxGroup> =
+export const OptionalDefaultTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
 	Template.bind({});
 OptionalDefaultTheme.args = {
 	optional: true,
@@ -92,49 +106,64 @@ OptionalDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingTextBrandTheme: StoryFn<typeof CheckboxGroup> =
+export const SupportingTextBrandTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
 	Template.bind({});
 SupportingTextBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: themeCheckboxBrand,
 };
 SupportingTextBrandTheme.args = {
 	supporting: 'Pick the issues and topics that interest you',
+	theme: themeCheckboxGroupBrand,
+	themeChild: themeCheckboxBrand,
 };
 
 // *****************************************************************************
 
-export const ErrorDefaultTheme: StoryFn<typeof CheckboxGroup> = Template.bind(
-	{},
-);
+export const ErrorDefaultTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
+	Template.bind({});
 ErrorDefaultTheme.args = {
 	error: 'This newsletter is not available in your region',
 };
 
 // *****************************************************************************
 
-export const ErrorBrandTheme: StoryFn<typeof CheckboxGroup> = Template.bind({});
+export const ErrorBrandTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
+	Template.bind({});
 ErrorBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: themeCheckboxBrand,
 };
 ErrorBrandTheme.args = {
 	error: 'This newsletter is not available in your region',
+	theme: themeCheckboxGroupBrand,
+	themeChild: themeCheckboxBrand,
 };
 
 // *****************************************************************************
 
-export const ErrorCustomTheme: StoryFn<typeof CheckboxGroup> = Template.bind(
-	{},
-);
+export const ErrorCustomTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
+	Template.bind({});
 ErrorCustomTheme.args = {
-	theme: {
-		textLabel: palette.sport[400],
-		textError: palette.sport[400],
-	},
 	error: 'This newsletter is not available in your region',
+	theme: {
+		textLabel: palette.neutral[86],
+		textError: palette.error[500],
+	},
+	themeChild: {
+		fillSelected: palette.brand[800],
+		fillUnselected: palette.neutral[20],
+		borderSelected: palette.brand[800],
+		borderUnselected: palette.neutral[60],
+		borderHover: palette.brand[800],
+		borderError: palette.error[500],
+		textLabel: palette.neutral[86],
+	},
+};
+ErrorCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
+	},
 };

--- a/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from './Checkbox';
 import CheckboxStories from './Checkbox.stories';
 import type { CheckboxGroupProps } from './CheckboxGroup';
 import { CheckboxGroup } from './CheckboxGroup';
-import { checkboxThemeBrand } from './theme';
+import { themeCheckboxBrand } from './theme';
 
 const meta: Meta<typeof CheckboxGroup> = {
 	title: 'CheckboxGroup',
@@ -49,7 +49,7 @@ DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: checkboxThemeBrand,
+	theme: themeCheckboxBrand,
 };
 
 // *****************************************************************************
@@ -68,7 +68,7 @@ VisuallyHideLegendBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: checkboxThemeBrand,
+	theme: themeCheckboxBrand,
 };
 VisuallyHideLegendBrandTheme.args = {
 	hideLabel: true,
@@ -98,7 +98,7 @@ SupportingTextBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: checkboxThemeBrand,
+	theme: themeCheckboxBrand,
 };
 SupportingTextBrandTheme.args = {
 	supporting: 'Pick the issues and topics that interest you',
@@ -120,11 +120,13 @@ ErrorBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: checkboxThemeBrand,
+	theme: themeCheckboxBrand,
 };
 ErrorBrandTheme.args = {
 	error: 'This newsletter is not available in your region',
 };
+
+// *****************************************************************************
 
 export const ErrorCustomTheme: StoryFn<typeof CheckboxGroup> = Template.bind(
 	{},

--- a/libs/@guardian/source-react-components/src/checkbox/theme.ts
+++ b/libs/@guardian/source-react-components/src/checkbox/theme.ts
@@ -1,7 +1,12 @@
 import { palette } from '@guardian/source-foundations';
 import type { Theme } from '../@types/Theme';
 import type { ThemeLabel } from '../label/theme';
-import { labelThemeBrand, labelThemeDefault } from '../label/theme';
+import {
+	labelThemeBrand,
+	labelThemeDefault,
+	themeLabelBrand,
+	themeLabel,
+} from '../label/theme';
 import type { ThemeUserFeedback } from '../user-feedback/theme';
 import {
 	userFeedbackThemeBrand,
@@ -21,6 +26,38 @@ export type ThemeCheckbox = {
 };
 
 export type ThemeCheckboxGroup = ThemeLabel & ThemeUserFeedback;
+
+export const themeCheckbox: ThemeCheckbox = {
+	borderUnselected: palette.neutral[46],
+	borderHover: palette.brand[500],
+	borderSelected: palette.brand[500],
+	borderError: palette.error[400],
+	fillSelected: palette.brand[500],
+	fillUnselected: 'transparent',
+	textLabel: palette.neutral[7],
+	textSupporting: palette.neutral[46],
+	textIndeterminate: palette.neutral[46],
+};
+
+export const themeCheckboxGroup: ThemeCheckboxGroup = {
+	...themeLabel,
+};
+
+export const themeCheckboxBrand: ThemeCheckbox = {
+	borderUnselected: palette.brand[800],
+	borderSelected: palette.neutral[100],
+	borderHover: palette.neutral[100],
+	borderError: palette.error[500],
+	fillSelected: palette.neutral[100],
+	fillUnselected: 'transparent',
+	textLabel: palette.neutral[100],
+	textSupporting: palette.brand[800],
+	textIndeterminate: palette.brand[800],
+};
+
+export const themeCheckboxGroupBrand: ThemeCheckboxGroup = {
+	...themeLabelBrand,
+};
 
 /** @deprecated Use `checkboxTheme` and component `theme` prop instead of emotion's `ThemeProvider` */
 export const checkboxThemeDefault = {
@@ -51,30 +88,6 @@ export const checkboxThemeBrand = {
 	},
 	...userFeedbackThemeBrand,
 	...labelThemeBrand,
-};
-
-export const themeCheckbox: ThemeCheckbox = {
-	borderUnselected: palette.neutral[46],
-	borderHover: palette.brand[500],
-	borderSelected: palette.brand[500],
-	borderError: palette.error[400],
-	fillSelected: palette.brand[500],
-	fillUnselected: 'transparent',
-	textLabel: palette.neutral[7],
-	textSupporting: palette.neutral[46],
-	textIndeterminate: palette.neutral[46],
-};
-
-export const themeCheckboxBrand: ThemeCheckbox = {
-	borderUnselected: palette.brand[800],
-	borderSelected: palette.neutral[100],
-	borderHover: palette.neutral[100],
-	borderError: palette.error[500],
-	fillSelected: palette.neutral[100],
-	fillUnselected: 'transparent',
-	textLabel: palette.neutral[100],
-	textSupporting: palette.brand[800],
-	textIndeterminate: palette.brand[800],
 };
 
 export const transformProviderTheme = (

--- a/libs/@guardian/source-react-components/src/checkbox/theme.ts
+++ b/libs/@guardian/source-react-components/src/checkbox/theme.ts
@@ -9,6 +9,8 @@ import {
 } from '../label/theme';
 import type { ThemeUserFeedback } from '../user-feedback/theme';
 import {
+	themeUserFeedback,
+	themeUserFeedbackBrand,
 	userFeedbackThemeBrand,
 	userFeedbackThemeDefault,
 } from '../user-feedback/theme';
@@ -41,6 +43,7 @@ export const themeCheckbox: ThemeCheckbox = {
 
 export const themeCheckboxGroup: ThemeCheckboxGroup = {
 	...themeLabel,
+	...themeUserFeedback,
 };
 
 export const themeCheckboxBrand: ThemeCheckbox = {
@@ -57,6 +60,7 @@ export const themeCheckboxBrand: ThemeCheckbox = {
 
 export const themeCheckboxGroupBrand: ThemeCheckboxGroup = {
 	...themeLabelBrand,
+	...themeUserFeedbackBrand,
 };
 
 /** @deprecated Use `checkboxTheme` and component `theme` prop instead of emotion's `ThemeProvider` */

--- a/libs/@guardian/source-react-components/src/checkbox/theme.ts
+++ b/libs/@guardian/source-react-components/src/checkbox/theme.ts
@@ -4,8 +4,8 @@ import type { ThemeLabel } from '../label/theme';
 import {
 	labelThemeBrand,
 	labelThemeDefault,
-	themeLabelBrand,
 	themeLabel,
+	themeLabelBrand,
 } from '../label/theme';
 import type { ThemeUserFeedback } from '../user-feedback/theme';
 import {

--- a/libs/@guardian/source-react-components/src/choice-card/ChoiceCard.stories.tsx
+++ b/libs/@guardian/source-react-components/src/choice-card/ChoiceCard.stories.tsx
@@ -74,10 +74,26 @@ IconDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const CustomTheme: StoryFn<typeof ChoiceCard> = Template.bind({});
-CustomTheme.args = {
+export const IconCustomTheme: StoryFn<typeof ChoiceCard> = Template.bind({});
+IconCustomTheme.args = {
+	label: 'Camera',
+	// @ts-expect-error - Storybook maps 'JSX element' to <em>Option 1</em>
+	icon: 'JSX element',
 	theme: {
-		backgroundUnselected: palette.neutral[0],
-		textUnselected: palette.lifestyle[500],
+		textUnselected: palette.neutral[86],
+		borderUnselected: palette.neutral[86],
+		backgroundUnselected: palette.neutral[20],
+		textSelected: palette.brand[400],
+		borderSelected: palette.brand[800],
+		backgroundSelected: palette.neutral[100],
+		textHover: palette.brand[800],
+		borderHover: palette.brand[800],
+		backgroundHover: palette.neutral[20],
+		backgroundTick: palette.brand[400],
+	},
+};
+IconCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };

--- a/libs/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.stories.tsx
@@ -1,4 +1,4 @@
-import { breakpoints } from '@guardian/source-foundations';
+import { breakpoints, palette } from '@guardian/source-foundations';
 import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import { ChoiceCard } from './ChoiceCard';
@@ -351,3 +351,58 @@ UnControlledSingleSelectDefaultTheme.args = {
 	multi: false,
 };
 UnControlledSingleSelectDefaultTheme.storyName = 'Un-controlled Single Select';
+
+// *****************************************************************************
+
+export const WithSupportingCustomTheme: StoryFn<typeof ChoiceCardGroup> = (
+	args: ChoiceCardGroupProps,
+) => {
+	const themeChoiceCard = {
+		textUnselected: palette.neutral[86],
+		borderUnselected: palette.neutral[86],
+		backgroundUnselected: palette.neutral[20],
+		textSelected: palette.brand[400],
+		borderSelected: palette.brand[800],
+		backgroundSelected: palette.neutral[100],
+		textHover: palette.brand[800],
+		borderHover: palette.brand[800],
+		backgroundHover: palette.neutral[20],
+		backgroundTick: palette.brand[400],
+	};
+	return (
+		<ChoiceCardGroup {...args}>
+			<ChoiceCard
+				id="abc1"
+				value="option-1"
+				label="Option 1"
+				key={1}
+				theme={themeChoiceCard}
+			/>
+			<ChoiceCard
+				id="abc2"
+				value="option-2"
+				label="Option 2"
+				key={2}
+				theme={themeChoiceCard}
+			/>
+			<ChoiceCard
+				id="abc3"
+				value="option-3"
+				label="Option 3"
+				key={3}
+				theme={themeChoiceCard}
+			/>
+		</ChoiceCardGroup>
+	);
+};
+WithSupportingCustomTheme.args = {
+	theme: {
+		textLabel: palette.neutral[86],
+		textSupporting: palette.neutral[60],
+	},
+};
+WithSupportingCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
+	},
+};

--- a/libs/@guardian/source-react-components/src/choice-card/theme.ts
+++ b/libs/@guardian/source-react-components/src/choice-card/theme.ts
@@ -1,8 +1,11 @@
 import { palette } from '@guardian/source-foundations';
 import type { Theme } from '../@types/Theme';
-import type { ThemeLabel } from '../label/theme';
+import { themeLabel, type ThemeLabel } from '../label/theme';
 import type { ThemeUserFeedback } from '../user-feedback/theme';
-import { userFeedbackThemeDefault } from '../user-feedback/theme';
+import {
+	themeUserFeedback,
+	userFeedbackThemeDefault,
+} from '../user-feedback/theme';
 
 export type ThemeChoiceCard = {
 	textUnselected: string;
@@ -17,6 +20,28 @@ export type ThemeChoiceCard = {
 	backgroundHover: string;
 	backgroundSelected: string;
 	backgroundTick: string;
+};
+
+export type ThemeChoiceCardGroup = ThemeLabel & ThemeUserFeedback;
+
+export const themeChoiceCard: ThemeChoiceCard = {
+	textUnselected: palette.neutral[46],
+	textSelected: palette.brand[400],
+	textHover: palette.brand[500],
+	textError: palette.error[400],
+	borderUnselected: palette.neutral[46],
+	borderSelected: palette.brand[500],
+	borderHover: palette.brand[500],
+	borderError: palette.error[400],
+	backgroundUnselected: 'transparent',
+	backgroundHover: 'transparent',
+	backgroundSelected: '#E3F6FF',
+	backgroundTick: palette.brand[500],
+} as const;
+
+export const themeChoiceCardGroup: ThemeChoiceCardGroup = {
+	...themeLabel,
+	...themeUserFeedback,
 };
 
 /** @deprecated Use `choiceCardTheme` and component `theme` prop instead of emotion's `ThemeProvider` */
@@ -39,22 +64,6 @@ export const choiceCardThemeDefault = {
 	...userFeedbackThemeDefault,
 } as const;
 
-export const themeChoiceCard: ThemeChoiceCard = {
-	textUnselected: palette.neutral[46],
-	textSelected: palette.brand[400],
-	textHover: palette.brand[500],
-	textError: palette.error[400],
-	borderUnselected: palette.neutral[46],
-	borderSelected: palette.brand[500],
-	borderHover: palette.brand[500],
-	borderError: palette.error[400],
-	backgroundUnselected: 'transparent',
-	backgroundHover: 'transparent',
-	backgroundSelected: '#E3F6FF',
-	backgroundTick: palette.brand[500],
-} as const;
-
-export type ThemeChoiceCardGroup = ThemeLabel & ThemeUserFeedback;
 export const transformProviderTheme = (
 	providerTheme: Theme['choiceCard'],
 ): Partial<ThemeChoiceCard> => {

--- a/libs/@guardian/source-react-components/src/icons/Icons.stories.tsx
+++ b/libs/@guardian/source-react-components/src/icons/Icons.stories.tsx
@@ -351,3 +351,19 @@ WidePaymentIconsDefaultTheme.args = {
 	isAnnouncedByScreenReader: true,
 	icons: Object.values(widePaymentIcons),
 };
+
+// *****************************************************************************
+
+export const MediumIconsCustomTheme: StoryFn<IconChromaticStoryArgs> =
+	Template.bind({});
+MediumIconsCustomTheme.args = {
+	theme: { fill: palette.neutral[86] },
+	size: 'medium',
+	isAnnouncedByScreenReader: true,
+	icons: Object.values(uiIcons),
+};
+MediumIconsCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
+	},
+};

--- a/libs/@guardian/source-react-components/src/label/Label.stories.tsx
+++ b/libs/@guardian/source-react-components/src/label/Label.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 import { Label } from './Label';
-import { themeBrandLabel } from './theme';
+import { themeLabelBrand } from './theme';
 import type { LabelProps } from './types';
 import { palette } from '@guardian/source-foundations';
 
@@ -57,7 +57,7 @@ WithHiddenLabelDefaultTheme.args = {
 
 export const DefaultBrandTheme: StoryFn<typeof Label> = Template.bind({});
 DefaultBrandTheme.args = {
-	theme: themeBrandLabel,
+	theme: themeLabelBrand,
 };
 DefaultBrandTheme.parameters = {
 	backgrounds: {
@@ -71,7 +71,7 @@ export const WithSupportingTextBrandTheme: StoryFn<typeof Label> =
 	Template.bind({});
 WithSupportingTextBrandTheme.args = {
 	supporting: 'alex@example.com',
-	theme: themeBrandLabel,
+	theme: themeLabelBrand,
 };
 WithSupportingTextBrandTheme.parameters = {
 	backgrounds: {
@@ -84,7 +84,7 @@ WithSupportingTextBrandTheme.parameters = {
 export const WithOptionalBrandTheme: StoryFn<typeof Label> = Template.bind({});
 WithOptionalBrandTheme.args = {
 	optional: true,
-	theme: themeBrandLabel,
+	theme: themeLabelBrand,
 };
 WithOptionalBrandTheme.parameters = {
 	backgrounds: {
@@ -99,7 +99,7 @@ export const WithHiddenLabelBrandTheme: StoryFn<typeof Label> = Template.bind(
 );
 WithHiddenLabelBrandTheme.args = {
 	hideLabel: true,
-	theme: themeBrandLabel,
+	theme: themeLabelBrand,
 };
 WithHiddenLabelBrandTheme.parameters = {
 	backgrounds: {
@@ -139,7 +139,7 @@ WithOptionalSmallDefaultTheme.args = {
 export const DefaultSmallBrandTheme: StoryFn<typeof Label> = Template.bind({});
 DefaultSmallBrandTheme.args = {
 	size: 'small',
-	theme: themeBrandLabel,
+	theme: themeLabelBrand,
 };
 DefaultSmallBrandTheme.parameters = {
 	backgrounds: {
@@ -154,7 +154,7 @@ export const WithSupportingTextSmallBrandTheme: StoryFn<typeof Label> =
 WithSupportingTextSmallBrandTheme.args = {
 	supporting: 'alex@example.com',
 	size: 'small',
-	theme: themeBrandLabel,
+	theme: themeLabelBrand,
 };
 WithSupportingTextSmallBrandTheme.parameters = {
 	backgrounds: {
@@ -170,7 +170,7 @@ export const WithOptionalSmallBrandTheme: StoryFn<typeof Label> = Template.bind(
 WithOptionalSmallBrandTheme.args = {
 	optional: true,
 	size: 'small',
-	theme: themeBrandLabel,
+	theme: themeLabelBrand,
 };
 WithOptionalSmallBrandTheme.parameters = {
 	backgrounds: {

--- a/libs/@guardian/source-react-components/src/label/Label.stories.tsx
+++ b/libs/@guardian/source-react-components/src/label/Label.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { Label } from './Label';
 import { themeBrandLabel } from './theme';
 import type { LabelProps } from './types';
+import { palette } from '@guardian/source-foundations';
 
 const meta: Meta<typeof Label> = {
 	title: 'Label',
@@ -174,5 +175,19 @@ WithOptionalSmallBrandTheme.args = {
 WithOptionalSmallBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
+	},
+};
+
+// *****************************************************************************
+
+export const DefaultCustomTheme: StoryFn<typeof Label> = Template.bind({});
+DefaultCustomTheme.args = {
+	theme: {
+		textLabel: palette.neutral[86],
+	},
+};
+DefaultCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };

--- a/libs/@guardian/source-react-components/src/label/Legend.stories.tsx
+++ b/libs/@guardian/source-react-components/src/label/Legend.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { Legend } from './Legend';
 import { labelThemeBrand } from './theme';
 import type { LegendProps } from './types';
+import { palette } from '@guardian/source-foundations';
 
 const meta: Meta<typeof Legend> = {
 	title: 'Legend',
@@ -138,6 +139,20 @@ WithHiddenLabelBrandTheme.parameters = {
 		default: 'brandBackground.primary',
 	},
 	theme: labelThemeBrand,
+};
+
+// *****************************************************************************
+
+export const DefaultCustomTheme: StoryFn<typeof Legend> = Template.bind({});
+DefaultCustomTheme.args = {
+	theme: {
+		textLabel: palette.neutral[86],
+	},
+};
+DefaultCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
+	},
 };
 
 // *****************************************************************************

--- a/libs/@guardian/source-react-components/src/label/theme.ts
+++ b/libs/@guardian/source-react-components/src/label/theme.ts
@@ -35,7 +35,7 @@ export const themeLabel = {
 	textSuccess: palette.success[400],
 };
 
-export const themeBrandLabel = {
+export const themeLabelBrand = {
 	textLabel: palette.neutral[100],
 	textOptional: palette.brand[800],
 	textSupporting: palette.brand[800],

--- a/libs/@guardian/source-react-components/src/link/ButtonLink.stories.tsx
+++ b/libs/@guardian/source-react-components/src/link/ButtonLink.stories.tsx
@@ -68,23 +68,16 @@ RightIconButtonLinkDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const PrimaryIconButtonLinkCustomTheme: StoryFn<typeof ButtonLink> =
+export const PrimaryIconLinkCustomTheme: StoryFn<typeof ButtonLink> =
 	Template.bind({});
-PrimaryIconButtonLinkCustomTheme.args = {
+PrimaryIconLinkCustomTheme.args = {
 	theme: {
-		textPrimary: palette.news[400],
-		textPrimaryHover: palette.news[550],
+		textPrimary: palette.neutral[86],
+		textPrimaryHover: palette.brand[800],
 	},
 };
-
-// *****************************************************************************
-
-export const SecondaryIconButtonLinkCustomTheme: StoryFn<typeof ButtonLink> =
-	Template.bind({});
-SecondaryIconButtonLinkCustomTheme.args = {
-	priority: 'secondary',
-	theme: {
-		textSecondary: palette.opinion[400],
-		textSecondaryHover: palette.opinion[550],
+PrimaryIconLinkCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };

--- a/libs/@guardian/source-react-components/src/link/Link.stories.tsx
+++ b/libs/@guardian/source-react-components/src/link/Link.stories.tsx
@@ -190,22 +190,19 @@ UnderlineHoverTextSans.args = {
 	icon: undefined,
 };
 
+// *****************************************************************************
+
 export const PrimaryIconLinkCustomTheme: StoryFn<typeof Link> = Template.bind(
 	{},
 );
 PrimaryIconLinkCustomTheme.args = {
 	theme: {
-		textPrimary: palette.news[400],
-		textPrimaryHover: palette.news[500],
+		textPrimary: palette.neutral[86],
+		textPrimaryHover: palette.brand[800],
 	},
 };
-
-export const SecondaryIconLinkCustomTheme: StoryFn<typeof Link> = Template.bind(
-	{},
-);
-SecondaryIconLinkCustomTheme.args = {
-	theme: {
-		textSecondary: palette.news[400],
-		textSecondaryHover: palette.news[500],
+PrimaryIconLinkCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };

--- a/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/Radio.stories.tsx
@@ -107,13 +107,19 @@ UnlabelledDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const CustomTheme: StoryFn<typeof Radio> = Template.bind({});
-CustomTheme.args = {
+export const DefaultCustomTheme: StoryFn<typeof Radio> = Template.bind({});
+DefaultCustomTheme.args = {
 	theme: {
-		fillUnselected: palette.lifestyle[500],
-		fillSelected: palette.lifestyle[400],
-		borderSelected: palette.lifestyle[300],
-		borderHover: palette.lifestyle[400],
-		textLabel: palette.lifestyle[400],
+		fillSelected: palette.brand[800],
+		fillUnselected: palette.neutral[20],
+		borderSelected: palette.brand[800],
+		borderUnselected: palette.neutral[60],
+		borderHover: palette.brand[800],
+		textLabel: palette.neutral[86],
+	},
+};
+DefaultCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
@@ -4,6 +4,7 @@ import RadioStories from './Radio.stories';
 import type { RadioGroupProps } from './RadioGroup';
 import { RadioGroup } from './RadioGroup';
 import { themeRadioBrand } from './theme';
+import { palette } from '@guardian/source-foundations';
 
 const meta: Meta<typeof RadioGroup> = {
 	title: 'RadioGroup',
@@ -136,4 +137,23 @@ export const SupportingMediaWithErrorDefaultTheme: StoryFn<typeof RadioGroup> =
 SupportingMediaWithErrorDefaultTheme.args = {
 	error: 'Please select a colour',
 	supporting: <Image />,
+};
+
+// *****************************************************************************
+
+export const DefaultCustomTheme: StoryFn<typeof RadioGroup> = Template.bind({});
+DefaultCustomTheme.args = {
+	theme: {
+		fillSelected: palette.brand[800],
+		fillUnselected: palette.neutral[20],
+		borderSelected: palette.brand[800],
+		borderUnselected: palette.neutral[60],
+		borderHover: palette.brand[800],
+		textLabel: palette.neutral[86],
+	},
+};
+DefaultCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
+	},
 };

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
@@ -3,7 +3,12 @@ import { Radio } from './Radio';
 import RadioStories from './Radio.stories';
 import type { RadioGroupProps } from './RadioGroup';
 import { RadioGroup } from './RadioGroup';
-import { themeRadioBrand } from './theme';
+import {
+	ThemeRadio,
+	themeRadioBrand,
+	themeRadioGroup,
+	themeRadioGroupBrand,
+} from './theme';
 import { palette } from '@guardian/source-foundations';
 
 const meta: Meta<typeof RadioGroup> = {
@@ -40,41 +45,47 @@ const Image = () => (
 	/>
 );
 
-const Template: StoryFn<typeof RadioGroup> = (args: RadioGroupProps) => (
+type RadioGroupPropsAndCustomArgs = React.ComponentProps<typeof RadioGroup> & {
+	themeRadio?: Partial<ThemeRadio>;
+};
+
+const Template: StoryFn<RadioGroupPropsAndCustomArgs> = (
+	args: RadioGroupPropsAndCustomArgs,
+) => (
 	<RadioGroup {...args}>
-		<Radio {...RadioStories.args} theme={args.theme} key="radio-1" />
-		<Radio label="Blue" value="blue" theme={args.theme} key="radio-2" />
+		<Radio {...RadioStories.args} theme={args.themeRadio} key="radio-1" />
+		<Radio label="Blue" value="blue" theme={args.themeRadio} key="radio-2" />
 	</RadioGroup>
 );
 
-export const DefaultDefaultTheme: StoryFn<typeof RadioGroup> = Template.bind(
-	{},
-);
+export const DefaultDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+	Template.bind({});
 
 // *****************************************************************************
 
-export const DefaultBrandTheme: StoryFn<typeof RadioGroup> = Template.bind({});
+export const DefaultBrandTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+	Template.bind({});
 DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
 };
 DefaultBrandTheme.args = {
-	theme: themeRadioBrand,
+	theme: themeRadioGroupBrand,
+	themeRadio: themeRadioBrand,
 };
 
 // *****************************************************************************
 
-export const HorizontalDefaultTheme: StoryFn<typeof RadioGroup> = Template.bind(
-	{},
-);
+export const HorizontalDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+	Template.bind({});
 HorizontalDefaultTheme.args = {
 	orientation: 'horizontal',
 };
 
 // *****************************************************************************
 
-export const VisuallyHideLegendDefaultTheme: StoryFn<typeof RadioGroup> =
+export const VisuallyHideLegendDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
 	Template.bind({});
 VisuallyHideLegendDefaultTheme.args = {
 	hideLabel: true,
@@ -82,7 +93,7 @@ VisuallyHideLegendDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingTextDefaultTheme: StoryFn<typeof RadioGroup> =
+export const SupportingTextDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
 	Template.bind({});
 SupportingTextDefaultTheme.args = {
 	supporting: 'You can always change it later',
@@ -90,7 +101,7 @@ SupportingTextDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingTextBrandTheme: StoryFn<typeof RadioGroup> =
+export const SupportingTextBrandTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
 	Template.bind({});
 SupportingTextBrandTheme.parameters = {
 	backgrounds: {
@@ -99,12 +110,13 @@ SupportingTextBrandTheme.parameters = {
 };
 SupportingTextBrandTheme.args = {
 	supporting: 'You can always change it later',
-	theme: themeRadioBrand,
+	theme: themeRadioGroupBrand,
+	themeRadio: themeRadioBrand,
 };
 
 // *****************************************************************************
 
-export const SupportingMediaDefaultTheme: StoryFn<typeof RadioGroup> =
+export const SupportingMediaDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
 	Template.bind({});
 SupportingMediaDefaultTheme.args = {
 	supporting: <Image />,
@@ -112,17 +124,20 @@ SupportingMediaDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const ErrorDefaultTheme: StoryFn<typeof RadioGroup> = Template.bind({});
+export const ErrorDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+	Template.bind({});
 ErrorDefaultTheme.args = {
 	error: 'The selected colour is out of stock',
 };
 
 // *****************************************************************************
 
-export const ErrorBrandTheme: StoryFn<typeof RadioGroup> = Template.bind({});
+export const ErrorBrandTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+	Template.bind({});
 ErrorBrandTheme.args = {
 	error: 'The selected colour is out of stock',
-	theme: themeRadioBrand,
+	theme: themeRadioGroupBrand,
+	themeRadio: themeRadioBrand,
 };
 ErrorBrandTheme.parameters = {
 	backgrounds: {
@@ -132,7 +147,7 @@ ErrorBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const SupportingMediaWithErrorDefaultTheme: StoryFn<typeof RadioGroup> =
+export const SupportingMediaWithErrorDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
 	Template.bind({});
 SupportingMediaWithErrorDefaultTheme.args = {
 	error: 'Please select a colour',
@@ -141,9 +156,11 @@ SupportingMediaWithErrorDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const DefaultCustomTheme: StoryFn<typeof RadioGroup> = Template.bind({});
+export const DefaultCustomTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+	Template.bind({});
 DefaultCustomTheme.args = {
-	theme: {
+	theme: { textLabel: palette.neutral[86] },
+	themeRadio: {
 		fillSelected: palette.brand[800],
 		fillUnselected: palette.neutral[20],
 		borderSelected: palette.brand[800],

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
@@ -1,14 +1,8 @@
 import type { Meta, StoryFn } from '@storybook/react';
 import { Radio } from './Radio';
 import RadioStories from './Radio.stories';
-import type { RadioGroupProps } from './RadioGroup';
 import { RadioGroup } from './RadioGroup';
-import {
-	ThemeRadio,
-	themeRadioBrand,
-	themeRadioGroup,
-	themeRadioGroupBrand,
-} from './theme';
+import { ThemeRadio, themeRadioBrand, themeRadioGroupBrand } from './theme';
 import { palette } from '@guardian/source-foundations';
 
 const meta: Meta<typeof RadioGroup> = {

--- a/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
@@ -39,25 +39,25 @@ const Image = () => (
 	/>
 );
 
-type RadioGroupPropsAndCustomArgs = React.ComponentProps<typeof RadioGroup> & {
-	themeRadio?: Partial<ThemeRadio>;
+type RadioGroupPropsAndChildTheme = React.ComponentProps<typeof RadioGroup> & {
+	themeChild?: Partial<ThemeRadio>;
 };
 
-const Template: StoryFn<RadioGroupPropsAndCustomArgs> = (
-	args: RadioGroupPropsAndCustomArgs,
+const Template: StoryFn<RadioGroupPropsAndChildTheme> = (
+	args: RadioGroupPropsAndChildTheme,
 ) => (
 	<RadioGroup {...args}>
-		<Radio {...RadioStories.args} theme={args.themeRadio} key="radio-1" />
-		<Radio label="Blue" value="blue" theme={args.themeRadio} key="radio-2" />
+		<Radio {...RadioStories.args} theme={args.themeChild} key="radio-1" />
+		<Radio label="Blue" value="blue" theme={args.themeChild} key="radio-2" />
 	</RadioGroup>
 );
 
-export const DefaultDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+export const DefaultDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
 	Template.bind({});
 
 // *****************************************************************************
 
-export const DefaultBrandTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+export const DefaultBrandTheme: StoryFn<RadioGroupPropsAndChildTheme> =
 	Template.bind({});
 DefaultBrandTheme.parameters = {
 	backgrounds: {
@@ -66,12 +66,12 @@ DefaultBrandTheme.parameters = {
 };
 DefaultBrandTheme.args = {
 	theme: themeRadioGroupBrand,
-	themeRadio: themeRadioBrand,
+	themeChild: themeRadioBrand,
 };
 
 // *****************************************************************************
 
-export const HorizontalDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+export const HorizontalDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
 	Template.bind({});
 HorizontalDefaultTheme.args = {
 	orientation: 'horizontal',
@@ -79,7 +79,7 @@ HorizontalDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const VisuallyHideLegendDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+export const VisuallyHideLegendDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
 	Template.bind({});
 VisuallyHideLegendDefaultTheme.args = {
 	hideLabel: true,
@@ -87,7 +87,7 @@ VisuallyHideLegendDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingTextDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+export const SupportingTextDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
 	Template.bind({});
 SupportingTextDefaultTheme.args = {
 	supporting: 'You can always change it later',
@@ -95,7 +95,7 @@ SupportingTextDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const SupportingTextBrandTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+export const SupportingTextBrandTheme: StoryFn<RadioGroupPropsAndChildTheme> =
 	Template.bind({});
 SupportingTextBrandTheme.parameters = {
 	backgrounds: {
@@ -105,12 +105,12 @@ SupportingTextBrandTheme.parameters = {
 SupportingTextBrandTheme.args = {
 	supporting: 'You can always change it later',
 	theme: themeRadioGroupBrand,
-	themeRadio: themeRadioBrand,
+	themeChild: themeRadioBrand,
 };
 
 // *****************************************************************************
 
-export const SupportingMediaDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+export const SupportingMediaDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
 	Template.bind({});
 SupportingMediaDefaultTheme.args = {
 	supporting: <Image />,
@@ -118,7 +118,7 @@ SupportingMediaDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const ErrorDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+export const ErrorDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
 	Template.bind({});
 ErrorDefaultTheme.args = {
 	error: 'The selected colour is out of stock',
@@ -126,12 +126,12 @@ ErrorDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const ErrorBrandTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+export const ErrorBrandTheme: StoryFn<RadioGroupPropsAndChildTheme> =
 	Template.bind({});
 ErrorBrandTheme.args = {
 	error: 'The selected colour is out of stock',
 	theme: themeRadioGroupBrand,
-	themeRadio: themeRadioBrand,
+	themeChild: themeRadioBrand,
 };
 ErrorBrandTheme.parameters = {
 	backgrounds: {
@@ -141,7 +141,7 @@ ErrorBrandTheme.parameters = {
 
 // *****************************************************************************
 
-export const SupportingMediaWithErrorDefaultTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+export const SupportingMediaWithErrorDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
 	Template.bind({});
 SupportingMediaWithErrorDefaultTheme.args = {
 	error: 'Please select a colour',
@@ -150,11 +150,11 @@ SupportingMediaWithErrorDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const DefaultCustomTheme: StoryFn<RadioGroupPropsAndCustomArgs> =
+export const DefaultCustomTheme: StoryFn<RadioGroupPropsAndChildTheme> =
 	Template.bind({});
 DefaultCustomTheme.args = {
 	theme: { textLabel: palette.neutral[86] },
-	themeRadio: {
+	themeChild: {
 		fillSelected: palette.brand[800],
 		fillUnselected: palette.neutral[20],
 		borderSelected: palette.brand[800],

--- a/libs/@guardian/source-react-components/src/radio/theme.ts
+++ b/libs/@guardian/source-react-components/src/radio/theme.ts
@@ -1,10 +1,16 @@
 import { palette } from '@guardian/source-foundations';
 import type { Theme } from '../@types/Theme';
 import type { ThemeLabel } from '../label/theme';
-import { labelThemeBrand, labelThemeDefault, themeLabel } from '../label/theme';
+import {
+	labelThemeBrand,
+	labelThemeDefault,
+	themeLabelBrand,
+	themeLabel,
+} from '../label/theme';
 import type { ThemeUserFeedback } from '../user-feedback/theme';
 import {
 	themeUserFeedback,
+	themeUserFeedbackBrand,
 	userFeedbackThemeBrand,
 	userFeedbackThemeDefault,
 } from '../user-feedback/theme';
@@ -40,9 +46,10 @@ export const themeRadio: ThemeRadio = {
 export const themeRadioGroup: ThemeRadioGroup = {
 	borderHover: palette.brand[500],
 	borderError: palette.error[400],
-	...themeUserFeedback,
 	...themeLabel,
+	...themeUserFeedback,
 };
+
 export const themeRadioBrand: ThemeRadio = {
 	borderSelected: palette.neutral[100],
 	borderUnselected: palette.brand[800],
@@ -52,6 +59,13 @@ export const themeRadioBrand: ThemeRadio = {
 	fillUnselected: 'transparent',
 	textLabel: palette.neutral[100],
 	textSupporting: palette.brand[800],
+};
+
+export const themeRadioGroupBrand: ThemeRadioGroup = {
+	borderHover: palette.neutral[100],
+	borderError: palette.error[500],
+	...themeLabelBrand,
+	...themeUserFeedbackBrand,
 };
 
 export const transformProviderTheme = (

--- a/libs/@guardian/source-react-components/src/radio/theme.ts
+++ b/libs/@guardian/source-react-components/src/radio/theme.ts
@@ -4,8 +4,8 @@ import type { ThemeLabel } from '../label/theme';
 import {
 	labelThemeBrand,
 	labelThemeDefault,
-	themeLabelBrand,
 	themeLabel,
+	themeLabelBrand,
 } from '../label/theme';
 import type { ThemeUserFeedback } from '../user-feedback/theme';
 import {

--- a/libs/@guardian/source-react-components/src/select/Select.stories.tsx
+++ b/libs/@guardian/source-react-components/src/select/Select.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { Option } from './Option';
 import type { SelectProps } from './Select';
 import { Select } from './Select';
+import { pathToFileURL } from 'url';
 
 const meta: Meta<typeof Select> = {
 	title: 'Select',
@@ -112,10 +113,42 @@ SupportingErrorTextDefaultTheme.args = {
 
 // *****************************************************************************
 
-export const CustomTheme: StoryFn<typeof Select> = Template.bind({});
-CustomTheme.args = {
+export const SupportingTextCustomTheme: StoryFn<typeof Select> = Template.bind(
+	{},
+);
+SupportingTextCustomTheme.args = {
+	supporting: 'Leave blank if you are not within the US',
 	theme: {
-		textUserInput: palette.brandAlt[200],
-		iconFill: palette.labs[400],
+		textLabel: palette.neutral[86],
+		textSupporting: palette.neutral[60],
+		textUserInput: palette.neutral[86],
+		iconFill: palette.neutral[86],
+		border: palette.neutral[60],
+		backgroundInput: palette.neutral[20],
+	},
+};
+SupportingTextCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
+	},
+};
+
+// *****************************************************************************
+
+export const ErrorWithMessageCustomTheme: StoryFn<typeof Select> =
+	Template.bind({});
+ErrorWithMessageCustomTheme.args = {
+	error: 'error',
+	theme: {
+		textLabel: palette.neutral[86],
+		textError: palette.error[500],
+		iconFill: palette.error[500],
+		border: palette.error[500],
+		backgroundInput: palette.neutral[20],
+	},
+};
+ErrorWithMessageCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };

--- a/libs/@guardian/source-react-components/src/text-area/TextArea.stories.tsx
+++ b/libs/@guardian/source-react-components/src/text-area/TextArea.stories.tsx
@@ -179,15 +179,41 @@ SuccessWithMessageSmallDefaultTheme.args = {
 
 // *****************************************************************************
 
+export const SupportingTextCustomTheme: StoryFn<typeof TextArea> =
+	Template.bind({});
+SupportingTextCustomTheme.args = {
+	supporting:
+		'Please keep comments respectful and abide by the community guidelines.',
+	theme: {
+		text: palette.neutral[86],
+		textLabel: palette.neutral[86],
+		textSupporting: palette.neutral[60],
+		border: palette.neutral[60],
+		background: palette.neutral[20],
+	},
+};
+SupportingTextCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
+	},
+};
+
+// *****************************************************************************
+
 export const ErrorWithMessageCustomTheme: StoryFn<typeof TextArea> =
 	Template.bind({});
 ErrorWithMessageCustomTheme.args = {
 	error: 'error',
 	theme: {
-		textLabel: palette.lifestyle[100],
-		textError: palette.lifestyle[300],
-		borderError: palette.lifestyle[300],
-		background: palette.lifestyle[800],
+		textLabel: palette.neutral[86],
+		textError: palette.error[500],
+		borderError: palette.error[500],
+		background: palette.neutral[20],
+	},
+};
+ErrorWithMessageCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };
 

--- a/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
+++ b/libs/@guardian/source-react-components/src/text-input/TextInput.stories.tsx
@@ -225,6 +225,27 @@ ConstraintSmallDefaultTheme.args = {
 	type: 'tel',
 	size: 'small',
 };
+
+// *****************************************************************************
+
+export const SupportingTextCustomTheme: StoryFn<typeof TextInput> =
+	Template.bind({});
+SupportingTextCustomTheme.args = {
+	supporting: 'alex@example.com',
+	theme: {
+		text: palette.neutral[86],
+		textLabel: palette.neutral[86],
+		textSupporting: palette.neutral[60],
+		border: palette.neutral[60],
+		background: palette.neutral[20],
+	},
+};
+SupportingTextCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
+	},
+};
+
 // *****************************************************************************
 
 export const ErrorWithMessageCustomTheme: StoryFn<typeof TextInput> =
@@ -232,10 +253,15 @@ export const ErrorWithMessageCustomTheme: StoryFn<typeof TextInput> =
 ErrorWithMessageCustomTheme.args = {
 	error: 'error',
 	theme: {
-		textLabel: palette.lifestyle[100],
-		textError: palette.lifestyle[300],
-		borderError: palette.lifestyle[300],
-		background: palette.lifestyle[800],
+		textLabel: palette.neutral[86],
+		textError: palette.error[500],
+		borderError: palette.error[500],
+		background: palette.neutral[20],
+	},
+};
+ErrorWithMessageCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
 	},
 };
 

--- a/libs/@guardian/source-react-components/src/user-feedback/InlineError.stories.tsx
+++ b/libs/@guardian/source-react-components/src/user-feedback/InlineError.stories.tsx
@@ -72,8 +72,15 @@ InlineErrorSmallBrandTheme.parameters = {
 	theme: userFeedbackThemeBrand,
 };
 
+// *****************************************************************************
+
 export const InlineErrorCustomTheme: StoryFn<typeof InlineError> =
 	Template.bind({});
 InlineErrorCustomTheme.args = {
-	theme: { textError: palette.brandAlt[300] },
+	theme: { textError: palette.error[500] },
+};
+InlineErrorCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
+	},
 };

--- a/libs/@guardian/source-react-components/src/user-feedback/InlineSuccess.stories.tsx
+++ b/libs/@guardian/source-react-components/src/user-feedback/InlineSuccess.stories.tsx
@@ -54,8 +54,15 @@ InlineSuccessSmallBrandTheme.parameters = {
 	theme: userFeedbackThemeBrand,
 };
 
+// *****************************************************************************
+
 export const InlineSuccessCustomTheme: StoryFn<typeof InlineSuccess> =
 	Template.bind({});
 InlineSuccessCustomTheme.args = {
-	theme: { textSuccess: palette.sport[400] },
+	theme: { textSuccess: palette.success[500] },
+};
+InlineSuccessCustomTheme.parameters = {
+	backgrounds: {
+		default: 'background.inverse',
+	},
 };

--- a/libs/@guardian/source-react-components/src/user-feedback/theme.ts
+++ b/libs/@guardian/source-react-components/src/user-feedback/theme.ts
@@ -4,6 +4,7 @@ export type ThemeUserFeedback = {
 	textSuccess: string;
 	textError: string;
 };
+
 export const userFeedbackThemeDefault = {
 	userFeedback: {
 		textSuccess: palette.success[400],
@@ -21,4 +22,9 @@ export const userFeedbackThemeBrand = {
 export const themeUserFeedback = {
 	textSuccess: palette.success[400],
 	textError: palette.error[400],
+};
+
+export const themeUserFeedbackBrand = {
+	textSuccess: palette.success[500],
+	textError: palette.error[500],
 };


### PR DESCRIPTION
## What are you changing?

- Update custom theme examples in Storybook. Rather than using random colours from the Source palette these are now based on existing designs for dark mode.
  
## Why?

- This makes the examples more consistent and realistic.
