### PR TITLE
Allow conversion of rem font size to pixels in typography presets

### DIFF
--- a/libs/@guardian/design-tokens/src/tokens.json
+++ b/libs/@guardian/design-tokens/src/tokens.json
@@ -1537,7 +1537,7 @@
 					"fontSize": "{typography.fontSize.14}",
 					"lineHeight": "{typography.lineHeight.regular}",
 					"fontWeight": "{typography.fontWeight.regular}",
-					"fontStyle": "Italic"
+					"fontStyle": "italic"
 				}
 			},
 			"textSansItalic15": {

--- a/libs/@guardian/design-tokens/tokens.d.ts
+++ b/libs/@guardian/design-tokens/tokens.d.ts
@@ -1444,7 +1444,7 @@ export declare const tokens: {
 				readonly fontSize: '14px';
 				readonly lineHeight: 1.3;
 				readonly fontWeight: 400;
-				readonly fontStyle: 'Italic';
+				readonly fontStyle: 'italic';
 			};
 			readonly textSansItalic15: {
 				readonly fontFamily: readonly [

--- a/libs/@guardian/design-tokens/tokens.js
+++ b/libs/@guardian/design-tokens/tokens.js
@@ -1440,7 +1440,7 @@ export const tokens = {
 				fontSize: '14px',
 				lineHeight: 1.3,
 				fontWeight: 400,
-				fontStyle: 'Italic',
+				fontStyle: 'italic',
 			},
 			textSansItalic15: {
 				fontFamily: [

--- a/libs/@guardian/design-tokens/variables.css
+++ b/libs/@guardian/design-tokens/variables.css
@@ -1410,7 +1410,7 @@
 	--source-typography-presets-textSansItalic14-font-size: var(
 		--source-typography-fontSize-14
 	);
-	--source-typography-presets-textSansItalic14-font-style: Italic;
+	--source-typography-presets-textSansItalic14-font-style: italic;
 	--source-typography-presets-textSansItalic14-font-weight: var(
 		--source-typography-fontWeight-regular
 	);

--- a/libs/@guardian/source-foundations/src/tokens.test.ts
+++ b/libs/@guardian/source-foundations/src/tokens.test.ts
@@ -1870,7 +1870,7 @@ describe('Typography preset CSS output', () => {
 			font-size: 0.875rem;
 			line-height: 1.3;
 			font-weight: 400;
-			font-style: Italic;
+			font-style: italic;
 			--source-text-decoration-thickness: 2px;
 			`,
 			{ isFragment: true },
@@ -2681,7 +2681,7 @@ describe('Typography preset object output', () => {
 			fontSize: '0.875rem',
 			lineHeight: 1.3,
 			fontWeight: 400,
-			fontStyle: 'Italic',
+			fontStyle: 'italic',
 		});
 		expect(typePresetObject.textSansItalic15Object).toEqual({
 			fontFamily:

--- a/libs/@guardian/source-foundations/src/typography/css.ts
+++ b/libs/@guardian/source-foundations/src/typography/css.ts
@@ -790,7 +790,7 @@ export const textSansItalic14 = `
 	font-size: 0.875rem;
 	line-height: 1.3;
 	font-weight: 400;
-	font-style: Italic;
+	font-style: italic;
 	--source-text-decoration-thickness: 2px;
 `;
 

--- a/libs/@guardian/source-foundations/src/typography/objects.ts
+++ b/libs/@guardian/source-foundations/src/typography/objects.ts
@@ -741,7 +741,7 @@ export const textSansItalic14Object = {
 	fontSize: '0.875rem',
 	lineHeight: 1.3,
 	fontWeight: 400,
-	fontStyle: 'Italic',
+	fontStyle: 'italic',
 } as const;
 
 export const textSansItalic15Object = {

--- a/libs/@guardian/source-foundations/src/typography/storybookTypographyPresets.tsx
+++ b/libs/@guardian/source-foundations/src/typography/storybookTypographyPresets.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import * as presets from './css';
 import { space } from '../space/space';
 import { palette } from '../colour/palette';
+import { typographyPresetPx } from '../utils/typography';
 
 const presetTokens = tokens.typography.presets;
 type Preset = keyof typeof presetTokens;

--- a/libs/@guardian/source-foundations/src/typography/storybookTypographyPresets.tsx
+++ b/libs/@guardian/source-foundations/src/typography/storybookTypographyPresets.tsx
@@ -3,7 +3,6 @@ import { css } from '@emotion/react';
 import * as presets from './css';
 import { space } from '../space/space';
 import { palette } from '../colour/palette';
-import { typographyPresetPx } from '../utils/typography';
 
 const presetTokens = tokens.typography.presets;
 type Preset = keyof typeof presetTokens;

--- a/libs/@guardian/source-foundations/src/typography/types.ts
+++ b/libs/@guardian/source-foundations/src/typography/types.ts
@@ -115,3 +115,12 @@ export type Fs = <
 		unit: ScaleUnit;
 	},
 ) => TypographyStyles;
+
+export type TypographyPreset = `
+	font-family: ${string};
+	font-size: ${number}rem;
+	line-height: ${number};
+	font-weight: ${number};
+	font-style: ${'normal' | 'italic'};
+	--source-text-decoration-thickness: ${number}px;
+`;

--- a/libs/@guardian/source-foundations/src/utils/typography.test.ts
+++ b/libs/@guardian/source-foundations/src/utils/typography.test.ts
@@ -1,0 +1,30 @@
+import { headlineBold24, titlepiece42 } from '../typography/css';
+import { presetToPx } from './typography';
+
+describe('presetToPx', () => {
+	it('should convert preset font size value from rem to px', () => {
+		expect(presetToPx(headlineBold24)).toMatchCSS(
+			`
+			font-family: "GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
+			font-size: 24px;
+			line-height: 1.15;
+			font-weight: 700;
+			font-style: normal;
+			--source-text-decoration-thickness: 3px;
+			`,
+			{ isFragment: true },
+		);
+
+		expect(presetToPx(titlepiece42)).toMatchCSS(
+			`
+			font-family: "GT Guardian Titlepiece", Georgia, serif;
+			font-size: 42px;
+			line-height: 1.15;
+			font-weight: 700;
+			font-style: normal;
+			--source-text-decoration-thickness: 5px;
+			`,
+			{ isFragment: true },
+		);
+	});
+});

--- a/libs/@guardian/source-foundations/src/utils/typography.ts
+++ b/libs/@guardian/source-foundations/src/utils/typography.ts
@@ -1,10 +1,15 @@
-const REGEX_FONT_SIZE = /font-size:\s(\d+\.\d+)rem/;
+/*
+ * Convert font size in typography preset from default rem value to pixels
+ */
 
 export const presetToPx = (preset: string) => {
+	const REGEX_FONT_SIZE = /font-size:\s(\d+\.\d+)rem/;
+
 	const matches = preset.match(REGEX_FONT_SIZE);
 	if (matches?.[1]) {
 		const pxVal = parseFloat(matches[1]) * 16;
 		return preset.replace(REGEX_FONT_SIZE, `font-size: ${pxVal}px`);
 	}
+
 	return preset;
 };

--- a/libs/@guardian/source-foundations/src/utils/typography.ts
+++ b/libs/@guardian/source-foundations/src/utils/typography.ts
@@ -1,0 +1,10 @@
+const REGEX_FONT_SIZE = /font-size:\s(\d+\.\d+)rem/;
+
+export const typographyPresetPx = (preset: string) => {
+	const matches = preset.match(REGEX_FONT_SIZE);
+	if (matches?.[1]) {
+		const pxVal = parseFloat(matches[1]) * 16;
+		return preset.replace(REGEX_FONT_SIZE, `font-size: ${pxVal}px`);
+	}
+	return preset;
+};

--- a/libs/@guardian/source-foundations/src/utils/typography.ts
+++ b/libs/@guardian/source-foundations/src/utils/typography.ts
@@ -1,6 +1,6 @@
 const REGEX_FONT_SIZE = /font-size:\s(\d+\.\d+)rem/;
 
-export const typographyPresetPx = (preset: string) => {
+export const presetToPx = (preset: string) => {
 	const matches = preset.match(REGEX_FONT_SIZE);
 	if (matches?.[1]) {
 		const pxVal = parseFloat(matches[1]) * 16;

--- a/libs/@guardian/source-foundations/src/utils/typography.ts
+++ b/libs/@guardian/source-foundations/src/utils/typography.ts
@@ -1,8 +1,9 @@
-/*
- * Convert font size in typography preset from default rem value to pixels
- */
+import type { TypographyPreset } from '../typography/types';
 
-export const presetToPx = (preset: string) => {
+/*
+ * Convert `font-size` value in typography preset from rem to px
+ */
+export const presetToPx = (preset: TypographyPreset) => {
 	const REGEX_FONT_SIZE = /font-size:\s(\d+\.\d+)rem/;
 
 	const matches = preset.match(REGEX_FONT_SIZE);


### PR DESCRIPTION
## What are you changing?

Adds `presetToPx` helper to convert default rem font size in a given typography preset to a pixel value. Line height is untouched as this is already specified as a unitless relative value.

## Why?

We want to encourage use of rem font sizes so rather than duplicating all of the presets with different units a conversion function provides a pixel equivalent where strictly necessary. 

```js
presetToPx(headlineBold24))
```

👇 

```css
font-family: "GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
font-size: 24px;
line-height: 1.15;
font-weight: 700;
font-style: normal;
--source-text-decoration-thickness: 3px;
```

## Notes

This adds a `TypographyPreset` type to define the shape of a preset, but this hasn't been applied to the presets themselves as it hides the underlying values of the properties with the expected type:

<img width="624" alt="Screenshot 2024-03-27 at 16 44 16" src="https://github.com/guardian/csnx/assets/1166188/505d3d72-0d65-49ef-94f1-b6ac3dc0b173">

With untyped presets the values are exposed:

<img width="630" alt="Screenshot 2024-03-27 at 16 43 52" src="https://github.com/guardian/csnx/assets/1166188/2acbe100-4306-4317-85b5-8862153a2e4d">
