### PR TITLE
make `@guardian/source` a module

### DIFF
--- a/libs/@guardian/source/package.json
+++ b/libs/@guardian/source/package.json
@@ -3,6 +3,7 @@
 	"version": "0.1.0",
 	"license": "Apache-2.0",
 	"sideEffects": false,
+	"type": "module",
 	"dependencies": {
 		"mini-svg-data-uri": "1.4.4"
 	},


### PR DESCRIPTION
## What are you changing?

- make `@guardian/source` a module

## Why?
 
- why not? it's the way
