### PR TITLE
Refactor `ab-core` for clearer intent

### DIFF
--- a/.changeset/odd-jobs-flow.md
+++ b/.changeset/odd-jobs-flow.md
@@ -1,0 +1,5 @@
+---
+'@guardian/ab-core': patch
+---
+
+Smaller source code

--- a/libs/@guardian/ab-core/src/fixture.ts
+++ b/libs/@guardian/ab-core/src/fixture.ts
@@ -41,12 +41,7 @@ export const genAbTest = (genAbConfig: GenAbConfig): ABTest => {
 		audienceOffset,
 		audience,
 		author: 'n/a',
-		canRun: (): boolean => {
-			if (canRun !== undefined) {
-				return !!canRun;
-			}
-			return true;
-		},
+		canRun: (): boolean => canRun ?? true,
 		description: 'n/a',
 		start: '0001-01-01',
 		expiry,


### PR DESCRIPTION
## What are you changing?

- use nullish coalescing to convert a `boolean | undefined` into a `boolean`

## Why?

- nullish coalescing is shorter and more expressive about the intent
- a [follow-up on a recent formatting change](https://github.com/guardian/csnx/pull/1374#discussion_r1577925315)
