### PR TITLE
Sort `package.json` in new Source packages

### DIFF
--- a/libs/@guardian/source-development-kitchen/react-components/package.json
+++ b/libs/@guardian/source-development-kitchen/react-components/package.json
@@ -1,6 +1,6 @@
 {
-	"//": "sub-package to match the `exports` field in the parent package.json",
 	"private": true,
 	"type": "module",
-	"main": "../dist/react-components.js"
+	"main": "../dist/react-components.js",
+	"//": "sub-package to match the `exports` field in the parent package.json"
 }

--- a/libs/@guardian/source/foundations/package.json
+++ b/libs/@guardian/source/foundations/package.json
@@ -1,6 +1,6 @@
 {
-	"//": "sub-package to match the `exports` field in the parent package.json",
 	"private": true,
 	"type": "module",
-	"main": "../dist/foundations.js"
+	"main": "../dist/foundations.js",
+	"//": "sub-package to match the `exports` field in the parent package.json"
 }

--- a/libs/@guardian/source/react-components/package.json
+++ b/libs/@guardian/source/react-components/package.json
@@ -1,6 +1,6 @@
 {
-	"//": "sub-package to match the `exports` field in the parent package.json",
 	"private": true,
 	"type": "module",
-	"main": "../dist/react-components.js"
+	"main": "../dist/react-components.js",
+	"//": "sub-package to match the `exports` field in the parent package.json"
 }


### PR DESCRIPTION
## What are you changing?

- Sorted `package.json` files in new Source packages by running `sort-package-json`.

## Why?

- `sort-package-json` runs as a pre-commit hook. Merging from `main` into branches that existed before these new packages were created may cause these changes to be applied there depending on what files have been touched. It makes sense to apply these changes in a single place rather than an unrelated branch.