### PR TITLE
Update Source Development Kitchen components to use typography presets

### DIFF
--- a/.changeset/old-zebras-divide.md
+++ b/.changeset/old-zebras-divide.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': major
+---
+
+Updates dependencies to `@guardian/source-foundations@14.2.2` and `@guardian/source-react-components@23.0.0`, and replaces use of deprecated typography API with typography presets

--- a/libs/@guardian/source-react-components-development-kitchen/package.json
+++ b/libs/@guardian/source-react-components-development-kitchen/package.json
@@ -15,7 +15,7 @@
 		"@babel/core": "7.24.0",
 		"@emotion/react": "11.11.1",
 		"@guardian/libs": "16.0.0",
-		"@guardian/source-foundations": "14.1.4",
+		"@guardian/source-foundations": "14.2.2",
 		"@guardian/source-react-components": "22.0.1",
 		"@types/react": "18.2.11",
 		"react": "18.2.0",

--- a/libs/@guardian/source-react-components-development-kitchen/package.json
+++ b/libs/@guardian/source-react-components-development-kitchen/package.json
@@ -16,7 +16,7 @@
 		"@emotion/react": "11.11.1",
 		"@guardian/libs": "16.0.0",
 		"@guardian/source-foundations": "14.2.2",
-		"@guardian/source-react-components": "22.0.1",
+		"@guardian/source-react-components": "23.0.0",
 		"@types/react": "18.2.11",
 		"react": "18.2.0",
 		"tslib": "2.6.2",
@@ -26,8 +26,8 @@
 	"peerDependencies": {
 		"@emotion/react": "^11.11.1",
 		"@guardian/libs": "^16.0.0",
-		"@guardian/source-foundations": "^14.1.4",
-		"@guardian/source-react-components": "^22.0.1",
+		"@guardian/source-foundations": "^14.2.2",
+		"@guardian/source-react-components": "^23.0.0",
 		"react": "^18.2.0",
 		"tslib": "^2.6.2",
 		"typescript": "~5.3.3"

--- a/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/age-warning/AgeWarning.tsx
@@ -4,7 +4,8 @@ import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import {
 	palette,
 	space,
-	textSans,
+	textSans12,
+	textSans17,
 	visuallyHidden,
 } from '@guardian/source-foundations';
 import { darkModeCss } from './styles';
@@ -36,7 +37,7 @@ const ageWarningStyles = (
 	isSmall: boolean,
 	supportsDarkMode: boolean,
 ): SerializedStyles => css`
-	${isSmall ? textSans.xxsmall() : textSans.medium()};
+	${isSmall ? textSans12 : textSans17}
 	color: ${palette.neutral[7]};
 	background-color: ${palette.brandAlt[400]};
 	display: inline-block;

--- a/libs/@guardian/source-react-components-development-kitchen/src/divider/Divider.tsx
+++ b/libs/@guardian/source-react-components-development-kitchen/src/divider/Divider.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import { border, space, text, textSans } from '@guardian/source-foundations';
+import { border, space, text, textSans15 } from '@guardian/source-foundations';
 import type { Props } from '@guardian/source-react-components';
 import { fullStyles, partialStyles } from './styles';
 
@@ -50,7 +50,7 @@ export const Divider = ({
 					css`
 						display: flex;
 						flex-direction: row;
-						${textSans.small()};
+						${textSans15};
 						color: ${text.supporting};
 						margin-bottom: -10px;
 						width: 100%;

--- a/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/styles.ts
@@ -4,7 +4,7 @@ import {
 	focusHalo,
 	remHeight,
 	remSpace,
-	textSans,
+	textSansBold15,
 } from '@guardian/source-foundations';
 import { themeColour } from './theme';
 
@@ -71,7 +71,7 @@ export const overlayStyles = css`
 `;
 
 export const showHideLabelStyles = css`
-	${textSans.small({ fontWeight: 'bold' })};
+	${textSansBold15};
 	display: inline-flex;
 	justify-content: space-between;
 	box-shadow: none;

--- a/libs/@guardian/source-react-components-development-kitchen/src/file-input/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/file-input/styles.ts
@@ -7,7 +7,9 @@ import {
 	remHeight,
 	remSpace,
 	space,
-	textSans,
+	textSans14,
+	textSans15,
+	textSans17,
 } from '@guardian/source-foundations';
 import { fileInputThemeDefault } from './theme';
 import type { Size as SizeType } from './types';
@@ -39,7 +41,7 @@ const xsmallUpload = css`
 export const warningText = (
 	fileInput = fileInputThemeDefault.fileInput,
 ): SerializedStyles => css`
-	${textSans.xsmall()};
+	${textSans14};
 	color: ${fileInput.supporting};
 	margin: 2px 0 0;
 `;
@@ -56,13 +58,13 @@ export const fontSizes: {
 	[key in SizeType]: SerializedStyles;
 } = {
 	default: css`
-		${textSans.medium()};
+		${textSans17};
 	`,
 	small: css`
-		${textSans.small()};
+		${textSans15};
 	`,
 	xsmall: css`
-		${textSans.xsmall()};
+		${textSans14};
 	`,
 };
 

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/footerLinksStyles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/footerLinksStyles.ts
@@ -5,7 +5,8 @@ import {
 	brandAlt,
 	from,
 	space,
-	textSans,
+	textSans15,
+	textSans17,
 	until,
 } from '@guardian/source-foundations';
 
@@ -108,12 +109,14 @@ export function getItemStyles(useColumns: boolean) {
 export const linkElementStyles = css`
 	display: block;
 	text-decoration: none;
-	${textSans.small({ lineHeight: 'tight' })}
+	${textSans15};
+	line-height: 1.15;
 	:hover {
 		text-decoration: underline;
 		color: ${brandAlt[400]};
 	}
 	${from.mobileMedium} {
-		${textSans.medium({ lineHeight: 'tight' })}
+		${textSans17};
+		line-height: 1.15;
 	}
 `;

--- a/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/footerWithContentsStyles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/footer-with-contents/footerWithContentsStyles.ts
@@ -4,14 +4,15 @@ import {
 	from,
 	neutral,
 	space,
-	textSans,
+	textSans12,
+	textSans17,
 } from '@guardian/source-foundations';
 
 export const footer = css`
 	background-color: ${brand[400]};
 	color: ${neutral[100]};
 	padding-bottom: ${space[1]}px;
-	${textSans.medium()};
+	${textSans17};
 `;
 
 export const contentWrapperStyles = css`
@@ -21,7 +22,7 @@ export const contentWrapperStyles = css`
 
 export const copyrightStyles = css`
 	display: block;
-	${textSans.xxsmall()};
+	${textSans12};
 	padding-top: ${space[6]}px;
 	padding-bottom: 18px;
 	${from.tablet} {

--- a/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/sharedStyles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/numeric-input/sharedStyles.ts
@@ -1,16 +1,21 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { size, space, textSans } from '@guardian/source-foundations';
+import {
+	size,
+	space,
+	textSans14,
+	textSans17,
+} from '@guardian/source-foundations';
 import { textInputThemeDefault } from '@guardian/source-react-components';
 import type { InputSize } from '@guardian/source-react-components';
 
 const inputSizeDefault = css`
-	${textSans.medium()};
+	${textSans17};
 	height: ${size.medium}px;
 `;
 
 const inputSizeSmall = css`
-	${textSans.xsmall()};
+	${textSans14};
 	height: ${size.small}px;
 `;
 

--- a/libs/@guardian/source-react-components-development-kitchen/src/summary/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/summary/styles.ts
@@ -1,6 +1,11 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { size, space, textSans } from '@guardian/source-foundations';
+import {
+	size,
+	space,
+	textSans17,
+	textSansBold17,
+} from '@guardian/source-foundations';
 
 export const wrapperStyles = (color: string): SerializedStyles => css`
 	border: 2px solid ${color};
@@ -24,10 +29,8 @@ export const messageStyles = (
 	color: string,
 	isBold = true,
 ): SerializedStyles => css`
-	${textSans.medium({
-		fontWeight: isBold ? 'bold' : 'regular',
-		lineHeight: 'loose',
-	})}
+	${isBold ? textSansBold17 : textSans17};
+	line-height: 1.4;
 	color: ${color};
 `;
 
@@ -36,5 +39,5 @@ export const messageWrapperStyles = css`
 `;
 
 export const contextStyles = css`
-	${textSans.medium()}
+	${textSans17};
 `;

--- a/libs/@guardian/source-react-components-development-kitchen/src/tabs/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/tabs/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { from, space, textSans } from '@guardian/source-foundations';
+import { from, space, textSansBold17 } from '@guardian/source-foundations';
 import { tabThemeColour } from './theme';
 
 export const tabList = css`
@@ -10,9 +10,7 @@ export const tabList = css`
 
 export const tabButton = css`
 	background-color: ${tabThemeColour('--background')};
-	${textSans.medium({
-		fontWeight: 'bold',
-	})}
+	${textSansBold17};
 	position: relative;
 	display: flex;
 	align-items: center;
@@ -42,9 +40,7 @@ export const tabButton = css`
 	}
 
 	${from.phablet} {
-		${textSans.medium({
-			fontWeight: 'bold',
-		})}
+		${textSansBold17}
 		width: 210px;
 	}
 

--- a/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/styles.ts
+++ b/libs/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { neutral, success, textSans } from '@guardian/source-foundations';
+import { neutral, success, textSans15 } from '@guardian/source-foundations';
 import type { LabelPosition } from './ToggleSwitchApps';
 
 export const buttonStyles = (labelPosition: LabelPosition) => css`
@@ -88,7 +88,7 @@ export const androidStyles = css`
 `;
 
 export const labelStyles = css`
-	${textSans.small()};
+	${textSans15};
 	display: flex;
 	color: ${neutral[7]};
 	align-items: center;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,7 +456,7 @@ importers:
         version: 3.0.3
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.24.5)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.3.3)
+        version: 29.1.1(@babel/core@7.24.0)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.3.3)
       tslib:
         specifier: 2.6.2
         version: 2.6.2
@@ -651,8 +651,8 @@ importers:
         specifier: 14.2.2
         version: 14.2.2(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components':
-        specifier: 22.0.1
-        version: 22.0.1(@emotion/react@11.11.1)(@guardian/source-foundations@14.2.2)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 23.0.0
+        version: 23.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.2.2)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@types/react':
         specifier: 18.2.11
         version: 18.2.11
@@ -931,29 +931,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/core@7.24.5:
-    resolution: {integrity: sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.24.2
-      '@babel/generator': 7.24.5
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
-      '@babel/helpers': 7.24.5
-      '@babel/parser': 7.24.5
-      '@babel/template': 7.24.0
-      '@babel/traverse': 7.24.5
-      '@babel/types': 7.24.5
-      convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/generator@7.24.4:
     resolution: {integrity: sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==}
     engines: {node: '>=6.9.0'}
@@ -962,16 +939,6 @@ packages:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
-
-  /@babel/generator@7.24.5:
-    resolution: {integrity: sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.5
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
-      jsesc: 2.5.2
-    dev: true
 
   /@babel/helper-annotate-as-pure@7.22.5:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
@@ -1104,13 +1071,6 @@ packages:
     dependencies:
       '@babel/types': 7.24.0
 
-  /@babel/helper-module-imports@7.24.3:
-    resolution: {integrity: sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.5
-    dev: true
-
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==}
     engines: {node: '>=6.9.0'}
@@ -1136,20 +1096,6 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
-    dev: true
-
-  /@babel/helper-module-transforms@7.24.5(@babel/core@7.24.5):
-    resolution: {integrity: sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.24.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-module-imports': 7.24.3
-      '@babel/helper-simple-access': 7.24.5
-      '@babel/helper-split-export-declaration': 7.24.5
-      '@babel/helper-validator-identifier': 7.24.5
     dev: true
 
   /@babel/helper-optimise-call-expression@7.22.5:
@@ -1194,13 +1140,6 @@ packages:
     dependencies:
       '@babel/types': 7.24.0
 
-  /@babel/helper-simple-access@7.24.5:
-    resolution: {integrity: sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.5
-    dev: true
-
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
@@ -1213,30 +1152,13 @@ packages:
     dependencies:
       '@babel/types': 7.24.0
 
-  /@babel/helper-split-export-declaration@7.24.5:
-    resolution: {integrity: sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.24.5
-    dev: true
-
   /@babel/helper-string-parser@7.23.4:
     resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-string-parser@7.24.1:
-    resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
-
-  /@babel/helper-validator-identifier@7.24.5:
-    resolution: {integrity: sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==}
-    engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-option@7.22.15:
     resolution: {integrity: sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==}
@@ -1263,17 +1185,6 @@ packages:
       '@babel/types': 7.24.0
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/helpers@7.24.5:
-    resolution: {integrity: sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.24.0
-      '@babel/traverse': 7.24.5
-      '@babel/types': 7.24.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@babel/highlight@7.24.2:
     resolution: {integrity: sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==}
@@ -1306,14 +1217,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.24.0
-
-  /@babel/parser@7.24.5:
-    resolution: {integrity: sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.24.5
-    dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.24.0):
     resolution: {integrity: sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==}
@@ -2358,24 +2261,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/traverse@7.24.5:
-    resolution: {integrity: sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.24.2
-      '@babel/generator': 7.24.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.24.5
-      '@babel/parser': 7.24.5
-      '@babel/types': 7.24.5
-      debug: 4.3.4(supports-color@8.1.1)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/types@7.23.5:
     resolution: {integrity: sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==}
     engines: {node: '>=6.9.0'}
@@ -2392,15 +2277,6 @@ packages:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
-
-  /@babel/types@7.24.5:
-    resolution: {integrity: sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-string-parser': 7.24.1
-      '@babel/helper-validator-identifier': 7.24.5
-      to-fast-properties: 2.0.0
-    dev: true
 
   /@base2/pretty-print-object@1.0.1:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
@@ -3353,11 +3229,11 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /@guardian/source-react-components@22.0.1(@emotion/react@11.11.1)(@guardian/source-foundations@14.2.2)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3):
-    resolution: {integrity: sha512-jpnFdc/fIRQswufgFDjlv0RQvtNpWd5PL7PJa4r7oNp8H8f+LEVn1D/WkuLFQwtP+T3S/wGF5GrcOmTMyFTlYA==}
+  /@guardian/source-react-components@23.0.0(@emotion/react@11.11.1)(@guardian/source-foundations@14.2.2)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-jBa9fsiG+V4DLfQwmPFy8sleJCDOYP5A1X0SeIPrPhQPDGXBAuwl9qNJMlR7N0MHCv7z1OchgDlHDQUf9S+Qlw==}
     peerDependencies:
       '@emotion/react': ^11.11.1
-      '@guardian/source-foundations': ^14.1.4
+      '@guardian/source-foundations': ^14.2.2
       react: ^18.2.0
       tslib: ^2.6.2
       typescript: ~5.3.3
@@ -4218,27 +4094,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-android-arm-eabi@4.17.2:
-    resolution: {integrity: sha512-NM0jFxY8bB8QLkoKxIQeObCaDlJKewVlIEkuyYKm5An1tdVZ966w2+MPQ2l8LBZLjR+SgyV+nRkTIunzOYBMLQ==}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-android-arm64@4.13.0:
     resolution: {integrity: sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-android-arm64@4.17.2:
-    resolution: {integrity: sha512-yeX/Usk7daNIVwkq2uGoq2BYJKZY1JfyLTaHO/jaiSwi/lsf8fTFoQW/n6IdAsx5tx+iotu2zCJwz8MxI6D/Bw==}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-darwin-arm64@4.13.0:
@@ -4248,27 +4108,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.17.2:
-    resolution: {integrity: sha512-kcMLpE6uCwls023+kknm71ug7MZOrtXo+y5p/tsg6jltpDtgQY1Eq5sGfHcQfb+lfuKwhBmEURDga9N0ol4YPw==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-darwin-x64@4.13.0:
     resolution: {integrity: sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-darwin-x64@4.17.2:
-    resolution: {integrity: sha512-AtKwD0VEx0zWkL0ZjixEkp5tbNLzX+FCqGG1SvOu993HnSz4qDI6S4kGzubrEJAljpVkhRSlg5bzpV//E6ysTQ==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-gnueabihf@4.13.0:
@@ -4278,35 +4122,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.17.2:
-    resolution: {integrity: sha512-3reX2fUHqN7sffBNqmEyMQVj/CKhIHZd4y631duy0hZqI8Qoqf6lTtmAKvJFYa6bhU95B1D0WgzHkmTg33In0A==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-arm-musleabihf@4.17.2:
-    resolution: {integrity: sha512-uSqpsp91mheRgw96xtyAGP9FW5ChctTFEoXP0r5FAzj/3ZRv3Uxjtc7taRQSaQM/q85KEKjKsZuiZM3GyUivRg==}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-arm64-gnu@4.13.0:
     resolution: {integrity: sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-linux-arm64-gnu@4.17.2:
-    resolution: {integrity: sha512-EMMPHkiCRtE8Wdk3Qhtciq6BndLtstqZIroHiiGzB3C5LDJmIZcSzVtLRbwuXuUft1Cnv+9fxuDtDxz3k3EW2A==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-musl@4.13.0:
@@ -4316,43 +4136,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.17.2:
-    resolution: {integrity: sha512-NMPylUUZ1i0z/xJUIx6VUhISZDRT+uTWpBcjdv0/zkp7b/bQDF+NfnfdzuTiB1G6HTodgoFa93hp0O1xl+/UbA==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-powerpc64le-gnu@4.17.2:
-    resolution: {integrity: sha512-T19My13y8uYXPw/L/k0JYaX1fJKFT/PWdXiHr8mTbXWxjVF1t+8Xl31DgBBvEKclw+1b00Chg0hxE2O7bTG7GQ==}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-riscv64-gnu@4.13.0:
     resolution: {integrity: sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-linux-riscv64-gnu@4.17.2:
-    resolution: {integrity: sha512-BOaNfthf3X3fOWAB+IJ9kxTgPmMqPPH5f5k2DcCsRrBIbWnaJCgX2ll77dV1TdSy9SaXTR5iDXRL8n7AnoP5cg==}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rollup/rollup-linux-s390x-gnu@4.17.2:
-    resolution: {integrity: sha512-W0UP/x7bnn3xN2eYMql2T/+wpASLE5SjObXILTMPUBDB/Fg/FxC+gX4nvCfPBCbNhz51C+HcqQp2qQ4u25ok6g==}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-gnu@4.13.0:
@@ -4362,27 +4150,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.17.2:
-    resolution: {integrity: sha512-Hy7pLwByUOuyaFC6mAr7m+oMC+V7qyifzs/nW2OJfC8H4hbCzOX07Ov0VFk/zP3kBsELWNFi7rJtgbKYsav9QQ==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-linux-x64-musl@4.13.0:
     resolution: {integrity: sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-linux-x64-musl@4.17.2:
-    resolution: {integrity: sha512-h1+yTWeYbRdAyJ/jMiVw0l6fOOm/0D1vNLui9iPuqgRGnXA0u21gAqOyB5iHjlM9MMfNOm9RHCQ7zLIzT0x11Q==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-arm64-msvc@4.13.0:
@@ -4392,14 +4164,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.17.2:
-    resolution: {integrity: sha512-tmdtXMfKAjy5+IQsVtDiCfqbynAQE/TQRpWdVataHmhMb9DCoJxp9vLcCBjEQWMiUYxO1QprH/HbY9ragCEFLA==}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-win32-ia32-msvc@4.13.0:
     resolution: {integrity: sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==}
     cpu: [ia32]
@@ -4407,27 +4171,11 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.17.2:
-    resolution: {integrity: sha512-7II/QCSTAHuE5vdZaQEwJq2ZACkBpQDOmQsE6D6XUbnBHW8IAhm4eTufL6msLJorzrHDFv3CF8oCA/hSIRuZeQ==}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rollup/rollup-win32-x64-msvc@4.13.0:
     resolution: {integrity: sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-win32-x64-msvc@4.17.2:
-    resolution: {integrity: sha512-TGGO7v7qOq4CYmSBVEYpI1Y5xDuCEnbVC5Vth8mOsW0gDSzxNrVERPc790IGHsrT2dQSimgMr9Ub3Y1Jci5/8w==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@shikijs/core@1.2.4:
@@ -14639,32 +14387,6 @@ packages:
       '@rollup/rollup-win32-x64-msvc': 4.13.0
       fsevents: 2.3.3
 
-  /rollup@4.17.2:
-    resolution: {integrity: sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-    dependencies:
-      '@types/estree': 1.0.5
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.17.2
-      '@rollup/rollup-android-arm64': 4.17.2
-      '@rollup/rollup-darwin-arm64': 4.17.2
-      '@rollup/rollup-darwin-x64': 4.17.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.17.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.17.2
-      '@rollup/rollup-linux-arm64-gnu': 4.17.2
-      '@rollup/rollup-linux-arm64-musl': 4.17.2
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.17.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.17.2
-      '@rollup/rollup-linux-s390x-gnu': 4.17.2
-      '@rollup/rollup-linux-x64-gnu': 4.17.2
-      '@rollup/rollup-linux-x64-musl': 4.17.2
-      '@rollup/rollup-win32-arm64-msvc': 4.17.2
-      '@rollup/rollup-win32-ia32-msvc': 4.17.2
-      '@rollup/rollup-win32-x64-msvc': 4.17.2
-      fsevents: 2.3.3
-    dev: true
-
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -15726,41 +15448,6 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-jest@29.1.1(@babel/core@7.24.5)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3 <6'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.24.5
-      bs-logger: 0.2.6
-      esbuild: 0.20.2
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@18.19.3)(ts-node@10.9.2)
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.4
-      typescript: 5.3.3
-      yargs-parser: 21.1.1
-    dev: true
-
   /ts-node@10.9.1(@swc/core@1.4.0)(@types/node@18.19.3)(typescript@5.3.3):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
@@ -16431,7 +16118,7 @@ packages:
       '@types/node': 18.19.3
       esbuild: 0.20.2
       postcss: 8.4.38
-      rollup: 4.17.2
+      rollup: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,11 +648,11 @@ importers:
         specifier: 16.0.0
         version: 16.0.0(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-foundations':
-        specifier: 14.1.4
-        version: 14.1.4(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 14.2.2
+        version: 14.2.2(tslib@2.6.2)(typescript@5.3.3)
       '@guardian/source-react-components':
         specifier: 22.0.1
-        version: 22.0.1(@emotion/react@11.11.1)(@guardian/source-foundations@14.1.4)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
+        version: 22.0.1(@emotion/react@11.11.1)(@guardian/source-foundations@14.2.2)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@types/react':
         specifier: 18.2.11
         version: 18.2.11
@@ -3348,6 +3348,25 @@ packages:
     dependencies:
       '@emotion/react': 11.11.1(@types/react@18.2.11)(react@18.2.0)
       '@guardian/source-foundations': 14.1.4(tslib@2.6.2)(typescript@5.3.3)
+      react: 18.2.0
+      tslib: 2.6.2
+      typescript: 5.3.3
+    dev: true
+
+  /@guardian/source-react-components@22.0.1(@emotion/react@11.11.1)(@guardian/source-foundations@14.2.2)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-jpnFdc/fIRQswufgFDjlv0RQvtNpWd5PL7PJa4r7oNp8H8f+LEVn1D/WkuLFQwtP+T3S/wGF5GrcOmTMyFTlYA==}
+    peerDependencies:
+      '@emotion/react': ^11.11.1
+      '@guardian/source-foundations': ^14.1.4
+      react: ^18.2.0
+      tslib: ^2.6.2
+      typescript: ~5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@emotion/react': 11.11.1(@types/react@18.2.11)(react@18.2.0)
+      '@guardian/source-foundations': 14.2.2(tslib@2.6.2)(typescript@5.3.3)
       react: 18.2.0
       tslib: 2.6.2
       typescript: 5.3.3


### PR DESCRIPTION
## What are you changing?

- Updates Source Development Kitchen components to latest version of Source Foundations and replaces uses of typography API with typography presets.

## Why?

- The typography API is deprecated and will be removed in a future release.
