### PR TITLE
Test: browser default underline styles

### DIFF
--- a/libs/@guardian/source/src/react-components/link/styles.ts
+++ b/libs/@guardian/source/src/react-components/link/styles.ts
@@ -13,19 +13,12 @@ export const link = css`
 	${textSans17};
 	cursor: pointer;
 	text-decoration: underline;
-	text-underline-position: under;
-	text-underline-offset: 5%;
 
 	display: inline;
 	align-items: center;
 
 	&:focus {
 		${focusHalo};
-	}
-
-	&:hover {
-		/* If the hover text decoration thickness is not set, we default to the initial value. */
-		text-decoration-thickness: var(--source-text-decoration-thickness, auto);
 	}
 `;
 


### PR DESCRIPTION
## What are you changing?

- Removes custom link underline styles

## Why?

- The Design System team are considering removing these in favour of default styles, so this is so they can see how it looks in the browser

## Screenshots

> [!note]
> All screenshots are from macOS

### Basic link

| Chrome | Safari | Firefox |
| --- | --- | --- |
| <img width="179" alt="Screenshot 2024-06-13 at 16 45 39" src="https://github.com/guardian/csnx/assets/1166188/333aee0f-113d-411c-bcdf-601bfa257743"> | <img width="175" alt="Screenshot 2024-06-13 at 16 45 48" src="https://github.com/guardian/csnx/assets/1166188/3f5dba2e-defa-4cb4-b672-4a57a0ba321d"> | <img width="183" alt="Screenshot 2024-06-13 at 16 47 17" src="https://github.com/guardian/csnx/assets/1166188/0c2bb03d-6563-49a6-96e0-b6a8b4a3ca77"> |

### Additional examples

#### Chrome

<img width="752" alt="Screenshot 2024-06-13 at 16 44 42" src="https://github.com/guardian/csnx/assets/1166188/3b0ec1a7-1561-4686-ad49-58cb43d81e6f">
<img width="719" alt="Screenshot 2024-06-13 at 16 44 49" src="https://github.com/guardian/csnx/assets/1166188/f99707a1-513c-4a54-b35b-ec0337114739">

#### Safari

<img width="880" alt="Screenshot 2024-06-13 at 16 45 07" src="https://github.com/guardian/csnx/assets/1166188/3d3a9971-145f-4e27-ac3a-034efca9f220">
<img width="723" alt="Screenshot 2024-06-13 at 16 45 17" src="https://github.com/guardian/csnx/assets/1166188/ebeafbee-5d69-4061-8ce3-81232803f7b8">

#### Firefox

<img width="877" alt="Screenshot 2024-06-13 at 16 46 56" src="https://github.com/guardian/csnx/assets/1166188/8cb54083-85b0-41da-9895-8f70cc821fae">
<img width="724" alt="Screenshot 2024-06-13 at 16 47 05" src="https://github.com/guardian/csnx/assets/1166188/9c59af53-d4c6-4aa6-8cfd-2e78a5367df6">
