### PR TITLE
identity-auth-frontend | Bump `@guardian/identity-auth` peer dependency

### DIFF
--- a/.changeset/two-jokes-doubt.md
+++ b/.changeset/two-jokes-doubt.md
@@ -1,0 +1,5 @@
+---
+'@guardian/identity-auth-frontend': major
+---
+
+Update peer dependency `@guardian/identity-auth` to `2.1.0`

--- a/libs/@guardian/identity-auth-frontend/package.json
+++ b/libs/@guardian/identity-auth-frontend/package.json
@@ -6,14 +6,14 @@
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"devDependencies": {
-		"@guardian/identity-auth": "2.0.1",
+		"@guardian/identity-auth": "2.1.0",
 		"@guardian/libs": "16.0.0",
 		"jest-fetch-mock": "3.0.3",
 		"tslib": "2.6.2",
 		"typescript": "5.3.3"
 	},
 	"peerDependencies": {
-		"@guardian/identity-auth": "^2.0.1",
+		"@guardian/identity-auth": "^2.1.0",
 		"@guardian/libs": "^16.0.0",
 		"tslib": "^2.6.2",
 		"typescript": "~5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,7 +426,7 @@ importers:
   libs/@guardian/identity-auth-frontend:
     devDependencies:
       '@guardian/identity-auth':
-        specifier: 2.0.1
+        specifier: 2.1.0
         version: link:../identity-auth
       '@guardian/libs':
         specifier: 16.0.0


### PR DESCRIPTION
## What are you changing?

- Updates `@guardian/identity-auth-frontend` peer dependency on `@guardian/identity-auth`
  - Major release as a peerdep change [should be a major version](https://github.com/guardian/recommendations/blob/main/npm-packages.md#changes-to-peerdependencies-ranges-are-breaking)
