### PR TITLE
Narrow the type of space-related objects in source-foundations

### DIFF
--- a/.changeset/long-rice-exist.md
+++ b/.changeset/long-rice-exist.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-foundations': patch
+---
+
+Narrow the type used for spacing in source-foundations

--- a/libs/@guardian/source-foundations/src/utils/convert-value.ts
+++ b/libs/@guardian/source-foundations/src/utils/convert-value.ts
@@ -1,5 +1,9 @@
 export const rootPixelFontSize = 16;
+
 export const pxToRem = (px: number): number => px / rootPixelFontSize;
-export const pxStringToNumber = (px: string): number => Number(px.slice(0, -2));
+
+export const pxStringToNumber = <N extends number>(px: `${N}px`): N =>
+	Number(px.slice(0, -2)) as N;
+
 export const fontArrayToString = (fonts: readonly string[]): string =>
 	fonts.map((name) => (name.includes(' ') ? `"${name}"` : name)).join(', ');


### PR DESCRIPTION
## What are you changing?

Modify the `pxStringToNumber` function to output a narrow constant number type. This makes various space-related objects, such as `space`, as narrow as possible.

## Why?

For example, the `space` object...

Before:
```typescript
const space: {
    readonly 0: number;
    readonly 1: number;
    readonly 2: number;
    readonly 3: number;
    readonly 4: number;
    readonly 5: number;
    readonly 6: number;
    readonly 8: number;
    readonly 9: number;
    readonly 10: number;
    readonly 12: number;
    readonly 14: number;
    readonly 16: number;
    readonly 18: number;
    readonly 24: number;
}
```

After:
```typescript
const space: {
    readonly 0: 2;
    readonly 1: 4;
    readonly 2: 8;
    readonly 3: 12;
    readonly 4: 16;
    readonly 5: 20;
    readonly 6: 24;
    readonly 8: 32;
    readonly 9: 36;
    readonly 10: 40;
    readonly 12: 48;
    readonly 14: 56;
    readonly 16: 64;
    readonly 18: 72;
    readonly 24: 96;
}
```