### PR TITLE
Update Source components to use typography presets

### DIFF
--- a/libs/@guardian/source-react-components/package.json
+++ b/libs/@guardian/source-react-components/package.json
@@ -16,7 +16,7 @@
 	"devDependencies": {
 		"@babel/core": "7.24.0",
 		"@emotion/react": "11.11.1",
-		"@guardian/source-foundations": "14.1.4",
+		"@guardian/source-foundations": "14.2.0",
 		"@svgr/babel-preset": "8.1.0",
 		"@svgr/core": "8.1.0",
 		"@svgr/plugin-jsx": "8.1.0",
@@ -39,7 +39,7 @@
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.11.1",
-		"@guardian/source-foundations": "^14.1.4",
+		"@guardian/source-foundations": "^14.2.0",
 		"react": "^18.2.0",
 		"tslib": "^2.6.2",
 		"typescript": "~5.3.3"

--- a/libs/@guardian/source-react-components/package.json
+++ b/libs/@guardian/source-react-components/package.json
@@ -16,7 +16,7 @@
 	"devDependencies": {
 		"@babel/core": "7.24.0",
 		"@emotion/react": "11.11.1",
-		"@guardian/source-foundations": "14.2.0",
+		"@guardian/source-foundations": "14.2.2",
 		"@svgr/babel-preset": "8.1.0",
 		"@svgr/core": "8.1.0",
 		"@svgr/plugin-jsx": "8.1.0",
@@ -39,7 +39,7 @@
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.11.1",
-		"@guardian/source-foundations": "^14.2.0",
+		"@guardian/source-foundations": "^14.2.2",
 		"react": "^18.2.0",
 		"tslib": "^2.6.2",
 		"typescript": "~5.3.3"

--- a/libs/@guardian/source-react-components/src/accordion/styles.ts
+++ b/libs/@guardian/source-react-components/src/accordion/styles.ts
@@ -3,10 +3,10 @@ import { css } from '@emotion/react';
 import {
 	focusHalo,
 	from,
-	headline,
+	headlineBold17,
 	remSpace,
 	space,
-	textSans,
+	textSansBold15,
 	transitions,
 	until,
 	visuallyHidden,
@@ -53,7 +53,7 @@ export const noJsButton = (accordion: ThemeAccordion): SerializedStyles => css`
 `;
 
 export const labelText = css`
-	${headline.xxxsmall({ fontWeight: 'bold' })};
+	${headlineBold17};
 	margin-right: ${remSpace[4]};
 `;
 
@@ -127,7 +127,7 @@ export const toggle = css`
 `;
 
 export const toggleLabel = (accordion: ThemeAccordion): SerializedStyles => css`
-	${textSans.small({ fontWeight: 'bold' })};
+	${textSansBold15};
 	color: ${accordion.textLabel};
 	${until.tablet} {
 		${visuallyHidden}

--- a/libs/@guardian/source-react-components/src/button/styles.ts
+++ b/libs/@guardian/source-react-components/src/button/styles.ts
@@ -4,7 +4,8 @@ import {
 	focusHaloSpaced,
 	height,
 	space,
-	textSans,
+	textSansBold14,
+	textSansBold17,
 	transitions,
 	width,
 } from '@guardian/source-foundations';
@@ -120,7 +121,7 @@ const subdued = (button: ThemeButton): SerializedStyles => css`
 	TODO: find a more scalable solution to this (see https://css-tricks.com/how-to-tame-line-height-in-css/)
 */
 const defaultSize = css`
-	${textSans.medium({ fontWeight: 'bold' })};
+	${textSansBold17};
 	height: ${height.ctaMedium}px;
 	min-height: ${height.ctaMedium}px;
 	padding: 0 ${space[5]}px;
@@ -129,7 +130,7 @@ const defaultSize = css`
 `;
 
 const smallSize = css`
-	${textSans.medium({ fontWeight: 'bold' })};
+	${textSansBold17};
 	height: ${height.ctaSmall}px;
 	min-height: ${height.ctaSmall}px;
 	padding: 0 ${space[4]}px;
@@ -138,7 +139,7 @@ const smallSize = css`
 `;
 
 const xsmallSize = css`
-	${textSans.xsmall({ fontWeight: 'bold' })};
+	${textSansBold14};
 	height: ${height.ctaXsmall}px;
 	min-height: ${height.ctaXsmall}px;
 	padding: 0 ${space[3]}px;

--- a/libs/@guardian/source-react-components/src/checkbox/styles.ts
+++ b/libs/@guardian/source-react-components/src/checkbox/styles.ts
@@ -6,7 +6,9 @@ import {
 	height,
 	resets,
 	space,
-	textSans,
+	textSans15,
+	textSans17,
+	textSans24,
 	transitions,
 	width,
 } from '@guardian/source-foundations';
@@ -104,7 +106,7 @@ export const checkbox = (
 
 		&:indeterminate {
 			&:after {
-				${textSans.xlarge()};
+				${textSans24};
 				color: ${checkbox.textIndeterminate};
 				content: '-';
 				position: absolute;
@@ -117,13 +119,13 @@ export const checkbox = (
 `;
 
 export const labelText = (checkbox: ThemeCheckbox): SerializedStyles => css`
-	${textSans.medium()};
+	${textSans17};
 	color: ${checkbox.textLabel};
 	width: 100%;
 `;
 
 export const labelTextWithSupportingText = css`
-	${textSans.medium()};
+	${textSans17};
 	margin-top: 1px;
 	/* If label text is empty, add additional spacing to align supporting text */
 	&:empty {
@@ -134,7 +136,7 @@ export const labelTextWithSupportingText = css`
 export const supportingText = (
 	checkbox: ThemeCheckbox,
 ): SerializedStyles => css`
-	${textSans.small()};
+	${textSans15};
 	color: ${checkbox.textSupporting};
 `;
 

--- a/libs/@guardian/source-react-components/src/choice-card/styles.ts
+++ b/libs/@guardian/source-react-components/src/choice-card/styles.ts
@@ -6,7 +6,7 @@ import {
 	palette,
 	resets,
 	space,
-	textSans,
+	textSansBold17,
 	transitions,
 	visuallyHidden,
 	width,
@@ -173,7 +173,7 @@ export const contentWrapper = css`
 	}
 
 	& > * {
-		${textSans.medium({ fontWeight: 'bold' })};
+		${textSansBold17};
 		text-align: center;
 	}
 

--- a/libs/@guardian/source-react-components/src/footer/styles.ts
+++ b/libs/@guardian/source-react-components/src/footer/styles.ts
@@ -6,7 +6,8 @@ import {
 	from,
 	height,
 	space,
-	textSans,
+	textSans12,
+	textSansBold15,
 	width,
 } from '@guardian/source-foundations';
 import { footerThemeBrand } from './theme';
@@ -61,7 +62,7 @@ export const links = (
 `;
 
 export const copyright = css`
-	${textSans.xxsmall()};
+	${textSans12};
 	display: block;
 `;
 
@@ -80,7 +81,7 @@ export const backToTop = (
 	height: ${height.ctaMedium}px;
 	padding-left: ${space[2]}px;
 
-	${textSans.small({ fontWeight: 'bold' })};
+	${textSansBold15};
 	color: ${footer.anchor};
 	background-color: ${footer.background};
 	text-decoration: none;

--- a/libs/@guardian/source-react-components/src/label/styles.ts
+++ b/libs/@guardian/source-react-components/src/label/styles.ts
@@ -1,14 +1,19 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { resets, textSans } from '@guardian/source-foundations';
+import {
+	resets,
+	textSans14,
+	textSansBold14,
+	textSansBold17,
+} from '@guardian/source-foundations';
 import type { InputSize } from '../@types/InputSize';
 import type { ThemeLabel } from './theme';
 
 const textSize: {
 	[key in InputSize]: string;
 } = {
-	medium: textSans.medium({ fontWeight: 'bold' }),
-	small: textSans.xsmall({ fontWeight: 'bold' }),
+	medium: textSansBold17,
+	small: textSansBold14,
 };
 
 export const legend = css`
@@ -24,13 +29,13 @@ export const labelText = (
 `;
 
 export const optionalText = (label: ThemeLabel): SerializedStyles => css`
-	${textSans.xsmall()};
+	${textSans14};
 	color: ${label.textOptional};
 	font-style: italic;
 `;
 
 export const supportingText = (label: ThemeLabel): SerializedStyles => css`
-	${textSans.xsmall()};
+	${textSans14};
 	color: ${label.textSupporting};
 	margin: 2px 0 0;
 `;

--- a/libs/@guardian/source-react-components/src/link/Link.stories.tsx
+++ b/libs/@guardian/source-react-components/src/link/Link.stories.tsx
@@ -1,10 +1,29 @@
 import { css } from '@emotion/react';
-import { headline, palette, textSans } from '@guardian/source-foundations';
+import {
+	headlineMedium14,
+	headlineMedium17,
+	headlineMedium20,
+	headlineMedium24,
+	headlineMedium28,
+	headlineMedium34,
+	headlineMedium42,
+	headlineMedium50,
+	headlineMedium70,
+	palette,
+	textSans12,
+	textSans14,
+	textSans15,
+	textSans17,
+	textSans20,
+	textSans24,
+	textSans28,
+	textSans34,
+} from '@guardian/source-foundations';
 import type { Meta, StoryFn } from '@storybook/react';
 import { SvgExternal } from '../../vendor/icons/SvgExternal';
 import { Link } from './Link';
 import type { LinkProps } from './Link';
-import { linkThemeBrand, linkThemeBrandAlt } from './theme';
+import { themeLinkBrand, themeLinkBrandAlt } from './theme';
 
 const meta: Meta<typeof Link> = {
 	title: 'Link',
@@ -29,6 +48,29 @@ const meta: Meta<typeof Link> = {
 
 export default meta;
 
+const textSans = [
+	textSans34,
+	textSans28,
+	textSans24,
+	textSans20,
+	textSans17,
+	textSans15,
+	textSans14,
+	textSans12,
+];
+
+const headline = [
+	headlineMedium70,
+	headlineMedium50,
+	headlineMedium42,
+	headlineMedium34,
+	headlineMedium28,
+	headlineMedium24,
+	headlineMedium20,
+	headlineMedium17,
+	headlineMedium14,
+];
+
 const Template: StoryFn<typeof Link> = (args: LinkProps) => (
 	<Link {...args}>Return to home page</Link>
 );
@@ -49,19 +91,17 @@ const UnderlineHoverHeadlineTemplate: StoryFn<typeof Link> = (
 				}
 			`}
 		>
-			{Object.values(headline)
-				.reverse()
-				.map((size, i) => (
-					<Link
-						key={i}
-						{...args}
-						cssOverrides={css`
-							${size()}
-						`}
-					>
-						{headlineText}
-					</Link>
-				))}
+			{headline.map((preset, i) => (
+				<Link
+					key={i}
+					{...args}
+					cssOverrides={css`
+						${preset}
+					`}
+				>
+					{headlineText}
+				</Link>
+			))}
 		</div>
 	);
 };
@@ -82,28 +122,26 @@ const UnderlineHoverTextSansTemplate: StoryFn<typeof Link> = (
 				}
 			`}
 		>
-			{Object.values(textSans)
-				.reverse()
-				.map((size, i) => (
-					<div
-						css={css`
-							padding: 10px 0;
-							${size()}
+			{textSans.map((preset, i) => (
+				<div
+					css={css`
+						padding: 10px 0;
+						${preset}
+					`}
+					key={i}
+				>
+					Some text sans, with a{' '}
+					<Link
+						{...args}
+						cssOverrides={css`
+							${preset}
 						`}
-						key={i}
 					>
-						Some text sans, with a{' '}
-						<Link
-							{...args}
-							cssOverrides={css`
-								${size()}
-							`}
-						>
-							{headlineText}
-						</Link>{' '}
-						in the middle of it
-					</div>
-				))}
+						{headlineText}
+					</Link>{' '}
+					in the middle of it
+				</div>
+			))}
 		</div>
 	);
 };
@@ -118,12 +156,12 @@ PrimaryLinkDefaultTheme.args = {
 export const PrimaryLinkBrandTheme: StoryFn<typeof Link> = Template.bind({});
 PrimaryLinkBrandTheme.args = {
 	icon: undefined,
+	theme: themeLinkBrand,
 };
 PrimaryLinkBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
-	theme: linkThemeBrand,
 };
 
 // *****************************************************************************
@@ -131,12 +169,12 @@ PrimaryLinkBrandTheme.parameters = {
 export const PrimaryLinkBrandAltTheme: StoryFn<typeof Link> = Template.bind({});
 PrimaryLinkBrandAltTheme.args = {
 	icon: undefined,
+	theme: themeLinkBrandAlt,
 };
 PrimaryLinkBrandAltTheme.parameters = {
 	backgrounds: {
 		default: 'brandAltBackground.primary',
 	},
-	theme: linkThemeBrandAlt,
 };
 
 // *****************************************************************************

--- a/libs/@guardian/source-react-components/src/link/styles.ts
+++ b/libs/@guardian/source-react-components/src/link/styles.ts
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import {
 	focusHalo,
 	space,
-	textSans,
+	textSans17,
 	width,
 } from '@guardian/source-foundations';
 import type { ReactElement } from 'react';
@@ -15,7 +15,7 @@ import { themeLink as defaultTheme } from './theme';
 
 export const link = css`
 	position: relative;
-	${textSans.medium()};
+	${textSans17};
 	cursor: pointer;
 	text-decoration: underline;
 	text-underline-position: under;

--- a/libs/@guardian/source-react-components/src/radio/styles.ts
+++ b/libs/@guardian/source-react-components/src/radio/styles.ts
@@ -6,7 +6,9 @@ import {
 	height,
 	resets,
 	space,
-	textSans,
+	textSans15,
+	textSans17,
+	textSansBold17,
 	transitions,
 	width,
 } from '@guardian/source-foundations';
@@ -107,13 +109,13 @@ export const radio = (radio: ThemeRadio): SerializedStyles => css`
 `;
 
 export const labelText = (radio: ThemeRadio): SerializedStyles => css`
-	${textSans.medium()};
+	${textSans17};
 	color: ${radio.textLabel};
 	width: 100%;
 `;
 
 export const labelTextWithSupportingText = css`
-	${textSans.medium({ fontWeight: 'bold' })};
+	${textSansBold17};
 	margin-top: 1px;
 	/* If label text is empty, add additional spacing to align supporting text */
 	&:empty {
@@ -122,6 +124,6 @@ export const labelTextWithSupportingText = css`
 `;
 
 export const supportingText = (radio: ThemeRadio): SerializedStyles => css`
-	${textSans.small()};
+	${textSans15};
 	color: ${radio.textSupporting};
 `;

--- a/libs/@guardian/source-react-components/src/select/styles.ts
+++ b/libs/@guardian/source-react-components/src/select/styles.ts
@@ -5,7 +5,7 @@ import {
 	focusHalo,
 	height,
 	space,
-	textSans,
+	textSans17,
 	width,
 } from '@guardian/source-foundations';
 import type { ThemeSelect } from './theme';
@@ -62,7 +62,7 @@ export const select = (select: ThemeSelect): SerializedStyles => css`
 	box-sizing: border-box;
 	height: ${height.inputMedium}px;
 	width: 100%;
-	${textSans.medium()};
+	${textSans17};
 	background-color: ${select.backgroundInput};
 	border: 1px solid ${select.border};
 	border-radius: 4px;

--- a/libs/@guardian/source-react-components/src/text-area/styles.ts
+++ b/libs/@guardian/source-react-components/src/text-area/styles.ts
@@ -1,14 +1,19 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { focusHalo, space, textSans } from '@guardian/source-foundations';
+import {
+	focusHalo,
+	space,
+	textSans14,
+	textSans17,
+} from '@guardian/source-foundations';
 import type { InputSize } from '../@types/InputSize';
 import type { ThemeTextArea } from './theme';
 
 const textAreaSize: {
 	[key in InputSize]: string;
 } = {
-	medium: textSans.medium(),
-	small: textSans.xsmall(),
+	medium: textSans17,
+	small: textSans14,
 };
 
 export const errorInput = (textArea: ThemeTextArea): SerializedStyles => css`

--- a/libs/@guardian/source-react-components/src/text-input/styles.ts
+++ b/libs/@guardian/source-react-components/src/text-input/styles.ts
@@ -1,16 +1,22 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { focusHalo, size, space, textSans } from '@guardian/source-foundations';
+import {
+	focusHalo,
+	size,
+	space,
+	textSans14,
+	textSans17,
+} from '@guardian/source-foundations';
 import type { InputSize } from '../@types/InputSize';
 import type { ThemeTextInput } from './theme';
 
 const inputSizeMedium = css`
-	${textSans.medium()};
+	${textSans17};
 	height: ${size.medium}px;
 `;
 
 const inputSizeSmall = css`
-	${textSans.xsmall()};
+	${textSans14};
 	height: ${size.small}px;
 `;
 

--- a/libs/@guardian/source-react-components/src/user-feedback/styles.ts
+++ b/libs/@guardian/source-react-components/src/user-feedback/styles.ts
@@ -1,6 +1,11 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { remHeight, remWidth, textSans } from '@guardian/source-foundations';
+import {
+	remHeight,
+	remWidth,
+	textSans14,
+	textSans17,
+} from '@guardian/source-foundations';
 import type { InputSize } from '../@types/InputSize';
 import type { ThemeUserFeedback } from './theme';
 
@@ -22,7 +27,7 @@ const inlineMessage = css`
 `;
 
 const inlineMessageSmall = css`
-	${textSans.xsmall()};
+	${textSans14};
 	svg {
 		width: ${remWidth.iconSmall}rem;
 		height: ${remHeight.iconSmall}rem;
@@ -30,7 +35,7 @@ const inlineMessageSmall = css`
 `;
 
 const inlineMessageMedium = css`
-	${textSans.medium()};
+	${textSans17};
 	svg {
 		width: ${remWidth.iconMedium}rem;
 		height: ${remHeight.iconMedium}rem;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,7 +190,7 @@ importers:
         version: 0.5.6(prettier@3.2.2)(typescript@5.3.3)
       '@astrojs/svelte':
         specifier: 5.3.0
-        version: 5.3.0(astro@4.5.16)(svelte@4.2.12)(typescript@5.3.3)(vite@5.2.8)
+        version: 5.3.0(astro@4.5.16)(svelte@4.2.12)(typescript@5.3.3)(vite@5.2.10)
       astro:
         specifier: 4.5.16
         version: 4.5.16(@types/node@18.19.3)(typescript@5.3.3)
@@ -456,7 +456,7 @@ importers:
         version: 3.0.3
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.24.0)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.3.3)
+        version: 29.1.1(@babel/core@7.24.5)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.3.3)
       tslib:
         specifier: 2.6.2
         version: 2.6.2
@@ -468,7 +468,7 @@ importers:
     devDependencies:
       '@guardian/identity-auth':
         specifier: 2.1.0
-        version: link:../identity-auth
+        version: 2.1.0(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/libs':
         specifier: 16.0.0
         version: 16.0.0(tslib@2.6.2)(typescript@5.3.3)
@@ -576,8 +576,8 @@ importers:
         specifier: 11.11.1
         version: 11.11.1(@types/react@18.2.11)(react@18.2.0)
       '@guardian/source-foundations':
-        specifier: 14.2.0
-        version: 14.2.0(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 14.2.2
+        version: 14.2.2(tslib@2.6.2)(typescript@5.3.3)
       '@svgr/babel-preset':
         specifier: 8.1.0
         version: 8.1.0(@babel/core@7.24.0)
@@ -835,7 +835,7 @@ packages:
       prismjs: 1.29.0
     dev: true
 
-  /@astrojs/svelte@5.3.0(astro@4.5.16)(svelte@4.2.12)(typescript@5.3.3)(vite@5.2.8):
+  /@astrojs/svelte@5.3.0(astro@4.5.16)(svelte@4.2.12)(typescript@5.3.3)(vite@5.2.10):
     resolution: {integrity: sha512-7jKT6uQo6V4XNS4DmlZTlliO4qn9dOTsbRB3PyIzAnbTNqJnDBPY6Hj0X5uhELXSmKkn/o+ncJ46kLtFLqEq8w==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
@@ -843,7 +843,7 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.90
       typescript: ^5.3.3
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@4.2.12)(vite@5.2.8)
+      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@4.2.12)(vite@5.2.10)
       astro: 4.5.16(@types/node@18.19.3)(typescript@5.3.3)
       svelte: 4.2.12
       svelte2tsx: 0.6.27(svelte@4.2.12)(typescript@5.3.3)
@@ -931,6 +931,29 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/core@7.24.5:
+    resolution: {integrity: sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.24.2
+      '@babel/generator': 7.24.5
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
+      '@babel/helpers': 7.24.5
+      '@babel/parser': 7.24.5
+      '@babel/template': 7.24.0
+      '@babel/traverse': 7.24.5
+      '@babel/types': 7.24.5
+      convert-source-map: 2.0.0
+      debug: 4.3.4(supports-color@8.1.1)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/generator@7.24.4:
     resolution: {integrity: sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==}
     engines: {node: '>=6.9.0'}
@@ -939,6 +962,16 @@ packages:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
+
+  /@babel/generator@7.24.5:
+    resolution: {integrity: sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.5
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 2.5.2
+    dev: true
 
   /@babel/helper-annotate-as-pure@7.22.5:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
@@ -1071,6 +1104,13 @@ packages:
     dependencies:
       '@babel/types': 7.24.0
 
+  /@babel/helper-module-imports@7.24.3:
+    resolution: {integrity: sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.5
+    dev: true
+
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
     engines: {node: '>=6.9.0'}
@@ -1096,6 +1136,20 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
+    dev: true
+
+  /@babel/helper-module-transforms@7.24.5(@babel/core@7.24.5):
+    resolution: {integrity: sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.24.3
+      '@babel/helper-simple-access': 7.24.5
+      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/helper-validator-identifier': 7.24.5
     dev: true
 
   /@babel/helper-optimise-call-expression@7.22.5:
@@ -1140,6 +1194,13 @@ packages:
     dependencies:
       '@babel/types': 7.24.0
 
+  /@babel/helper-simple-access@7.24.5:
+    resolution: {integrity: sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.5
+    dev: true
+
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
@@ -1152,13 +1213,30 @@ packages:
     dependencies:
       '@babel/types': 7.24.0
 
+  /@babel/helper-split-export-declaration@7.24.5:
+    resolution: {integrity: sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.5
+    dev: true
+
   /@babel/helper-string-parser@7.23.4:
     resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-string-parser@7.24.1:
+    resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier@7.24.5:
+    resolution: {integrity: sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==}
+    engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-validator-option@7.22.15:
     resolution: {integrity: sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==}
@@ -1185,6 +1263,17 @@ packages:
       '@babel/types': 7.24.0
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/helpers@7.24.5:
+    resolution: {integrity: sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.24.0
+      '@babel/traverse': 7.24.5
+      '@babel/types': 7.24.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@babel/highlight@7.24.2:
     resolution: {integrity: sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==}
@@ -1217,6 +1306,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.24.0
+
+  /@babel/parser@7.24.5:
+    resolution: {integrity: sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.24.5
+    dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==}
@@ -2261,6 +2358,24 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/traverse@7.24.5:
+    resolution: {integrity: sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.24.2
+      '@babel/generator': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/parser': 7.24.5
+      '@babel/types': 7.24.5
+      debug: 4.3.4(supports-color@8.1.1)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/types@7.23.5:
     resolution: {integrity: sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==}
     engines: {node: '>=6.9.0'}
@@ -2277,6 +2392,15 @@ packages:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
+
+  /@babel/types@7.24.5:
+    resolution: {integrity: sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.24.1
+      '@babel/helper-validator-identifier': 7.24.5
+      to-fast-properties: 2.0.0
+    dev: true
 
   /@base2/pretty-print-object@1.0.1:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
@@ -3154,6 +3278,21 @@ packages:
       typescript: 5.3.3
     dev: true
 
+  /@guardian/identity-auth@2.1.0(@guardian/libs@16.0.0)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-+AM0pcmRvRZUf92RYGJ2Q6KK1JpnQIxZ6pafsaBMGnF0IwiIk9DdfhaYZl0cyPQ3PwLTJJw2aSl453ivPAmHbw==}
+    peerDependencies:
+      '@guardian/libs': ^16.0.0
+      tslib: ^2.6.2
+      typescript: ~5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@guardian/libs': 16.0.0(tslib@2.6.2)(typescript@5.3.3)
+      tslib: 2.6.2
+      typescript: 5.3.3
+    dev: true
+
   /@guardian/libs@16.0.0(tslib@2.6.2)(typescript@5.3.3):
     resolution: {integrity: sha512-2i9cN6htXnvABIGhfqJGb9Bh/DdQOayUjb5ruqBGTiXEeDBHztctdVsi7+rPfMlwyPxQ+0qYLhM19f6J94vvhQ==}
     peerDependencies:
@@ -3181,8 +3320,8 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /@guardian/source-foundations@14.2.0(tslib@2.6.2)(typescript@5.3.3):
-    resolution: {integrity: sha512-uzphhaAyrXr59fPPuBUl6IzdtYTe5lqd90JTAuin34e32lP2VEqYi6EbydN0f/4kdYnek5tjkC6CbjXeuiqn/Q==}
+  /@guardian/source-foundations@14.2.2(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-198Akw1RqufsX6Iu/qzqeR4eC9L3ezHURVzMqJeB3ZRZtabdkL2Q562mS1UnSdyACeCLRMqlOXqZDO38gsjP/g==}
     peerDependencies:
       tslib: ^2.6.2
       typescript: ~5.3.3
@@ -4060,11 +4199,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-android-arm-eabi@4.17.2:
+    resolution: {integrity: sha512-NM0jFxY8bB8QLkoKxIQeObCaDlJKewVlIEkuyYKm5An1tdVZ966w2+MPQ2l8LBZLjR+SgyV+nRkTIunzOYBMLQ==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-android-arm64@4.13.0:
     resolution: {integrity: sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.17.2:
+    resolution: {integrity: sha512-yeX/Usk7daNIVwkq2uGoq2BYJKZY1JfyLTaHO/jaiSwi/lsf8fTFoQW/n6IdAsx5tx+iotu2zCJwz8MxI6D/Bw==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-darwin-arm64@4.13.0:
@@ -4074,11 +4229,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-darwin-arm64@4.17.2:
+    resolution: {integrity: sha512-kcMLpE6uCwls023+kknm71ug7MZOrtXo+y5p/tsg6jltpDtgQY1Eq5sGfHcQfb+lfuKwhBmEURDga9N0ol4YPw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-darwin-x64@4.13.0:
     resolution: {integrity: sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.17.2:
+    resolution: {integrity: sha512-AtKwD0VEx0zWkL0ZjixEkp5tbNLzX+FCqGG1SvOu993HnSz4qDI6S4kGzubrEJAljpVkhRSlg5bzpV//E6ysTQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-gnueabihf@4.13.0:
@@ -4088,11 +4259,35 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-linux-arm-gnueabihf@4.17.2:
+    resolution: {integrity: sha512-3reX2fUHqN7sffBNqmEyMQVj/CKhIHZd4y631duy0hZqI8Qoqf6lTtmAKvJFYa6bhU95B1D0WgzHkmTg33In0A==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf@4.17.2:
+    resolution: {integrity: sha512-uSqpsp91mheRgw96xtyAGP9FW5ChctTFEoXP0r5FAzj/3ZRv3Uxjtc7taRQSaQM/q85KEKjKsZuiZM3GyUivRg==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-linux-arm64-gnu@4.13.0:
     resolution: {integrity: sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.17.2:
+    resolution: {integrity: sha512-EMMPHkiCRtE8Wdk3Qhtciq6BndLtstqZIroHiiGzB3C5LDJmIZcSzVtLRbwuXuUft1Cnv+9fxuDtDxz3k3EW2A==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-musl@4.13.0:
@@ -4102,11 +4297,43 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-linux-arm64-musl@4.17.2:
+    resolution: {integrity: sha512-NMPylUUZ1i0z/xJUIx6VUhISZDRT+uTWpBcjdv0/zkp7b/bQDF+NfnfdzuTiB1G6HTodgoFa93hp0O1xl+/UbA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-powerpc64le-gnu@4.17.2:
+    resolution: {integrity: sha512-T19My13y8uYXPw/L/k0JYaX1fJKFT/PWdXiHr8mTbXWxjVF1t+8Xl31DgBBvEKclw+1b00Chg0hxE2O7bTG7GQ==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-linux-riscv64-gnu@4.13.0:
     resolution: {integrity: sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.17.2:
+    resolution: {integrity: sha512-BOaNfthf3X3fOWAB+IJ9kxTgPmMqPPH5f5k2DcCsRrBIbWnaJCgX2ll77dV1TdSy9SaXTR5iDXRL8n7AnoP5cg==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu@4.17.2:
+    resolution: {integrity: sha512-W0UP/x7bnn3xN2eYMql2T/+wpASLE5SjObXILTMPUBDB/Fg/FxC+gX4nvCfPBCbNhz51C+HcqQp2qQ4u25ok6g==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-gnu@4.13.0:
@@ -4116,11 +4343,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-linux-x64-gnu@4.17.2:
+    resolution: {integrity: sha512-Hy7pLwByUOuyaFC6mAr7m+oMC+V7qyifzs/nW2OJfC8H4hbCzOX07Ov0VFk/zP3kBsELWNFi7rJtgbKYsav9QQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-linux-x64-musl@4.13.0:
     resolution: {integrity: sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.17.2:
+    resolution: {integrity: sha512-h1+yTWeYbRdAyJ/jMiVw0l6fOOm/0D1vNLui9iPuqgRGnXA0u21gAqOyB5iHjlM9MMfNOm9RHCQ7zLIzT0x11Q==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-win32-arm64-msvc@4.13.0:
@@ -4130,6 +4373,14 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-win32-arm64-msvc@4.17.2:
+    resolution: {integrity: sha512-tmdtXMfKAjy5+IQsVtDiCfqbynAQE/TQRpWdVataHmhMb9DCoJxp9vLcCBjEQWMiUYxO1QprH/HbY9ragCEFLA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-win32-ia32-msvc@4.13.0:
     resolution: {integrity: sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==}
     cpu: [ia32]
@@ -4137,11 +4388,27 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@rollup/rollup-win32-ia32-msvc@4.17.2:
+    resolution: {integrity: sha512-7II/QCSTAHuE5vdZaQEwJq2ZACkBpQDOmQsE6D6XUbnBHW8IAhm4eTufL6msLJorzrHDFv3CF8oCA/hSIRuZeQ==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-win32-x64-msvc@4.13.0:
     resolution: {integrity: sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.17.2:
+    resolution: {integrity: sha512-TGGO7v7qOq4CYmSBVEYpI1Y5xDuCEnbVC5Vth8mOsW0gDSzxNrVERPc790IGHsrT2dQSimgMr9Ub3Y1Jci5/8w==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@shikijs/core@1.2.4:
@@ -4949,7 +5216,7 @@ packages:
       file-system-cache: 2.3.0
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.12)(vite@5.2.8):
+  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.12)(vite@5.2.10):
     resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
@@ -4957,30 +5224,30 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@4.2.12)(vite@5.2.8)
+      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@4.2.12)(vite@5.2.10)
       debug: 4.3.4(supports-color@8.1.1)
       svelte: 4.2.12
-      vite: 5.2.8(@types/node@18.19.3)
+      vite: 5.2.10(@types/node@18.19.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@3.0.2(svelte@4.2.12)(vite@5.2.8):
+  /@sveltejs/vite-plugin-svelte@3.0.2(svelte@4.2.12)(vite@5.2.10):
     resolution: {integrity: sha512-MpmF/cju2HqUls50WyTHQBZUV3ovV/Uk8k66AN2gwHogNAG8wnW8xtZDhzNBsFJJuvmq1qnzA5kE7YfMJNFv2Q==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.12)(vite@5.2.8)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.12)(vite@5.2.10)
       debug: 4.3.4(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.8
       svelte: 4.2.12
       svelte-hmr: 0.15.3(svelte@4.2.12)
-      vite: 5.2.8(@types/node@18.19.3)
-      vitefu: 0.2.5(vite@5.2.8)
+      vite: 5.2.10(@types/node@18.19.3)
+      vitefu: 0.2.5(vite@5.2.10)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6997,13 +7264,19 @@ packages:
     dev: true
     optional: true
 
-  /bare-fs@2.2.3:
-    resolution: {integrity: sha512-amG72llr9pstfXOBOHve1WjiuKKAMnebcmMbPWDZ7BCevAoJLpugjuAPRsDINEyjT0a6tbaVx3DctkXIRbLuJw==}
+  /bare-events@2.2.2:
+    resolution: {integrity: sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==}
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /bare-fs@2.3.0:
+    resolution: {integrity: sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==}
     requiresBuild: true
     dependencies:
       bare-events: 2.2.0
-      bare-path: 2.1.1
-      streamx: 2.16.1
+      bare-path: 2.1.2
+      bare-stream: 1.0.0
     dev: true
     optional: true
 
@@ -7013,11 +7286,19 @@ packages:
     dev: true
     optional: true
 
-  /bare-path@2.1.1:
-    resolution: {integrity: sha512-OHM+iwRDRMDBsSW7kl3dO62JyHdBKO3B25FB9vNQBPcGHMo4+eA8Yj41Lfbk3pS/seDY+siNge0LdRTulAau/A==}
+  /bare-path@2.1.2:
+    resolution: {integrity: sha512-o7KSt4prEphWUHa3QUwCxUI00R86VdjiuxmJK0iNVDHYPGo+HsDaVCnqCmPbf/MiW1ok8F4p3m8RTHlWk8K2ig==}
     requiresBuild: true
     dependencies:
       bare-os: 2.2.0
+    dev: true
+    optional: true
+
+  /bare-stream@1.0.0:
+    resolution: {integrity: sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==}
+    requiresBuild: true
+    dependencies:
+      streamx: 2.16.1
     dev: true
     optional: true
 
@@ -14339,6 +14620,32 @@ packages:
       '@rollup/rollup-win32-x64-msvc': 4.13.0
       fsevents: 2.3.3
 
+  /rollup@4.17.2:
+    resolution: {integrity: sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.17.2
+      '@rollup/rollup-android-arm64': 4.17.2
+      '@rollup/rollup-darwin-arm64': 4.17.2
+      '@rollup/rollup-darwin-x64': 4.17.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.17.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.17.2
+      '@rollup/rollup-linux-arm64-gnu': 4.17.2
+      '@rollup/rollup-linux-arm64-musl': 4.17.2
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.17.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.17.2
+      '@rollup/rollup-linux-s390x-gnu': 4.17.2
+      '@rollup/rollup-linux-x64-gnu': 4.17.2
+      '@rollup/rollup-linux-x64-musl': 4.17.2
+      '@rollup/rollup-win32-arm64-msvc': 4.17.2
+      '@rollup/rollup-win32-ia32-msvc': 4.17.2
+      '@rollup/rollup-win32-x64-msvc': 4.17.2
+      fsevents: 2.3.3
+    dev: true
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -14831,7 +15138,7 @@ packages:
       fast-fifo: 1.3.2
       queue-tick: 1.0.1
     optionalDependencies:
-      bare-events: 2.2.0
+      bare-events: 2.2.2
     dev: true
     optional: true
 
@@ -15114,8 +15421,8 @@ packages:
       pump: 3.0.0
       tar-stream: 3.1.7
     optionalDependencies:
-      bare-fs: 2.2.3
-      bare-path: 2.1.1
+      bare-fs: 2.3.0
+      bare-path: 2.1.2
     dev: true
     optional: true
 
@@ -15387,6 +15694,41 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.24.0
+      bs-logger: 0.2.6
+      esbuild: 0.20.2
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@18.19.3)(ts-node@10.9.2)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.4
+      typescript: 5.3.3
+      yargs-parser: 21.1.1
+    dev: true
+
+  /ts-jest@29.1.1(@babel/core@7.24.5)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.24.5
       bs-logger: 0.2.6
       esbuild: 0.20.2
       fast-json-stable-stringify: 2.1.0
@@ -16039,6 +16381,42 @@ packages:
       vfile-message: 4.0.2
     dev: true
 
+  /vite@5.2.10(@types/node@18.19.3):
+    resolution: {integrity: sha512-PAzgUZbP7msvQvqdSD+ErD5qGnSFiGOoWmV5yAKUEI0kdhjbH6nMWVyZQC/hSc4aXwc0oJ9aEdIiF9Oje0JFCw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.19.3
+      esbuild: 0.20.2
+      postcss: 8.4.38
+      rollup: 4.17.2
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /vite@5.2.8(@types/node@18.19.3):
     resolution: {integrity: sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -16073,6 +16451,17 @@ packages:
       rollup: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /vitefu@0.2.5(vite@5.2.10):
+    resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      vite: 5.2.10(@types/node@18.19.3)
     dev: true
 
   /vitefu@0.2.5(vite@5.2.8):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,8 +576,8 @@ importers:
         specifier: 11.11.1
         version: 11.11.1(@types/react@18.2.11)(react@18.2.0)
       '@guardian/source-foundations':
-        specifier: 14.1.4
-        version: 14.1.4(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 14.2.0
+        version: 14.2.0(tslib@2.6.2)(typescript@5.3.3)
       '@svgr/babel-preset':
         specifier: 8.1.0
         version: 8.1.0(@babel/core@7.24.0)
@@ -3169,6 +3169,20 @@ packages:
 
   /@guardian/source-foundations@14.1.4(tslib@2.6.2)(typescript@5.3.3):
     resolution: {integrity: sha512-SHkFVBxsE2dSNTKfzmGY1hD9BA7qJ2+bGY1plrUJlYJBCRQdno/YuNummO+wm0Q+kMgxRT0iz5md2DjKYERzQw==}
+    peerDependencies:
+      tslib: ^2.6.2
+      typescript: ~5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      mini-svg-data-uri: 1.4.4
+      tslib: 2.6.2
+      typescript: 5.3.3
+    dev: true
+
+  /@guardian/source-foundations@14.2.0(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-uzphhaAyrXr59fPPuBUl6IzdtYTe5lqd90JTAuin34e32lP2VEqYi6EbydN0f/4kdYnek5tjkC6CbjXeuiqn/Q==}
     peerDependencies:
       tslib: ^2.6.2
       typescript: ~5.3.3


### PR DESCRIPTION
## What are you changing?

Updates _Source React Components_ to latest version of _Source Foundations_ and replaces uses of typography API with typography presets.

## Why?

The typography API is deprecated and will be removed in a future release.
