### PR TITLE
ignore wireit cache dirs when looking for tests

### DIFF
--- a/configs/jest.config.js
+++ b/configs/jest.config.js
@@ -2,7 +2,7 @@
 export const config = {
 	clearMocks: true,
 	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-
+	testPathIgnorePatterns: ['/node_modules/', '/.wireit/'],
 	transformIgnorePatterns: ['node_modules/(?!@guardian)'],
 	transform: {
 		'^.+\\.[tj]sx?$': [


### PR DESCRIPTION
## What are you changing?

ignore `.wireit` dirs in jest

## Why?

so we dont run test files that just live in caches from earlier runs
