### PR TITLE
Fix CMP cypress tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ tsconfig.tsbuildinfo
 
 # storybook build dirs
 storybook-static
+
+# cypress stuff
+**/cypress/downloads/

--- a/libs/@guardian/libs/cypress/e2e/consent-management-platform/sourcepoint-tcfv2.cy.js
+++ b/libs/@guardian/libs/cypress/e2e/consent-management-platform/sourcepoint-tcfv2.cy.js
@@ -39,7 +39,7 @@ describe('Document', () => {
 });
 
 describe('Interaction', () => {
-	const buttonTitle = 'Yes, I’m happy';
+	const buttonTitle = 'Yes, I accept';
 
 	it(`should give all consents when clicking "${buttonTitle}"`, () => {
 		cy.visit(url);


### PR DESCRIPTION
## What are you changing?

update the CMP e2e to expect the current version of the CMP

## Why?

the CMP changed, so the cypress test broke

longer term, we should not really be testing for the presence of text in a button in document on the web that is not affected by code in this repo, but for now this stops the tests failing and allows us to publish packages again.