### PR TITLE
Make `react` and `@emotion/react` optional `peerDeps` of source

### DIFF
--- a/.changeset/kind-eyes-divide.md
+++ b/.changeset/kind-eyes-divide.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source': patch
+---
+
+Make `react` and `@emotion/react` optional `peerDeps` (you don't need them if you're not using react components).

--- a/libs/@guardian/source/package.json
+++ b/libs/@guardian/source/package.json
@@ -73,7 +73,13 @@
 		"typescript": "~5.3.3"
 	},
 	"peerDependenciesMeta": {
+		"@emotion/react": {
+			"optional": true
+		},
 		"@types/react": {
+			"optional": true
+		},
+		"react": {
 			"optional": true
 		},
 		"typescript": {


### PR DESCRIPTION
## What are you changing?

make `react` and `@emotion/react` optional `peerDeps` of source

## Why?

you don't need them if you're not using react components and i've just noticed we haven't done it!
