### PR TITLE
Improve `Inline` layout spacing

### DIFF
--- a/.changeset/early-rocks-run.md
+++ b/.changeset/early-rocks-run.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': major
+---
+
+Updates `Inline` layout component to remove additional spacing from bottom of child elements so they sit flush with the edges of the container

--- a/libs/@guardian/source-react-components/src/@types/Space.ts
+++ b/libs/@guardian/source-react-components/src/@types/Space.ts
@@ -1,0 +1,3 @@
+import type { space } from '@guardian/source-foundations';
+
+export type Space = keyof typeof space;

--- a/libs/@guardian/source-react-components/src/inline/@types/InlineSpace.ts
+++ b/libs/@guardian/source-react-components/src/inline/@types/InlineSpace.ts
@@ -1,1 +1,0 @@
-export type InlineSpace = 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24;

--- a/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
+++ b/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
@@ -107,66 +107,9 @@ Space24.args = {
 export const LotsOfItems: StoryFn<typeof Inline> = Template.bind({});
 LotsOfItems.args = {
 	space: 2,
-	children: [
-		<div key={1} css={box}>
-			1
-		</div>,
-		<div key={2} css={box}>
-			2
-		</div>,
-		<div key={3} css={box}>
-			3
-		</div>,
-		<div key={4} css={box}>
-			4
-		</div>,
-		<div key={5} css={box}>
-			5
-		</div>,
-		<div key={6} css={box}>
-			6
-		</div>,
-		<div key={7} css={box}>
-			7
-		</div>,
-		<div key={8} css={box}>
-			8
-		</div>,
-		<div key={9} css={box}>
-			9
-		</div>,
-		<div key={10} css={box}>
-			10
-		</div>,
-		<div key={11} css={box}>
-			11
-		</div>,
-		<div key={12} css={box}>
-			12
-		</div>,
-		<div key={13} css={box}>
-			13
-		</div>,
-		<div key={14} css={box}>
-			14
-		</div>,
-		<div key={15} css={box}>
-			15
-		</div>,
-		<div key={16} css={box}>
-			16
-		</div>,
-		<div key={17} css={box}>
-			17
-		</div>,
-		<div key={18} css={box}>
-			18
-		</div>,
-		<div key={19} css={box}>
-			19
-		</div>,
-		<div key={20} css={box}>
-			20
-		</div>,
-	],
+	children: Array.from({ length: 20 }, (_, i) => (
+		<div key={i} css={box}>
+			{i + 1}
+		</div>
+	)),
 };

--- a/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
+++ b/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
@@ -1,8 +1,8 @@
+import { css } from '@emotion/react';
+import { palette, space } from '@guardian/source-foundations';
 import type { Meta, StoryFn } from '@storybook/react';
 import type { InlineProps } from './Inline';
 import { Inline } from './Inline';
-import { css } from '@emotion/react';
-import { palette, space } from '@guardian/source-foundations';
 
 const meta: Meta<typeof Inline> = {
 	title: 'Inline',

--- a/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
+++ b/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryFn } from '@storybook/react';
 import type { InlineProps } from './Inline';
 import { Inline } from './Inline';
+import { css } from '@emotion/react';
+import { palette, space } from '@guardian/source-foundations';
 
 const meta: Meta<typeof Inline> = {
 	title: 'Inline',
@@ -9,16 +11,30 @@ const meta: Meta<typeof Inline> = {
 
 export default meta;
 
+const wrapper = css`
+	outline: 1px dashed ${palette.neutral[46]};
+`;
+
+const box = css`
+	display: grid;
+	place-items: center;
+	width: ${space[12]}px;
+	height: ${space[12]}px;
+	background: ${palette.news[600]};
+`;
+
 const Template: StoryFn<typeof Inline> = (args: InlineProps) => (
-	<Inline {...args}>
-		{args.children ?? (
-			<>
-				<div>[Item 1]</div>
-				<div>[Item 2]</div>
-				<div>[Item 3]</div>
-			</>
-		)}
-	</Inline>
+	<div css={wrapper}>
+		<Inline {...args}>
+			{args.children ?? (
+				<>
+					<div css={box}>1</div>
+					<div css={box}>2</div>
+					<div css={box}>3</div>
+				</>
+			)}
+		</Inline>
+	</div>
 );
 
 export const NoSpace: StoryFn<typeof Inline> = Template.bind({});
@@ -90,26 +106,67 @@ Space24.args = {
 
 export const LotsOfItems: StoryFn<typeof Inline> = Template.bind({});
 LotsOfItems.args = {
+	space: 2,
 	children: [
-		<div key={1}>[Item 1]</div>,
-		<div key={2}>[Item 2]</div>,
-		<div key={3}>[Item 3]</div>,
-		<div key={4}>[Item 4]</div>,
-		<div key={5}>[Item 5]</div>,
-		<div key={6}>[Item 6]</div>,
-		<div key={7}>[Item 7]</div>,
-		<div key={8}>[Item 8]</div>,
-		<div key={9}>[Item 9]</div>,
-		<div key={10}>[Item 10]</div>,
-		<div key={11}>[Item 11]</div>,
-		<div key={12}>[Item 12]</div>,
-		<div key={13}>[Item 13]</div>,
-		<div key={14}>[Item 14]</div>,
-		<div key={15}>[Item 15]</div>,
-		<div key={16}>[Item 16]</div>,
-		<div key={17}>[Item 17]</div>,
-		<div key={18}>[Item 18]</div>,
-		<div key={19}>[Item 19]</div>,
-		<div key={20}>[Item 20]</div>,
+		<div key={1} css={box}>
+			1
+		</div>,
+		<div key={2} css={box}>
+			2
+		</div>,
+		<div key={3} css={box}>
+			3
+		</div>,
+		<div key={4} css={box}>
+			4
+		</div>,
+		<div key={5} css={box}>
+			5
+		</div>,
+		<div key={6} css={box}>
+			6
+		</div>,
+		<div key={7} css={box}>
+			7
+		</div>,
+		<div key={8} css={box}>
+			8
+		</div>,
+		<div key={9} css={box}>
+			9
+		</div>,
+		<div key={10} css={box}>
+			10
+		</div>,
+		<div key={11} css={box}>
+			11
+		</div>,
+		<div key={12} css={box}>
+			12
+		</div>,
+		<div key={13} css={box}>
+			13
+		</div>,
+		<div key={14} css={box}>
+			14
+		</div>,
+		<div key={15} css={box}>
+			15
+		</div>,
+		<div key={16} css={box}>
+			16
+		</div>,
+		<div key={17} css={box}>
+			17
+		</div>,
+		<div key={18} css={box}>
+			18
+		</div>,
+		<div key={19} css={box}>
+			19
+		</div>,
+		<div key={20} css={box}>
+			20
+		</div>,
 	],
 };

--- a/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
+++ b/libs/@guardian/source-react-components/src/inline/Inline.stories.tsx
@@ -104,10 +104,10 @@ Space24.args = {
 
 // *****************************************************************************
 
-export const LotsOfItems: StoryFn<typeof Inline> = Template.bind({});
-LotsOfItems.args = {
+export const MultipleChildElements: StoryFn<typeof Inline> = Template.bind({});
+MultipleChildElements.args = {
 	space: 2,
-	children: Array.from({ length: 20 }, (_, i) => (
+	children: Array.from({ length: 24 }, (_, i) => (
 		<div key={i} css={box}>
 			{i + 1}
 		</div>

--- a/libs/@guardian/source-react-components/src/inline/Inline.tsx
+++ b/libs/@guardian/source-react-components/src/inline/Inline.tsx
@@ -2,7 +2,7 @@ import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import type { HTMLAttributes } from 'react';
 import type { Props } from '../@types/Props';
 import type { InlineSpace } from './@types/InlineSpace';
-import { inline, inlineSpace } from './styles';
+import { inline, inlineSpace, inlineWrapper } from './styles';
 
 export interface InlineProps extends HTMLAttributes<HTMLDivElement>, Props {
 	/**
@@ -26,11 +26,13 @@ export const Inline = ({
 	...props
 }: InlineProps): EmotionJSX.Element => {
 	return (
-		<div
-			css={[inline, space ? inlineSpace[space] : '', cssOverrides]}
-			{...props}
-		>
-			{children}
+		<div css={inline}>
+			<div
+				css={[inlineWrapper, space && inlineSpace(space), cssOverrides]}
+				{...props}
+			>
+				{children}
+			</div>
 		</div>
 	);
 };

--- a/libs/@guardian/source-react-components/src/inline/Inline.tsx
+++ b/libs/@guardian/source-react-components/src/inline/Inline.tsx
@@ -1,14 +1,14 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import type { HTMLAttributes } from 'react';
 import type { Props } from '../@types/Props';
-import type { InlineSpace } from './@types/InlineSpace';
+import type { Space } from '../@types/Space';
 import { inline, inlineSpace, inlineWrapper } from './styles';
 
 export interface InlineProps extends HTMLAttributes<HTMLDivElement>, Props {
 	/**
 	 * [Units of space](https://www.theguardian.design/2a1e5182b/p/449bd5-space) between inline items (one unit is 4px).
 	 */
-	space?: InlineSpace;
+	space?: Space;
 }
 
 /**

--- a/libs/@guardian/source-react-components/src/inline/Inline.tsx
+++ b/libs/@guardian/source-react-components/src/inline/Inline.tsx
@@ -6,18 +6,19 @@ import { inline, inlineSpace, inlineWrapper } from './styles';
 
 export interface InlineProps extends HTMLAttributes<HTMLDivElement>, Props {
 	/**
-	 * [Units of space](https://www.theguardian.design/2a1e5182b/p/449bd5-space) between inline items (one unit is 4px).
+	 * [Units of space](https://guardian.github.io/storybooks/?path=/docs/source-foundations_space--docs)
+	 * between children.
 	 */
 	space?: Space;
 }
 
 /**
- * [Storybook](https://guardian.github.io/csnx/?path=/story/source-react-components_inline--no-space) •
- * [Design System](https://theguardian.design/2a1e5182b/p/99f3c1-inline) •
+ * [Storybook](https://guardian.github.io/storybooks/?path=/docs/source-react-components_inline--docs) •
  * [GitHub](https://github.com/guardian/csnx/tree/main/libs/@guardian/source-react-components/src/inline/Inline.tsx) •
  * [NPM](https://www.npmjs.com/package/@guardian/source-react-components)
  *
- * `Inline` components will be laid out one next to the other.
+ * `Inline` child elements are laid out horizontally, wrapping on to another row
+ * if there isn't enough room. Spacing is applied between adjacent children.
  */
 export const Inline = ({
 	cssOverrides,

--- a/libs/@guardian/source-react-components/src/inline/styles.ts
+++ b/libs/@guardian/source-react-components/src/inline/styles.ts
@@ -4,36 +4,17 @@ import { space } from '@guardian/source-foundations';
 import type { InlineSpace } from './@types/InlineSpace';
 
 export const inline = css`
+	overflow: hidden;
+`;
+
+export const inlineWrapper = css`
 	display: flex;
 	flex-wrap: wrap;
 `;
 
-const inlineSpaceStyle = (number: InlineSpace): SerializedStyles => css`
-	margin-left: -${space[number]}px;
-	& > * {
-		margin-left: ${space[number]}px;
-		margin-bottom: ${space[number]}px;
+export const inlineSpace = (number: InlineSpace): SerializedStyles => css`
+	margin: -${space[number] / 2}px;
+	> * {
+		margin: ${space[number] / 2}px;
 	}
 `;
-
-export const inlineSpace: {
-	1: SerializedStyles;
-	2: SerializedStyles;
-	3: SerializedStyles;
-	4: SerializedStyles;
-	5: SerializedStyles;
-	6: SerializedStyles;
-	9: SerializedStyles;
-	12: SerializedStyles;
-	24: SerializedStyles;
-} = {
-	1: inlineSpaceStyle(1),
-	2: inlineSpaceStyle(2),
-	3: inlineSpaceStyle(3),
-	4: inlineSpaceStyle(4),
-	5: inlineSpaceStyle(5),
-	6: inlineSpaceStyle(6),
-	9: inlineSpaceStyle(9),
-	12: inlineSpaceStyle(12),
-	24: inlineSpaceStyle(24),
-};

--- a/libs/@guardian/source-react-components/src/inline/styles.ts
+++ b/libs/@guardian/source-react-components/src/inline/styles.ts
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { space } from '@guardian/source-foundations';
-import type { InlineSpace } from './@types/InlineSpace';
+import type { Space } from '../@types/Space';
 
 export const inline = css`
 	overflow: hidden;
@@ -12,7 +12,7 @@ export const inlineWrapper = css`
 	flex-wrap: wrap;
 `;
 
-export const inlineSpace = (number: InlineSpace): SerializedStyles => css`
+export const inlineSpace = (number: Space): SerializedStyles => css`
 	margin: -${space[number] / 2}px;
 	> * {
 		margin: ${space[number] / 2}px;


### PR DESCRIPTION
## What are you changing?

Removes additional spacing from bottom of child elements so that they are flush with the container

## Why?

The `Inline` layout component is used to lay out child elements horizontally with consistent spacing added between adjacent children. Children will wrap on to another row if there isn't enough horizontal spacing. If wrapping occurs the same spacing is applied between rows. Children should otherwise sit flush with the edges of the container. Currently spacing is added to the bottom of every child which is particularly noticeable when larger spacing values are used.

We could potentially use the [`gap` property](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) in place of negative margins, although this [would exclude older browsers](https://caniuse.com/?search=gap). Unfortunately support for `gap` on flex layouts cannot be reliably feature detected as older browsers may support `gap` for grid layout, but not flex layouts.

### Before

<img width="470" alt="Screenshot 2024-04-18 at 12 22 15" src="https://github.com/guardian/csnx/assets/1166188/4b5d2150-2b81-4bf1-871b-76cad72ba387">

<img width="471" alt="Screenshot 2024-04-18 at 12 22 32" src="https://github.com/guardian/csnx/assets/1166188/0bb1d03f-98e4-4aaa-94fc-2097faba01ab">

### After

<img width="471" alt="Screenshot 2024-04-18 at 16 29 19" src="https://github.com/guardian/csnx/assets/1166188/318dc5db-37ea-4db7-82a1-1a300929fecb">

<img width="470" alt="Screenshot 2024-04-18 at 16 29 31" src="https://github.com/guardian/csnx/assets/1166188/f9cb77ca-37c4-4884-b9b2-5d7929d1829d">

<img width="469" alt="Screenshot 2024-04-18 at 16 29 41" src="https://github.com/guardian/csnx/assets/1166188/bb87bb23-2f9f-4bdb-b11e-d4ed988fd448">