### PR TITLE
default consents for 11 is false

### DIFF
--- a/.changeset/shaggy-bobcats-yell.md
+++ b/.changeset/shaggy-bobcats-yell.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': patch
+---
+
+Make consent 11 false by default, currently undefined

--- a/libs/@guardian/libs/src/consent-management-platform/tcfv2/__fixtures__/api.getTCData.json
+++ b/libs/@guardian/libs/src/consent-management-platform/tcfv2/__fixtures__/api.getTCData.json
@@ -26,7 +26,8 @@
 			"7": true,
 			"8": true,
 			"9": true,
-			"10": true
+			"10": true,
+			"11": true
 		},
 		"legitimateInterests": {
 			"1": false,
@@ -38,7 +39,8 @@
 			"7": true,
 			"8": true,
 			"9": true,
-			"10": true
+			"10": true,
+			"11": true
 		}
 	},
 	"vendor": {

--- a/libs/@guardian/libs/src/consent-management-platform/tcfv2/getConsentState.test.js
+++ b/libs/@guardian/libs/src/consent-management-platform/tcfv2/getConsentState.test.js
@@ -34,6 +34,7 @@ describe('getConsentState', () => {
 			8: true,
 			9: true,
 			10: true,
+			11: true,
 		});
 		expect(eventStatus).toBe('tcloaded');
 		expect(vendorConsents).toMatchSnapshot();

--- a/libs/@guardian/libs/src/consent-management-platform/tcfv2/getConsentState.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/tcfv2/getConsentState.ts
@@ -13,6 +13,7 @@ const defaultConsents: TCFv2ConsentList = {
 	'8': false,
 	'9': false,
 	'10': false,
+	'11': false,
 };
 
 // get the current constent state using the official IAB method


### PR DESCRIPTION
## What does this change?
Default consent 11 to false. Note that this will set canTarget to false if only purpose 11 is de-selected which is not currently the case.
Copy over from https://github.com/guardian/consent-management-platform/pull/868

## Why?
It is currently 'undefined' if reader rejected all or explicitly rejected purpose 11