### PR TITLE
bump `@guardian/eslint-config-typescript` too

### DIFF
--- a/.changeset/pretty-poets-smash.md
+++ b/.changeset/pretty-poets-smash.md
@@ -1,5 +1,6 @@
 ---
 '@guardian/eslint-config': major
+'@guardian/eslint-config-typescript': major
 ---
 
 Requires curly braces in all circumstances.


### PR DESCRIPTION
## What are you changing?

- typescript config also breaking change

## Why?

- semver rules
