### PR TITLE
Prepare for CMP redux

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -22,4 +22,4 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/Cypress
-        key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml') }}
+        key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/canaries.yml
+++ b/.github/workflows/canaries.yml
@@ -24,13 +24,13 @@ jobs:
       - uses: nrwl/nx-set-shas@v4
       - uses: ./.github/actions/setup-node-env
 
+      - name: Version
+        run: pnpm changeset version --snapshot canary
+
       - run: pnpm nx run-many --target=build --all=true
 
       - name: Prepare Nx project for changesets
         uses: ./.github/actions/prepare-for-changesets
-
-      - name: Version
-        run: pnpm changeset version --snapshot canary
 
       - name: Release
         uses: changesets/action@v1

--- a/libs/@guardian/libs/package.json
+++ b/libs/@guardian/libs/package.json
@@ -6,6 +6,7 @@
 	"sideEffects": false,
 	"devDependencies": {
 		"@types/wcag-contrast": "3.0.3",
+		"cypress": "13.7.1",
 		"cypress-wait-until": "^3.0.1",
 		"eslint-plugin-cypress": "^2.15.1",
 		"jest-fetch-mock": "3.0.3",

--- a/libs/@guardian/libs/package.json
+++ b/libs/@guardian/libs/package.json
@@ -7,8 +7,8 @@
 	"devDependencies": {
 		"@types/wcag-contrast": "3.0.3",
 		"cypress": "13.7.1",
-		"cypress-wait-until": "^3.0.1",
-		"eslint-plugin-cypress": "^2.15.1",
+		"cypress-wait-until": "3.0.1",
+		"eslint-plugin-cypress": "2.15.1",
 		"jest-fetch-mock": "3.0.3",
 		"mockdate": "3.0.5",
 		"tslib": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"@typescript-eslint/parser": "6.21.0",
 		"babel-loader": "9.1.3",
 		"colorette": "2.0.20",
-		"cypress": "^13.7.0",
 		"eslint": "8.56.0",
 		"eslint-plugin-eslint-comments": "3.2.0",
 		"eslint-plugin-import": "2.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -478,10 +478,10 @@ importers:
         specifier: 13.7.1
         version: 13.7.1
       cypress-wait-until:
-        specifier: ^3.0.1
+        specifier: 3.0.1
         version: 3.0.1
       eslint-plugin-cypress:
-        specifier: ^2.15.1
+        specifier: 2.15.1
         version: 2.15.1(eslint@8.56.0)
       jest-fetch-mock:
         specifier: 3.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 2.2.0
       '@nx/cypress':
         specifier: 18.0.7
-        version: 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.1)(nx@18.0.7)(typescript@5.3.3)
+        version: 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(nx@18.0.7)(typescript@5.3.3)
       '@nx/devkit':
         specifier: 18.0.7
         version: 18.0.7(nx@18.0.7)
@@ -119,9 +119,6 @@ importers:
       colorette:
         specifier: 2.0.20
         version: 2.0.20
-      cypress:
-        specifier: ^13.7.0
-        version: 13.7.1
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -3574,10 +3571,10 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
 
-  /@nrwl/cypress@18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.1)(nx@18.0.7)(typescript@5.3.3):
+  /@nrwl/cypress@18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(nx@18.0.7)(typescript@5.3.3):
     resolution: {integrity: sha512-hKBwHuukCEyTonq8VKoBjTnYEmZ3AEyT30wMZTQZ/vdpdgYNSD1vIwFM6VUJfaBoj4kdnQfDMS9ti4nsTRDRIQ==}
     dependencies:
-      '@nx/cypress': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.1)(nx@18.0.7)(typescript@5.3.3)
+      '@nx/cypress': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(nx@18.0.7)(typescript@5.3.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3734,7 +3731,7 @@ packages:
       - debug
     dev: false
 
-  /@nx/cypress@18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.1)(nx@18.0.7)(typescript@5.3.3):
+  /@nx/cypress@18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(nx@18.0.7)(typescript@5.3.3):
     resolution: {integrity: sha512-bOCBr8OGGEjUHMkc+DgaXz2YQbC65DX8pPZ+teAXZiiZrs8/CsmkiN6sw00POOPC24hMDqSZgLKdayYZPxlLMQ==}
     peerDependencies:
       cypress: '>= 3 < 14'
@@ -3742,12 +3739,11 @@ packages:
       cypress:
         optional: true
     dependencies:
-      '@nrwl/cypress': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.1)(nx@18.0.7)(typescript@5.3.3)
+      '@nrwl/cypress': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(nx@18.0.7)(typescript@5.3.3)
       '@nx/devkit': 18.0.7(nx@18.0.7)
       '@nx/eslint': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(nx@18.0.7)
       '@nx/js': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(nx@18.0.7)(typescript@5.3.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.3.3)
-      cypress: 13.7.1
       detect-port: 1.5.1
       semver: 7.5.4
       tslib: 2.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 2.2.0
       '@nx/cypress':
         specifier: 18.0.7
-        version: 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.0)(nx@18.0.7)(typescript@5.3.3)
+        version: 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.1)(nx@18.0.7)(typescript@5.3.3)
       '@nx/devkit':
         specifier: 18.0.7
         version: 18.0.7(nx@18.0.7)
@@ -121,7 +121,7 @@ importers:
         version: 2.0.20
       cypress:
         specifier: ^13.7.0
-        version: 13.7.0
+        version: 13.7.1
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -474,6 +474,9 @@ importers:
       '@types/wcag-contrast':
         specifier: 3.0.3
         version: 3.0.3
+      cypress:
+        specifier: 13.7.1
+        version: 13.7.1
       cypress-wait-until:
         specifier: ^3.0.1
         version: 3.0.1
@@ -3571,10 +3574,10 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.16.0
 
-  /@nrwl/cypress@18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.0)(nx@18.0.7)(typescript@5.3.3):
+  /@nrwl/cypress@18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.1)(nx@18.0.7)(typescript@5.3.3):
     resolution: {integrity: sha512-hKBwHuukCEyTonq8VKoBjTnYEmZ3AEyT30wMZTQZ/vdpdgYNSD1vIwFM6VUJfaBoj4kdnQfDMS9ti4nsTRDRIQ==}
     dependencies:
-      '@nx/cypress': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.0)(nx@18.0.7)(typescript@5.3.3)
+      '@nx/cypress': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.1)(nx@18.0.7)(typescript@5.3.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -3731,7 +3734,7 @@ packages:
       - debug
     dev: false
 
-  /@nx/cypress@18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.0)(nx@18.0.7)(typescript@5.3.3):
+  /@nx/cypress@18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.1)(nx@18.0.7)(typescript@5.3.3):
     resolution: {integrity: sha512-bOCBr8OGGEjUHMkc+DgaXz2YQbC65DX8pPZ+teAXZiiZrs8/CsmkiN6sw00POOPC24hMDqSZgLKdayYZPxlLMQ==}
     peerDependencies:
       cypress: '>= 3 < 14'
@@ -3739,12 +3742,12 @@ packages:
       cypress:
         optional: true
     dependencies:
-      '@nrwl/cypress': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.0)(nx@18.0.7)(typescript@5.3.3)
+      '@nrwl/cypress': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(cypress@13.7.1)(nx@18.0.7)(typescript@5.3.3)
       '@nx/devkit': 18.0.7(nx@18.0.7)
       '@nx/eslint': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(nx@18.0.7)
       '@nx/js': 18.0.7(@swc-node/register@1.9.0)(@swc/core@1.4.0)(@types/node@18.19.3)(nx@18.0.7)(typescript@5.3.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.3.3)
-      cypress: 13.7.0
+      cypress: 13.7.1
       detect-port: 1.5.1
       semver: 7.5.4
       tslib: 2.6.2
@@ -8411,8 +8414,8 @@ packages:
     resolution: {integrity: sha512-kpoa8yL6Bi/JNsThGBbrrm7g4SNzYyBUv9M5pF6/NTVm/ClY0HnJzeuWnHiAUZKIZ5l86Oedb12wQyjx7/CWPg==}
     dev: true
 
-  /cypress@13.7.0:
-    resolution: {integrity: sha512-UimjRSJJYdTlvkChcdcfywKJ6tUYuwYuk/n1uMMglrvi+ZthNhoRYcxnWgTqUtkl17fXrPAsD5XT2rcQYN1xKA==}
+  /cypress@13.7.1:
+    resolution: {integrity: sha512-4u/rpFNxOFCoFX/Z5h+uwlkBO4mWzAjveURi3vqdSu56HPvVdyGTxGw4XKGWt399Y1JwIn9E1L9uMXQpc0o55w==}
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
## What are you changing?

- pulls some of the changes needed for #1128 into `main`

## Why?

- we need them (bug fixes and updates etc), but they're not really specific to moving the CMP code in, so it helps clean up #1128
