### PR TITLE
Refine `wireit` storybooks setup

### DIFF
--- a/apps/storybooks/.storybook/main.js
+++ b/apps/storybooks/.storybook/main.js
@@ -21,14 +21,17 @@ module.exports = {
 		return {
 			'source-foundations': {
 				title: 'source-foundations',
+				// port set in libs/@guardian/source-foundations/package.json
 				url: 'http://localhost:4401',
 			},
 			'source-react-components': {
 				title: 'source-react-components',
+				// port set in libs/@guardian/source-react-components/package.json
 				url: 'http://localhost:4402',
 			},
 			'source-react-components-development-kitchen': {
 				title: 'source-react-components-development-kitchen',
+				// port set in libs/@guardian/source-react-components-development-kitchen/package.json
 				url: 'http://localhost:4403',
 			},
 		};

--- a/apps/storybooks/package.json
+++ b/apps/storybooks/package.json
@@ -11,25 +11,20 @@
 	},
 	"wireit": {
 		"dev": {
-			"command": "sleep 5 && storybook dev --port 4400 --quiet",
+			"command": "storybook dev --port 4400 --quiet",
 			"dependencies": [
-				"dev:foundations",
-				"dev:react-components",
-				"dev:react-components-development-kitchen"
+				"storybooks",
+				"wait"
 			],
 			"service": true
 		},
-		"dev:foundations": {
-			"command": "cd ../../libs/@guardian/source-foundations && storybook dev --no-open --port 4401 --quiet",
+		"storybooks": {
+			"command": "pnpm -r --parallel storybook --no-open --quiet",
 			"service": true
 		},
-		"dev:react-components": {
-			"command": "cd ../../libs/@guardian/source-react-components && storybook dev --no-open --port 4402 --quiet",
-			"service": true
-		},
-		"dev:react-components-development-kitchen": {
-			"command": "cd ../../libs/@guardian/source-react-components-development-kitchen && storybook dev --no-open --port 4403 --quiet",
-			"service": true
+		"wait": {
+			"//": "wait for project storybooks to start before starting the composed one",
+			"command": "sleep 5"
 		}
 	}
 }

--- a/libs/@guardian/source-foundations/package.json
+++ b/libs/@guardian/source-foundations/package.json
@@ -5,7 +5,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"build-storybook": "wireit",
-		"storybook": "storybook dev"
+		"storybook": "storybook dev --port 4401"
 	},
 	"dependencies": {
 		"mini-svg-data-uri": "1.4.4"

--- a/libs/@guardian/source-react-components-development-kitchen/package.json
+++ b/libs/@guardian/source-react-components-development-kitchen/package.json
@@ -4,7 +4,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"build-storybook": "wireit",
-		"storybook": "storybook dev"
+		"storybook": "storybook dev --port 4403"
 	},
 	"devDependencies": {
 		"@babel/core": "7.24.0",

--- a/libs/@guardian/source-react-components/package.json
+++ b/libs/@guardian/source-react-components/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build-storybook": "wireit",
 		"create-icons": "ts-node scripts/create-icons",
-		"storybook": "storybook dev"
+		"storybook": "storybook dev --port 4402"
 	},
 	"devDependencies": {
 		"@babel/core": "7.24.0",


### PR DESCRIPTION
## What are you changing?

- uses `pnpm` to run all storybooks for the composed one

## Why?

- less config to get right, and improves the terminal output:

<img width="829" alt="image" src="https://github.com/guardian/csnx/assets/867233/8ae31a7c-630a-4b52-9805-370c7693397f">

