### PR TITLE
WIP: Refactor button styling

### DIFF
--- a/libs/@guardian/source/src/react-components/button/Button.tsx
+++ b/libs/@guardian/source/src/react-components/button/Button.tsx
@@ -49,6 +49,7 @@ export const Button = ({
 		{...props}
 	>
 		{buttonContents({
+			size,
 			hideLabel,
 			iconSvg,
 			isLoading,

--- a/libs/@guardian/source/src/react-components/button/LinkButton.tsx
+++ b/libs/@guardian/source/src/react-components/button/LinkButton.tsx
@@ -4,7 +4,7 @@ import { buttonContents } from './shared';
 import { buttonStyles } from './styles';
 
 export interface LinkButtonProps
-	extends SharedButtonProps,
+	extends Omit<SharedButtonProps, 'isLoading' | 'loadingAnnouncement'>,
 		AnchorHTMLAttributes<HTMLAnchorElement> {}
 
 /**

--- a/libs/@guardian/source/src/react-components/button/LinkButton.tsx
+++ b/libs/@guardian/source/src/react-components/button/LinkButton.tsx
@@ -42,6 +42,7 @@ export const LinkButton = ({
 		{...props}
 	>
 		{buttonContents({
+			size,
 			hideLabel,
 			iconSvg,
 			children,

--- a/libs/@guardian/source/src/react-components/button/shared.tsx
+++ b/libs/@guardian/source/src/react-components/button/shared.tsx
@@ -3,13 +3,32 @@ import type { ReactElement, ReactNode } from 'react';
 import { cloneElement } from 'react';
 import { visuallyHidden } from '../../foundations';
 import { Spinner } from '../spinner/Spinner';
+import { IconProps, IconSize } from '../@types/Icons';
+import { Size } from './@types/SharedButtonProps';
+
+const iconSize: Record<Size, IconSize> = {
+	xsmall: 'xsmall',
+	small: 'small',
+	default: 'medium',
+};
+
+/**
+ * Spinners do not use the same icon sizes so we specify custom sizes in pixels
+ */
+const spinnerSize: Record<Size, number> = {
+	xsmall: 16,
+	small: 20,
+	default: 24,
+};
 
 export const buttonContents = ({
+	size = 'default',
 	hideLabel,
 	iconSvg,
 	isLoading,
 	children,
 }: {
+	size?: Size;
 	hideLabel?: boolean;
 	iconSvg?: ReactElement;
 	isLoading?: boolean;
@@ -22,23 +41,26 @@ export const buttonContents = ({
 			contents.push(<div key="space" className="src-button-space" />);
 		}
 		contents.push(
-			cloneElement(
-				<Spinner
-					theme={{
-						background: 'transparent',
-						color: 'currentColor',
-					}}
-				/>,
-				{
-					key: 'svg',
-				},
-			),
+			<Spinner
+				size={spinnerSize[size]}
+				theme={{
+					background: 'transparent',
+					color: 'currentColor',
+				}}
+				key="spinner"
+			/>,
 		);
 	} else if (iconSvg) {
 		if (!hideLabel) {
 			contents.push(<div key="space" className="src-button-space" />);
 		}
-		contents.push(cloneElement(iconSvg, { key: 'svg' }));
+		contents.push(
+			cloneElement(iconSvg as ReactElement<IconProps>, {
+				size: iconSize[size],
+				theme: { fill: 'currentColor' },
+				key: 'icon',
+			}),
+		);
 	}
 	if (hideLabel) {
 		return (

--- a/libs/@guardian/source/src/react-components/button/shared.tsx
+++ b/libs/@guardian/source/src/react-components/button/shared.tsx
@@ -2,9 +2,9 @@ import { css } from '@emotion/react';
 import type { ReactElement, ReactNode } from 'react';
 import { cloneElement } from 'react';
 import { visuallyHidden } from '../../foundations';
+import type { IconProps, IconSize } from '../@types/Icons';
 import { Spinner } from '../spinner/Spinner';
-import { IconProps, IconSize } from '../@types/Icons';
-import { Size } from './@types/SharedButtonProps';
+import type { Size } from './@types/SharedButtonProps';
 
 const iconSize: Record<Size, IconSize> = {
 	xsmall: 'xsmall',

--- a/libs/@guardian/source/src/react-components/button/styles.ts
+++ b/libs/@guardian/source/src/react-components/button/styles.ts
@@ -42,26 +42,6 @@ const button = css`
 	}
 `;
 
-// Width of the loading spinner in pixels for each button size.
-const loadingSpinnerSizes: Record<Size, number> = {
-	xsmall: 16,
-	small: 20,
-	default: 24,
-};
-
-const applyButtonStylesToLoadingSpinner = (size: Size) => {
-	return css`
-		svg {
-			/*
-		 * The loading spinner width has been specified as 24px in the design
-		 * which falls outside of the icon sizes in foundations, so we
-		 * override the width here.
-		 */
-			width: ${loadingSpinnerSizes[size]}px;
-		}
-	`;
-};
-
 const primary = (button: ThemeButton): SerializedStyles => css`
 	background-color: ${button.backgroundPrimary};
 	color: ${button.textPrimary};
@@ -143,10 +123,7 @@ const iconDefault = css`
 	svg {
 		flex: 0 0 auto;
 		display: block;
-		fill: currentColor;
 		position: relative;
-		width: ${width.iconMedium}px;
-		height: auto;
 	}
 	.src-button-space {
 		width: ${space[3]}px;
@@ -157,10 +134,7 @@ const iconSmall = css`
 	svg {
 		flex: 0 0 auto;
 		display: block;
-		fill: currentColor;
 		position: relative;
-		width: ${width.iconSmall}px;
-		height: auto;
 	}
 	.src-button-space {
 		width: ${space[2]}px;
@@ -171,10 +145,7 @@ const iconXsmall = css`
 	svg {
 		flex: 0 0 auto;
 		display: block;
-		fill: currentColor;
 		position: relative;
-		width: ${width.iconXsmall}px;
-		height: auto;
 	}
 	.src-button-space {
 		width: ${space[1]}px;
@@ -193,6 +164,7 @@ const iconLeft = css`
 		margin-left: ${pullIconTowardEdge}px;
 	}
 `;
+
 const iconRight = css`
 	svg {
 		margin-right: ${pullIconTowardEdge}px;
@@ -296,6 +268,5 @@ export const buttonStyles =
 		(iconSvg ?? isLoading) && !hideLabel ? iconSides[iconSide] : '',
 		nudgeIcon ? iconNudgeAnimation : '',
 		hideLabel ? iconOnlySizes[size] : '',
-		isLoading ? applyButtonStylesToLoadingSpinner(size) : undefined,
 		cssOverrides,
 	];

--- a/libs/@guardian/source/src/react-components/button/styles.ts
+++ b/libs/@guardian/source/src/react-components/button/styles.ts
@@ -40,6 +40,12 @@ const button = css`
 	&:focus {
 		${focusHaloSpaced};
 	}
+
+	svg {
+		flex: 0 0 auto;
+		display: block;
+		position: relative;
+	}
 `;
 
 const primary = (button: ThemeButton): SerializedStyles => css`
@@ -99,6 +105,10 @@ const defaultSize = css`
 	padding: 0 ${space[5]}px;
 	border-radius: ${height.ctaMedium}px;
 	padding-bottom: 2px;
+
+	.src-button-space {
+		width: ${space[3]}px;
+	}
 `;
 
 const smallSize = css`
@@ -108,6 +118,10 @@ const smallSize = css`
 	padding: 0 ${space[4]}px;
 	border-radius: ${height.ctaSmall}px;
 	padding-bottom: 2px;
+
+	.src-button-space {
+		width: ${space[2]}px;
+	}
 `;
 
 const xsmallSize = css`
@@ -117,44 +131,16 @@ const xsmallSize = css`
 	padding: 0 ${space[3]}px;
 	border-radius: ${height.ctaXsmall}px;
 	padding-bottom: 1px;
-`;
 
-const iconDefault = css`
-	svg {
-		flex: 0 0 auto;
-		display: block;
-		position: relative;
-	}
-	.src-button-space {
-		width: ${space[3]}px;
-	}
-`;
-
-const iconSmall = css`
-	svg {
-		flex: 0 0 auto;
-		display: block;
-		position: relative;
-	}
-	.src-button-space {
-		width: ${space[2]}px;
-	}
-`;
-
-const iconXsmall = css`
-	svg {
-		flex: 0 0 auto;
-		display: block;
-		position: relative;
-	}
 	.src-button-space {
 		width: ${space[1]}px;
 	}
 `;
 
-/* TODO: we add some negative margin to icons to account for
- the extra space encoded into the SVG. We should consider removing
- or significantly reducing this space
+/**
+ * TODO: we add some negative margin to icons to account for the extra space
+ * encoded into the SVG. We should consider removing or significantly reducing
+ * this space.
  */
 const pullIconTowardEdge = -space[1];
 
@@ -171,22 +157,18 @@ const iconRight = css`
 	}
 `;
 
-const iconOnly = css`
-	padding: 0;
-`;
-
 const iconOnlyDefault = css`
-	${iconOnly};
+	padding: 0;
 	width: ${width.ctaMedium}px;
 `;
 
 const iconOnlySmall = css`
-	${iconOnly};
+	padding: 0;
 	width: ${width.ctaSmall}px;
 `;
 
 const iconOnlyXsmall = css`
-	${iconOnly};
+	padding: 0;
 	width: ${width.ctaXsmall}px;
 `;
 
@@ -226,13 +208,7 @@ const sizes: {
 	small: smallSize,
 	xsmall: xsmallSize,
 };
-const iconSizes: {
-	[key in Size]: SerializedStyles;
-} = {
-	default: iconDefault,
-	small: iconSmall,
-	xsmall: iconXsmall,
-};
+
 const iconOnlySizes: {
 	[key in Size]: SerializedStyles;
 } = {
@@ -264,7 +240,6 @@ export const buttonStyles =
 		button,
 		sizes[size],
 		priorities[priority](mergedTheme(providerTheme.button, theme)),
-		iconSvg ?? isLoading ? iconSizes[size] : '',
 		(iconSvg ?? isLoading) && !hideLabel ? iconSides[iconSide] : '',
 		nudgeIcon ? iconNudgeAnimation : '',
 		hideLabel ? iconOnlySizes[size] : '',


### PR DESCRIPTION
## What are you changing?

- Removes CSS overrides for icon / spinner size and colour in favour of `size` and `theme` prop
- Removes `isLoading` and `loadingAnnouncement` props from `LinkButton` as these are unsupported
- Refactors styles to simplify and remove duplication

## Why?

- Using props rather than CSS overrides makes styling more predictable
- Simplifying the styles makes things easier to understand and update

## To do

- [ ] Replace spacer `<div>`