### PR TITLE
Production release of `@guardian/source`

### DIFF
--- a/libs/@guardian/source/CHANGELOG.md
+++ b/libs/@guardian/source/CHANGELOG.md
@@ -5,3 +5,11 @@
 ### Minor Changes
 
 - e60f79e: third attempt
+
+## 1.0.0
+
+### Major Changes
+
+#### First production release of single source package.
+
+Combining @guardian/source-react-components and @guardian/source-foundations into single package.

--- a/libs/@guardian/source/CHANGELOG.md
+++ b/libs/@guardian/source/CHANGELOG.md
@@ -28,4 +28,4 @@ import { palette } from '@guardian/source/foundations'
 import { Button } from '@guardian/source/react-components'
 ```
 
-_There will be no more updates the two separate packages. From now on, all updates to Source will come via this single package._
+_There will be no more updates to the two separate packages. From now on, all updates to Source will come via this single package._

--- a/libs/@guardian/source/CHANGELOG.md
+++ b/libs/@guardian/source/CHANGELOG.md
@@ -10,6 +10,22 @@
 
 ### Major Changes
 
-#### First production release of single source package.
+#### First production release of single Source package.
 
-Combining @guardian/source-react-components and @guardian/source-foundations into single package.
+Combining `@guardian/source-foundations@16.0.0` and `@guardian/source-react-components@25.0.0` into single package.
+
+#### Before
+
+```
+import { palette } from '@guardian/source-foundations'
+import { Button } from '@guardian/source-react-components'
+```
+
+#### After
+
+```
+import { palette } from '@guardian/source/foundations'
+import { Button } from '@guardian/source/react-components'
+```
+
+_There will be no more updates the two separate packages. From now on, all updates to Source will come via this single package._

--- a/libs/@guardian/source/package.json
+++ b/libs/@guardian/source/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/source",
-	"version": "0.3.0",
+	"version": "1.0.0",
 	"license": "Apache-2.0",
 	"sideEffects": false,
 	"type": "module",


### PR DESCRIPTION
## What are you changing?

- Combining @guardian/source-react-components and @guardian/source-foundations into single package.

## Why?

- This helps with versioning and helps consumers keep their dependancies in sync

Co-authored-by: James Mockett <1166188+jamesmockett@users.noreply.github.com>
Co-authored-by: Alex Sanders <alex@sndrs.dev>
