### PR TITLE
Use native `fetch` in `libs` tests

### DIFF
--- a/libs/@guardian/libs/jest.config.ts
+++ b/libs/@guardian/libs/jest.config.ts
@@ -2,7 +2,7 @@
 export default {
 	displayName: '@guardian/libs',
 	preset: '../../../jest.preset.js',
-	testEnvironment: 'jest-environment-jsdom',
+	testEnvironment: './jest.testEnvironment.js',
 	transform: {
 		'^.+\\.[tj]sx?$': [
 			'ts-jest',

--- a/libs/@guardian/libs/jest.testEnvironment.js
+++ b/libs/@guardian/libs/jest.testEnvironment.js
@@ -1,0 +1,15 @@
+/* eslint-disable import/no-default-export -- it's what JSDOM env does */
+
+// https://stackoverflow.com/questions/74945569/cannot-access-built-in-node-js-fetch-function-from-jest-tests
+
+import JSDOMEnvironment from 'jest-environment-jsdom';
+
+export default class FixJSDOMEnvironment extends JSDOMEnvironment {
+	constructor(...args) {
+		super(...args);
+		this.global.fetch = fetch;
+		this.global.Request = Request;
+		this.global.Response = Response;
+		// And any other missing globals
+	}
+}

--- a/libs/@guardian/libs/src/consent-management-platform/index.test.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/index.test.ts
@@ -65,7 +65,9 @@ describe('hotfix cmp.init', () => {
 	});
 
 	it('warn if two versions are running simultaneously', () => {
-		const consoleWarn = jest.spyOn(global.console, 'warn');
+		const consoleWarn = jest
+			.spyOn(global.console, 'warn')
+			.mockImplementation(() => undefined);
 		cmp.init({ country: 'GB' });
 		const currentVersion = window.guCmpHotFix.cmp?.version;
 		const mockedVersion = 'X.X.X-mock';

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.test.js
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.test.js
@@ -1,5 +1,3 @@
-import http from 'http';
-import url from 'url';
 import { ACCOUNT_ID, ENDPOINT } from './lib/sourcepointConfig.ts';
 import { init } from './sourcepoint.ts';
 
@@ -58,17 +56,13 @@ describe('Sourcepoint unified', () => {
 		},
 	);
 
-	it.each(frameworks)('points at a real file', (framework, done) => {
+	it.each(frameworks)('points at a real file', async (framework) => {
 		init(framework);
 		expect(document.getElementById('sourcepoint-lib')).toBeTruthy();
 		const src = document.getElementById('sourcepoint-lib')?.getAttribute('src');
 
-		const { host, path } = url.parse(src ?? '');
-
-		const req = http.request({ method: 'HEAD', host, port: 80, path }, () =>
-			done(),
-		);
-		req.end();
+		const response = await fetch(src);
+		expect(response.ok).toBe(true);
 	});
 
 	it.each(frameworks)('should accept pubData', (framework) => {

--- a/libs/@guardian/libs/src/consent-management-platform/vendors.test.js
+++ b/libs/@guardian/libs/src/consent-management-platform/vendors.test.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { TCFV2VendorIDs } from './vendors.ts';
 
 const cmpBaseUrl = 'cdn.privacy-mgmt.com';
@@ -6,13 +5,13 @@ const guardianId = '5ec67f5bb8e05c4a1160fda1';
 const guardianVendorListUrl = `https://${cmpBaseUrl}/consent/tcfv2/vendor-list?vendorListId=${guardianId}`;
 
 it('the tcfv2 vendor ids used must be a subset of those known by the IAB as our vendors', async () => {
-	const iabGuardianVendorListResponse = await axios.get(guardianVendorListUrl);
+	const iabGuardianVendorListResponse = await fetch(guardianVendorListUrl);
+
+	const data = await iabGuardianVendorListResponse.json();
 
 	const vendorIds = Object.values(TCFV2VendorIDs).flat();
 
-	const iabVendorIds = iabGuardianVendorListResponse.data['vendors'].map(
-		(vendor) => vendor['_id'],
-	);
+	const iabVendorIds = data['vendors'].map((vendor) => vendor['_id']);
 
 	const missingVendorIds = vendorIds.filter((id) => !iabVendorIds.includes(id));
 


### PR DESCRIPTION
## What are you changing?

- uses the native node `fetch` in `libs` jest tests
- mocks an implementation of `console.warn` in CMP tests to stop it actually being logged when running tests

## Why?

remove deps and remove noise from test output

pulled out of #1348
