### PR TITLE
Use local version of cmp for the test page

### DIFF
--- a/apps/github-pages/package.json
+++ b/apps/github-pages/package.json
@@ -6,7 +6,6 @@
 	"devDependencies": {
 		"@astrojs/check": "0.5.6",
 		"@astrojs/svelte": "5.2.0",
-		"@guardian/consent-management-platform": "^13.11.1",
 		"astro": "4.4.6",
 		"svelte": "4.2.12",
 		"typescript": "5.3.3"

--- a/apps/github-pages/src/components/CmpTest.svelte
+++ b/apps/github-pages/src/components/CmpTest.svelte
@@ -1,8 +1,6 @@
 <script>
-	// always use the dist version
-
-	import { cmp, onConsentChange } from '@guardian/consent-management-platform';
-	import { log } from '@guardian/libs';
+	// this maps to the version in libs/@guardian/libs
+	import { cmp, onConsentChange, log } from '@guardian/libs';
 	import { onMount } from 'svelte';
 
 	switch (window.location.hash) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,9 +196,6 @@ importers:
       '@astrojs/svelte':
         specifier: 5.2.0
         version: 5.2.0(astro@4.4.6)(svelte@4.2.12)(typescript@5.3.3)(vite@5.1.4)
-      '@guardian/consent-management-platform':
-        specifier: ^13.11.1
-        version: 13.11.1(@guardian/libs@libs+@guardian+libs)
       astro:
         specifier: 4.4.6
         version: 4.4.6(@types/node@18.19.3)(typescript@5.3.3)
@@ -4146,14 +4143,6 @@ packages:
     dependencies:
       tslib: 2.6.2
       typescript: 5.3.3
-    dev: true
-
-  /@guardian/consent-management-platform@13.11.1(@guardian/libs@libs+@guardian+libs):
-    resolution: {integrity: sha512-cU9ssmMVV6EpX7H9QVAf0gdPrIdrGkvi/5ylGXF6xGvyvJ6CwUxM+vZhhm5tujoCiq6EuAVJX1tiZ3oHQMEdZg==}
-    peerDependencies:
-      '@guardian/libs': ^15.0.0 || ^16.0.0
-    dependencies:
-      '@guardian/libs': link:libs/@guardian/libs
     dev: true
 
   /@guardian/libs@16.0.0(tslib@2.6.2)(typescript@5.3.3):


### PR DESCRIPTION
## What are you changing?

- points the cmp test page to the actual CMP code

## Why?

- so the test page shows the state of the codebase
