### PR TITLE
Remove deprecated input reset style

### DIFF
--- a/.changeset/shy-buckets-obey.md
+++ b/.changeset/shy-buckets-obey.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-foundations': major
+---
+
+Removed deprecated input reset style

--- a/.changeset/shy-buckets-obey.md
+++ b/.changeset/shy-buckets-obey.md
@@ -2,4 +2,4 @@
 '@guardian/source-foundations': major
 ---
 
-Removed deprecated input reset style
+Removed deprecated `resets.input` reset style.

--- a/libs/@guardian/source-foundations/src/utils/resets.test.ts
+++ b/libs/@guardian/source-foundations/src/utils/resets.test.ts
@@ -8,10 +8,6 @@ test('resets.fieldset should be a valid CSS fragment', () => {
 	expect(resets.fieldset).toBeValidCSS({ isFragment: true });
 });
 
-test('resets.input should be an valid CSS fragment', () => {
-	expect(resets.input).toBeValidCSS({ isFragment: true });
-});
-
 test('resets.legend should be a valid CSS fragment', () => {
 	expect(resets.legend).toBeValidCSS({ isFragment: true });
 });

--- a/libs/@guardian/source-foundations/src/utils/resets.ts
+++ b/libs/@guardian/source-foundations/src/utils/resets.ts
@@ -16,15 +16,6 @@ const fieldset = `
 	margin: 0;
 `;
 
-/*
- * Remove styling of invalid input elements that gets applied in Firefox
- */
-const input = `
-	&:invalid {
-		box-shadow: none;
-	}
-`;
-
 ////////////////////////////
 // Default resets
 ////////////////////////////
@@ -122,8 +113,6 @@ const resetCSS = `
 export const resets = {
 	legend,
 	fieldset,
-	/** @deprecated This will be removed in a future release, as it relies on the Emotion framework */
-	input,
 	defaults,
 	resetCSS,
 };


### PR DESCRIPTION
## What are you changing?

- Removes deprecated input reset style.

## Why?

- This style is already part of the styles for the Source input components that need it so the separate export is unused.
- We previously moved all deprecated code into the `_deprecated` folder, but were unable to do so with this style as it's not exported separately, but as part of a larger object which is not deprecated. By removing this unused code _all_ deprecated code is now in a single location.
