### PR TITLE
Fix import order linting error

### DIFF
--- a/libs/@guardian/source/src/foundations/tokens.test.ts
+++ b/libs/@guardian/source/src/foundations/tokens.test.ts
@@ -1,5 +1,3 @@
-import * as typePresetCss from './__generated__/typography/css';
-import * as typePresetObject from './__generated__/typography/objects';
 import {
 	background,
 	border,
@@ -38,6 +36,8 @@ import {
 	titlepieceSizes,
 	underlineThickness,
 } from './__deprecated__/typography/data';
+import * as typePresetCss from './__generated__/typography/css';
+import * as typePresetObject from './__generated__/typography/objects';
 import { transitions } from './animation/transitions';
 import { breakpoints } from './breakpoints/breakpoints';
 import { palette } from './colour/palette';


### PR DESCRIPTION
## What are you changing?

- Updates import order in token tests to fix linting error

## Why?

- #1517 renamed the deprecated code folder in Source Foundations, but the import order was not updated to reflect this. This _should_ have resulted in a broken build, but the linting task appears to have been cached. The broken build is currently only apparent in Dependabot PRs whilst the build on `main` appears to be fine with a green tick.
