### PR TITLE
Update packages to latest patch release of `@guardian/source-react-components`

### DIFF
--- a/.changeset/dirty-beds-jog.md
+++ b/.changeset/dirty-beds-jog.md
@@ -1,0 +1,8 @@
+---
+'@guardian/source-react-components-development-kitchen': major
+'@guardian/eslint-plugin-source-react-components': major
+---
+
+Updated dependencies
+
+- @guardian/source-react-components@22.0.1

--- a/libs/@guardian/eslint-plugin-source-react-components/package.json
+++ b/libs/@guardian/eslint-plugin-source-react-components/package.json
@@ -20,7 +20,7 @@
 	},
 	"peerDependencies": {
 		"@guardian/libs": "^16.0.0",
-		"@guardian/source-react-components": "^22.0.0",
+		"@guardian/source-react-components": "^22.0.1",
 		"eslint": "^8.56.0",
 		"react": "^18.2.0",
 		"tslib": "^2.6.2",

--- a/libs/@guardian/eslint-plugin-source-react-components/package.json
+++ b/libs/@guardian/eslint-plugin-source-react-components/package.json
@@ -10,7 +10,7 @@
 		"@emotion/react": "11.11.1",
 		"@guardian/libs": "16.0.0",
 		"@guardian/source-foundations": "14.1.4",
-		"@guardian/source-react-components": "22.0.0",
+		"@guardian/source-react-components": "22.0.1",
 		"@types/eslint": "8.56.1",
 		"@types/estree": "1.0.5",
 		"eslint": "8.56.0",

--- a/libs/@guardian/source-react-components-development-kitchen/package.json
+++ b/libs/@guardian/source-react-components-development-kitchen/package.json
@@ -7,7 +7,7 @@
 		"@emotion/react": "11.11.1",
 		"@guardian/libs": "16.0.0",
 		"@guardian/source-foundations": "14.1.4",
-		"@guardian/source-react-components": "22.0.0",
+		"@guardian/source-react-components": "22.0.1",
 		"@types/react": "18.2.11",
 		"react": "18.2.0",
 		"tslib": "2.6.2",

--- a/libs/@guardian/source-react-components-development-kitchen/package.json
+++ b/libs/@guardian/source-react-components-development-kitchen/package.json
@@ -17,7 +17,7 @@
 		"@emotion/react": "^11.11.1",
 		"@guardian/libs": "^16.0.0",
 		"@guardian/source-foundations": "^14.1.4",
-		"@guardian/source-react-components": "^22.0.0",
+		"@guardian/source-react-components": "^22.0.1",
 		"react": "^18.2.0",
 		"tslib": "^2.6.2",
 		"typescript": "~5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,8 +385,8 @@ importers:
         specifier: 14.1.4
         version: 14.1.4(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components':
-        specifier: 22.0.0
-        version: 22.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.4)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 22.0.1
+        version: 22.0.1(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.4)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@types/eslint':
         specifier: 8.56.1
         version: 8.56.1
@@ -546,7 +546,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.4.0)(@types/node@18.19.3)(typescript@5.3.3)
+        version: 10.9.2(typescript@5.3.3)
       tslib:
         specifier: 2.6.2
         version: 2.6.2
@@ -654,8 +654,8 @@ importers:
         specifier: 14.1.4
         version: 14.1.4(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components':
-        specifier: 22.0.0
-        version: 22.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.4)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 22.0.1
+        version: 22.0.1(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.4)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@types/react':
         specifier: 18.2.11
         version: 18.2.11
@@ -3804,8 +3804,8 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /@guardian/source-react-components@22.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.4)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3):
-    resolution: {integrity: sha512-TTbNP96d40o/r+zeNGNTnE3FmcTOQoYiLhbqBt73kxxuyfeT+64vx9L7wRt2lEoVFtuIQpPf4ecrdWIV6aJmWQ==}
+  /@guardian/source-react-components@22.0.1(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.4)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-jpnFdc/fIRQswufgFDjlv0RQvtNpWd5PL7PJa4r7oNp8H8f+LEVn1D/WkuLFQwtP+T3S/wGF5GrcOmTMyFTlYA==}
     peerDependencies:
       '@emotion/react': ^11.11.1
       '@guardian/source-foundations': ^14.1.4
@@ -14786,6 +14786,38 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.19.3
+      acorn: 8.11.3
+      acorn-walk: 8.3.1
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.3.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /ts-node@10.9.2(typescript@5.3.3):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+      '@types/node':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
       acorn: 8.11.3
       acorn-walk: 8.3.1
       arg: 4.1.3


### PR DESCRIPTION
## What are you changing?

- Update `@guardian/source-react-components-development-kitchen` and `@guardian/eslint-plugin-source-react-components` dependencies to latest patch release of `@guardian/source-react-components`.
