### PR TITLE
Remove unused `Button` import

### DIFF
--- a/libs/@guardian/source/src/react-components/inline/Inline.stories.tsx
+++ b/libs/@guardian/source/src/react-components/inline/Inline.stories.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
 import type { Meta, StoryFn } from '@storybook/react';
 import { breakpoints, palette, space } from '../../foundations';
-import { Button } from '../button/Button';
 import type { InlineProps } from './Inline';
 import { Inline } from './Inline';
 


### PR DESCRIPTION
## What are you changing?

- Removes unused `Button` import from `Inline` stories

## Why?

- Button group examples were moved from here to the layout docs, but the import was not removed
