### PR TITLE
Display a file limit warning where applicable

### DIFF
--- a/.changeset/olive-ghosts-carry.md
+++ b/.changeset/olive-ghosts-carry.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': major
+---
+
+Displays a warning about the file size limit on uploads if a max file size has been provided.

--- a/libs/@guardian/source-react-components-development-kitchen/src/file-input/FileInput.stories.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/file-input/FileInput.stories.tsx
@@ -63,12 +63,7 @@ export const FileTypeValidation: StoryFn<typeof FileInput> = () => {
 
 export const FileSizeValidation: StoryFn<typeof FileInput> = () => {
 	return (
-		<FileInput
-			id="file-input"
-			label="Upload a file"
-			supporting="Only supports very very small images"
-			maxFileSize={1}
-		/>
+		<FileInput id="file-input" label="Upload a file" maxFileSize={5_000_000} />
 	);
 };
 

--- a/libs/@guardian/source-react-components-development-kitchen/src/file-input/FileInput.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/file-input/FileInput.tsx
@@ -9,6 +9,7 @@ import {
 	fileName as fileNameStyle,
 	fontSizes,
 	uploadSizes,
+	warningText,
 } from './styles';
 import type { Theme } from './theme';
 import type { FileInputProps } from './types';
@@ -87,6 +88,13 @@ export const FileInput: FC<FileInputProps> = ({
 				hideLabel={hideLabel}
 				cssOverrides={fontSizes[size]}
 			>
+				{maxFileSize && (
+					<p css={(theme: Theme) => warningText(theme.fileInput)}>
+						Please note, the maximum file size is{' '}
+						{getReadableFileSize(maxFileSize)}.
+					</p>
+				)}
+
 				{!!errorText && <InlineError>{errorText}</InlineError>}
 				<div
 					css={[
@@ -107,6 +115,7 @@ export const FileInput: FC<FileInputProps> = ({
 					/>
 				</div>
 			</Label>
+
 			{fileName && (
 				<>
 					{optional && (

--- a/libs/@guardian/source-react-components-development-kitchen/src/file-input/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/file-input/styles.ts
@@ -36,6 +36,14 @@ const xsmallUpload = css`
 	font-weight: ${fontWeights.bold};
 `;
 
+export const warningText = (
+	fileInput = fileInputThemeDefault.fileInput,
+): SerializedStyles => css`
+	${textSans.xsmall()};
+	color: ${fileInput.supporting};
+	margin: 2px 0 0;
+`;
+
 export const uploadSizes: {
 	[key in SizeType]: SerializedStyles;
 } = {


### PR DESCRIPTION
## What are you changing?
Adds a file limit warning underneath the supporting text on file input if a max file size has been provided.

## Why?
If there is a file size limit, this should be shown to the user before they try and upload a file. 

<img width="635" alt="Screenshot 2024-02-14 at 10 53 51" src="https://github.com/guardian/csnx/assets/20416599/34bfadf8-9c90-40bf-9578-74a6d7e3d7e2">

