### PR TITLE
Do not enable `incremental` in `@guardian/tsconfig`

### DIFF
--- a/.changeset/wet-llamas-camp.md
+++ b/.changeset/wet-llamas-camp.md
@@ -1,0 +1,7 @@
+---
+'@guardian/tsconfig': minor
+---
+
+Removes the `"incremental": true` setting, deferring [the TypeScript defaults](https://www.typescriptlang.org/tsconfig/#incremental).
+
+_This should be project-specific, not a default for all configs._

--- a/libs/@guardian/tsconfig/tsconfig.json
+++ b/libs/@guardian/tsconfig/tsconfig.json
@@ -2,7 +2,6 @@
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true,
-		"incremental": true,
 		"module": "esnext",
 		"moduleResolution": "node",
 		"noImplicitReturns": true,


### PR DESCRIPTION
## What are you changing?

removes `"incremental": true` from `@guardian/tsconfig`

## Why?

It should be a project's own choice to use it, if it's useful to that project.

It's not a valuable default, as [it requires other settings to work well](https://www.typescriptlang.org/tsconfig/#incremental).
