### PR TITLE
Fix maintenance scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Tasks that apply to all projects are defined in the [`Makefile`](./Makefile):
 
 ### Project-specific tasks
 
-Project-specific tasks are defined as `scripts` in a `package.json` or `targets` in a `project.json` files, and can be run with `make <project>:<script>`/`make <project>:<target>`:
+Project-specific tasks are defined as `scripts` in their `package.json`, and can be run with `make <project>:<script>`:
 
 #### @guardian/ab-core
 

--- a/tools/scripts/maintain-makefile/index.mjs
+++ b/tools/scripts/maintain-makefile/index.mjs
@@ -47,15 +47,20 @@ const tasksList = [
 	'',
 ];
 
-for (const task of tasks) {
-	const escapedTaskName = task.replace(/:/g, '\\:');
-	const [project, script] = task.split(':');
+for (const pkgTasks of tasks) {
+	const [pkg, scripts] = pkgTasks;
 
-	tasksList.push(`.PHONY: ${escapedTaskName}`);
-	tasksList.push(`${escapedTaskName}: env`);
-	tasksList.push(`	@corepack pnpm --filter ${project} ${script}`);
-	tasksList.push('');
+	for (const script of scripts) {
+		const makeTarget = `${pkg}:${script}`.replace(/:/g, '\\:');
+
+		tasksList.push(`.PHONY: ${makeTarget}`);
+		tasksList.push(`${makeTarget}: env`);
+		tasksList.push(`	@corepack pnpm --filter ${pkg} ${script}`);
+		tasksList.push('');
+	}
 }
+
+console.log(tasksList);
 
 contents = updateSection({
 	contents,

--- a/tools/scripts/maintain-readme/index.mjs
+++ b/tools/scripts/maintain-readme/index.mjs
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'node:url';
 import { pathFromRoot, projectRoot } from '../project-paths.mjs';
 import { getPackageList } from './get-package-list.mjs';
 import { getMakeTargets } from '../lib/get-make-targets.mjs';
+import { format } from 'prettier';
+import prettierConfig from '@guardian/prettier';
 import { getTasks } from '../lib/get-tasks.mjs';
 import _updateSection from 'update-section';
 
@@ -56,18 +58,22 @@ const tasks = await getTasks();
 
 const tasksList = [
 	'### Project-specific tasks',
-	'Project-specific tasks are defined as `scripts` in a `package.json` or `targets` in a `project.json` files, and can be run with `make <project>:<script>`/`make <project>:<target>`:',
+	'Project-specific tasks are defined as `scripts` in their `package.json`, and can be run with `make <project>:<script>`:',
 	'',
 ];
 
 let currentProject = '';
-for (const task of tasks) {
-	const thisProject = task.split(':')[0];
+for (const pkgTasks of tasks) {
+	const [thisProject, scripts] = pkgTasks;
+
 	if (thisProject !== currentProject) {
 		currentProject = thisProject;
 		tasksList.push(`#### ${currentProject}`);
 	}
-	tasksList.push(`- \`make ${task}\``);
+
+	for (const script of scripts) {
+		tasksList.push(`- \`make ${thisProject}:${script}\``);
+	}
 }
 
 contents = updateSection({
@@ -77,4 +83,7 @@ contents = updateSection({
 	updater: thisFilePathFromRoot,
 });
 
-await writeFile(readMePath, contents);
+await writeFile(
+	readMePath,
+	await format(contents, { filepath: readMePath, ...prettierConfig }),
+);


### PR DESCRIPTION
## What are you changing?

updates the readme/makefile maintenance scripts

## Why?

- handles npm-scripts with `:` in their name (for #1510)
- formats changes to readme with prettier (should fix clashes between unformatted changes to readme and commit hook failing)
- removed ref to Nx projects in readme
