### PR TITLE
Bump `source-react-components` to latest `source-foundations` release

### DIFF
--- a/.changeset/shy-lamps-carry.md
+++ b/.changeset/shy-lamps-carry.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': major
+---
+
+Update dependency on `@guardian/source-foundations`

--- a/libs/@guardian/source-react-components/package.json
+++ b/libs/@guardian/source-react-components/package.json
@@ -28,7 +28,7 @@
 	"devDependencies": {
 		"@babel/core": "7.24.0",
 		"@emotion/react": "11.11.1",
-		"@guardian/source-foundations": "14.2.2",
+		"@guardian/source-foundations": "16.0.0",
 		"@svgr/babel-preset": "8.1.0",
 		"@svgr/core": "8.1.0",
 		"@svgr/plugin-jsx": "8.1.0",
@@ -52,7 +52,7 @@
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.11.1",
-		"@guardian/source-foundations": "^14.2.2",
+		"@guardian/source-foundations": "^16.0.0",
 		"@types/react": "^18.2.11",
 		"react": "^18.2.0",
 		"tslib": "^2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -709,8 +709,8 @@ importers:
         specifier: 11.11.1
         version: 11.11.1(@types/react@18.2.11)(react@18.2.0)
       '@guardian/source-foundations':
-        specifier: 14.2.2
-        version: 14.2.2(tslib@2.6.2)(typescript@5.3.3)
+        specifier: 16.0.0
+        version: 16.0.0(tslib@2.6.2)(typescript@5.3.3)
       '@svgr/babel-preset':
         specifier: 8.1.0
         version: 8.1.0(@babel/core@7.24.0)
@@ -3572,6 +3572,20 @@ packages:
 
   /@guardian/source-foundations@14.2.2(tslib@2.6.2)(typescript@5.3.3):
     resolution: {integrity: sha512-198Akw1RqufsX6Iu/qzqeR4eC9L3ezHURVzMqJeB3ZRZtabdkL2Q562mS1UnSdyACeCLRMqlOXqZDO38gsjP/g==}
+    peerDependencies:
+      tslib: ^2.6.2
+      typescript: ~5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      mini-svg-data-uri: 1.4.4
+      tslib: 2.6.2
+      typescript: 5.3.3
+    dev: true
+
+  /@guardian/source-foundations@16.0.0(tslib@2.6.2)(typescript@5.3.3):
+    resolution: {integrity: sha512-bdRcJTEJ6tGmibGRwhQcY70NMACHCcsnNsiWRwW1fSPpvcAuR4xvXmn3UlaL1U/RO4Yk1YvJjPiV/n9WHnjbjQ==}
     peerDependencies:
       tslib: ^2.6.2
       typescript: ~5.3.3


### PR DESCRIPTION
## What are you changing?

- Bump `@guardian/source-react-components` to `@guardian/source-foundations@16.0.0`
