### PR TITLE
Add tertiary background to `ButtonTheme`

### DIFF
--- a/.changeset/perfect-wasps-beam.md
+++ b/.changeset/perfect-wasps-beam.md
@@ -1,0 +1,6 @@
+---
+'@guardian/source-react-components': minor
+---
+
+Enable theming of the `Button` tertiary background colour.
+Defaults to `transparent` to be backwards-compatible.

--- a/libs/@guardian/source-react-components/src/button/styles.ts
+++ b/libs/@guardian/source-react-components/src/button/styles.ts
@@ -88,6 +88,7 @@ const secondary = (button: ThemeButton): SerializedStyles => css`
 `;
 
 const tertiary = (button: ThemeButton): SerializedStyles => css`
+	background-color: ${button.backgroundTertiary};
 	color: ${button.textTertiary};
 	border: 1px solid ${button.borderTertiary};
 

--- a/libs/@guardian/source-react-components/src/button/theme.ts
+++ b/libs/@guardian/source-react-components/src/button/theme.ts
@@ -84,7 +84,7 @@ export const themeButton: ThemeButton = {
 	backgroundSecondary: palette.brand[800],
 	backgroundSecondaryHover: '#ACC9F7', // One-off colour variant generated from palette.brand[800]
 	textTertiary: palette.brand[400],
-	backgroundTertiary:  'transparent',
+	backgroundTertiary: 'transparent',
 	backgroundTertiaryHover: '#E5E5E5', // One-off colour variant
 	borderTertiary: palette.brand[400],
 	textSubdued: palette.brand[400],

--- a/libs/@guardian/source-react-components/src/button/theme.ts
+++ b/libs/@guardian/source-react-components/src/button/theme.ts
@@ -86,7 +86,7 @@ export const themeButton: ThemeButton = {
 	backgroundSecondary: palette.brand[800],
 	backgroundSecondaryHover: '#ACC9F7', // One-off colour variant generated from palette.brand[800]
 	textTertiary: palette.brand[400],
-	backgroundTertiary: palette.neutral[100],
+	backgroundTertiary:  'transparent',
 	backgroundTertiaryHover: '#E5E5E5', // One-off colour variant
 	borderTertiary: palette.brand[400],
 	textSubdued: palette.brand[400],

--- a/libs/@guardian/source-react-components/src/button/theme.ts
+++ b/libs/@guardian/source-react-components/src/button/theme.ts
@@ -9,7 +9,6 @@ export type ButtonTheme = {
 	backgroundSecondary?: string;
 	backgroundSecondaryHover?: string;
 	textTertiary?: string;
-	backgroundTertiary?: string;
 	backgroundTertiaryHover?: string;
 	borderTertiary?: string;
 	textSubdued?: string;
@@ -38,8 +37,7 @@ export const buttonThemeDefault: { button: ButtonTheme } = {
 		textSecondary: palette.brand[400],
 		backgroundSecondary: palette.brand[800],
 		backgroundSecondaryHover: '#ACC9F7', // One-off colour variant generated from palette.brand[800]
-		textTertiary: palette.neutral[100],
-		backgroundTertiary: palette.neutral[100],
+		textTertiary: palette.brand[400],
 		backgroundTertiaryHover: '#E5E5E5', // One-off colour variant
 		borderTertiary: palette.brand[400],
 		textSubdued: palette.brand[400],

--- a/libs/@guardian/source-react-components/src/button/theme.ts
+++ b/libs/@guardian/source-react-components/src/button/theme.ts
@@ -9,6 +9,7 @@ export type ButtonTheme = {
 	backgroundSecondary?: string;
 	backgroundSecondaryHover?: string;
 	textTertiary?: string;
+	backgroundTertiary?: string;
 	backgroundTertiaryHover?: string;
 	borderTertiary?: string;
 	textSubdued?: string;
@@ -22,6 +23,7 @@ export type ThemeButton = {
 	backgroundSecondary: string;
 	backgroundSecondaryHover: string;
 	textTertiary: string;
+	backgroundTertiary: string;
 	backgroundTertiaryHover: string;
 	borderTertiary: string;
 	textSubdued: string;
@@ -36,7 +38,8 @@ export const buttonThemeDefault: { button: ButtonTheme } = {
 		textSecondary: palette.brand[400],
 		backgroundSecondary: palette.brand[800],
 		backgroundSecondaryHover: '#ACC9F7', // One-off colour variant generated from palette.brand[800]
-		textTertiary: palette.brand[400],
+		textTertiary: palette.neutral[100],
+		backgroundTertiary: palette.neutral[100],
 		backgroundTertiaryHover: '#E5E5E5', // One-off colour variant
 		borderTertiary: palette.brand[400],
 		textSubdued: palette.brand[400],
@@ -83,6 +86,7 @@ export const themeButton: ThemeButton = {
 	backgroundSecondary: palette.brand[800],
 	backgroundSecondaryHover: '#ACC9F7', // One-off colour variant generated from palette.brand[800]
 	textTertiary: palette.brand[400],
+	backgroundTertiary: palette.neutral[100],
 	backgroundTertiaryHover: '#E5E5E5', // One-off colour variant
 	borderTertiary: palette.brand[400],
 	textSubdued: palette.brand[400],
@@ -96,6 +100,7 @@ export const themeButtonBrand: ThemeButton = {
 	backgroundSecondary: palette.brand[600],
 	backgroundSecondaryHover: '#234B8A', // One-off colour variant generated from palette.brand[600]
 	textTertiary: palette.neutral[100],
+	backgroundTertiary: 'transparent',
 	backgroundTertiaryHover: palette.brand[300],
 	borderTertiary: palette.neutral[100],
 	textSubdued: palette.neutral[100],
@@ -109,6 +114,7 @@ export const themeButtonBrandAlt: ThemeButton = {
 	backgroundSecondary: palette.brandAlt[200],
 	backgroundSecondaryHover: '#F2AE00', // One-off colour variant generated from palette.brandAlt[200]
 	textTertiary: palette.neutral[0],
+	backgroundTertiary: 'transparent',
 	backgroundTertiaryHover: '#FFD213', // One-off colour variant
 	borderTertiary: palette.neutral[7],
 	textSubdued: palette.neutral[7],


### PR DESCRIPTION
## What are you changing?

- Add a tertiary background to `ButtonTheme`

## Why?

- This matches the [Source design guide](https://theguardian.design/2a1e5182b/p/435225-button)
- It would enable us to [drop CSS overrides for pagination buttons](https://github.com/guardian/dotcom-rendering/pull/11012/files#diff-ac87731b6529e69cd791781f11af90f9e8333a52077d154f61daf8cbf5f97657R111-R114)