### PR TITLE
Update Source package dependencies

### DIFF
--- a/.changeset/dirty-papayas-repeat.md
+++ b/.changeset/dirty-papayas-repeat.md
@@ -1,0 +1,7 @@
+---
+'@guardian/source-react-components-development-kitchen': major
+'@guardian/eslint-plugin-source-react-components': major
+'@guardian/eslint-plugin-source-foundations': major
+---
+
+Updated dependencies

--- a/libs/@guardian/eslint-plugin-source-foundations/package.json
+++ b/libs/@guardian/eslint-plugin-source-foundations/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@guardian/libs": "16.0.0",
-		"@guardian/source-foundations": "14.0.0",
+		"@guardian/source-foundations": "14.1.4",
 		"@types/eslint": "8.56.1",
 		"@types/estree": "1.0.5",
 		"eslint": "8.56.0",
@@ -18,7 +18,7 @@
 	},
 	"peerDependencies": {
 		"@guardian/libs": "^16.0.0",
-		"@guardian/source-foundations": "^14.0.0",
+		"@guardian/source-foundations": "^14.1.4",
 		"eslint": "^8.56.0",
 		"tslib": "^2.6.2",
 		"typescript": "~5.3.3"

--- a/libs/@guardian/eslint-plugin-source-react-components/package.json
+++ b/libs/@guardian/eslint-plugin-source-react-components/package.json
@@ -9,8 +9,8 @@
 	"devDependencies": {
 		"@emotion/react": "11.11.1",
 		"@guardian/libs": "16.0.0",
-		"@guardian/source-foundations": "14.0.0",
-		"@guardian/source-react-components": "20.0.0",
+		"@guardian/source-foundations": "14.1.4",
+		"@guardian/source-react-components": "22.0.0",
 		"@types/eslint": "8.56.1",
 		"@types/estree": "1.0.5",
 		"eslint": "8.56.0",
@@ -20,7 +20,7 @@
 	},
 	"peerDependencies": {
 		"@guardian/libs": "^16.0.0",
-		"@guardian/source-react-components": "^20.0.0",
+		"@guardian/source-react-components": "^22.0.0",
 		"eslint": "^8.56.0",
 		"react": "^18.2.0",
 		"tslib": "^2.6.2",

--- a/libs/@guardian/source-react-components-development-kitchen/package.json
+++ b/libs/@guardian/source-react-components-development-kitchen/package.json
@@ -6,8 +6,8 @@
 		"@babel/core": "7.23.6",
 		"@emotion/react": "11.11.1",
 		"@guardian/libs": "16.0.0",
-		"@guardian/source-foundations": "14.0.0",
-		"@guardian/source-react-components": "20.0.0",
+		"@guardian/source-foundations": "14.1.4",
+		"@guardian/source-react-components": "22.0.0",
 		"@types/react": "18.2.11",
 		"react": "18.2.0",
 		"tslib": "2.6.2",
@@ -16,8 +16,8 @@
 	"peerDependencies": {
 		"@emotion/react": "^11.11.1",
 		"@guardian/libs": "^16.0.0",
-		"@guardian/source-foundations": "^14.0.0",
-		"@guardian/source-react-components": "^20.0.0",
+		"@guardian/source-foundations": "^14.1.4",
+		"@guardian/source-react-components": "^22.0.0",
 		"react": "^18.2.0",
 		"tslib": "^2.6.2",
 		"typescript": "~5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,8 +348,8 @@ importers:
         specifier: 16.0.0
         version: 16.0.0(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-foundations':
-        specifier: 14.0.0
-        version: 14.0.0(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 14.1.4
+        version: 14.1.4(tslib@2.6.2)(typescript@5.3.3)
       '@types/eslint':
         specifier: 8.56.1
         version: 8.56.1
@@ -382,11 +382,11 @@ importers:
         specifier: 16.0.0
         version: 16.0.0(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-foundations':
-        specifier: 14.0.0
-        version: 14.0.0(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 14.1.4
+        version: 14.1.4(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components':
-        specifier: 20.0.0
-        version: 20.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 22.0.0
+        version: 22.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.4)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@types/eslint':
         specifier: 8.56.1
         version: 8.56.1
@@ -651,11 +651,11 @@ importers:
         specifier: 16.0.0
         version: 16.0.0(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-foundations':
-        specifier: 14.0.0
-        version: 14.0.0(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 14.1.4
+        version: 14.1.4(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components':
-        specifier: 20.0.0
-        version: 20.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 22.0.0
+        version: 22.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.4)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@types/react':
         specifier: 18.2.11
         version: 18.2.11
@@ -3790,21 +3790,6 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /@guardian/source-foundations@14.0.0(tslib@2.6.2)(typescript@5.3.3):
-    resolution: {integrity: sha512-9/oTahVnH8BFwVHsNBDzLBZIrkQvcZkJ9fMDeHujIxtSZ8woUWe8X0A3ADxIoh3aTERG6LBIplr3hyxbc5lFcQ==}
-    deprecated: This version is no longer supported. Please upgrade to @latest.
-    peerDependencies:
-      tslib: ^2.6.2
-      typescript: ~5.3.3
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      mini-svg-data-uri: 1.4.4
-      tslib: 2.6.2
-      typescript: 5.3.3
-    dev: true
-
   /@guardian/source-foundations@14.1.4(tslib@2.6.2)(typescript@5.3.3):
     resolution: {integrity: sha512-SHkFVBxsE2dSNTKfzmGY1hD9BA7qJ2+bGY1plrUJlYJBCRQdno/YuNummO+wm0Q+kMgxRT0iz5md2DjKYERzQw==}
     peerDependencies:
@@ -3819,11 +3804,11 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /@guardian/source-react-components@20.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.0.0)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3):
-    resolution: {integrity: sha512-HHCMuNKalWSMaCyryKJbnrWJzzyLxBQccSexD6QAYCdZW0cKwemhGYWz+7GQ6JsblZDYvjRGpg5Zcs+fhFrqjQ==}
+  /@guardian/source-react-components@22.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.4)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-TTbNP96d40o/r+zeNGNTnE3FmcTOQoYiLhbqBt73kxxuyfeT+64vx9L7wRt2lEoVFtuIQpPf4ecrdWIV6aJmWQ==}
     peerDependencies:
       '@emotion/react': ^11.11.1
-      '@guardian/source-foundations': ^14.0.0
+      '@guardian/source-foundations': ^14.1.4
       react: ^18.2.0
       tslib: ^2.6.2
       typescript: ~5.3.3
@@ -3832,7 +3817,7 @@ packages:
         optional: true
     dependencies:
       '@emotion/react': 11.11.1(@types/react@18.2.11)(react@18.2.0)
-      '@guardian/source-foundations': 14.0.0(tslib@2.6.2)(typescript@5.3.3)
+      '@guardian/source-foundations': 14.1.4(tslib@2.6.2)(typescript@5.3.3)
       react: 18.2.0
       tslib: 2.6.2
       typescript: 5.3.3


### PR DESCRIPTION
## What are you changing?

- Updates dev kitchen and ESLint plugins to use latest versions of `@guardian/source-foundations` and `@guardian/source-react-components`
