### PR TITLE
Fix `identity-auth` linting

### DIFF
--- a/libs/@guardian/identity-auth/package.json
+++ b/libs/@guardian/identity-auth/package.json
@@ -13,8 +13,7 @@
 		"@guardian/libs": "16.0.0",
 		"jest-fetch-mock": "3.0.3",
 		"tslib": "2.6.2",
-		"typescript": "5.3.3",
-		"wireit": "0.14.4"
+		"typescript": "5.3.3"
 	},
 	"peerDependencies": {
 		"@guardian/libs": "^16.0.0",
@@ -45,6 +44,21 @@
 						"libs/@guardian/identity-auth/*.md"
 					]
 				}
+			},
+			"lint": {
+				"inputs": [
+					"{workspaceRoot}/libs/@guardian/identity-auth/**/*",
+					"{workspaceRoot}/.eslintrc.js"
+				]
+			},
+			"fix": {
+				"inputs": [
+					"{workspaceRoot}/libs/@guardian/identity-auth/**/*",
+					"{workspaceRoot}/.eslintrc.js"
+				],
+				"outputs": [
+					"{workspaceRoot}/libs/@guardian/identity-auth/"
+				]
 			},
 			"test": {
 				"executor": "@nx/jest:jest",
@@ -80,35 +94,6 @@
 					"watch": true
 				}
 			}
-		}
-	},
-	"wireit": {
-		"lint": {
-			"// W!RE!T": [
-				"This is too restrictive but it recreates the old Nx config.",
-				"We should remove the --ext flag."
-			],
-			"command": "eslint --cache . --ext .ts",
-			"files": [
-				"**",
-				"../../../.eslintrc.js"
-			],
-			"output": []
-		},
-		"fix": {
-			"// W!RE!T": [
-				"This is too restrictive but it recreates the old Nx config.",
-				"We should remove the --ext flag."
-			],
-			"command": "eslint --cache . --ext .ts --fix",
-			"files": [
-				"**",
-				"../../../.eslintrc.js"
-			],
-			"output": [
-				"**"
-			],
-			"clean": false
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -454,9 +454,6 @@ importers:
       typescript:
         specifier: 5.3.3
         version: 5.3.3
-      wireit:
-        specifier: 0.14.4
-        version: 0.14.4
 
   libs/@guardian/identity-auth-frontend:
     devDependencies:


### PR DESCRIPTION
## What are you changing?

- restoring the Nx management of `identity-auth` linting

## Why?

wireit config for a future change snuck through in #1348, which also removed the Nx setup prematurely. this corrects that.
