### PR TITLE
Remove Google Analytics from vendor list in cmp

### DIFF
--- a/.changeset/cool-bobcats-hug.md
+++ b/.changeset/cool-bobcats-hug.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Remove GA from cmp vendorlist

--- a/.changeset/cool-bobcats-hug.md
+++ b/.changeset/cool-bobcats-hug.md
@@ -1,5 +1,5 @@
 ---
-'@guardian/libs': minor
+'@guardian/libs': major
 ---
 
 Remove GA from cmp vendorlist

--- a/libs/@guardian/libs/src/consent-management-platform/vendors.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/vendors.ts
@@ -20,7 +20,6 @@ export const TCFV2VendorIDs: VendorIDType = {
 	braze: ['5ed8c49c4b8ce4571c7ad801'],
 	comscore: ['5efefe25b8e05c06542b2a77'],
 	criteo: ['5e98e7f1b8e05c111d01b462'],
-	'google-analytics': ['5e542b3a4cd8884eb41b5a72'],
 	'google-mobile-ads': ['5f1aada6b8e05c306c0597d7'],
 	'google-tag-manager': ['5e952f6107d9d20c88e7c975'],
 	googletag: ['5f1aada6b8e05c306c0597d7'],


### PR DESCRIPTION
## What are you changing?
Remove Google Analytics from the vendor list

## Why?
We've removed it from our codebase in https://github.com/guardian/commercial/pull/1393, https://github.com/guardian/dotcom-rendering/pull/11470 and https://github.com/guardian/frontend/pull/27188

And presumably sourcepoint as, [`vendors.test.ts`](https://github.com/guardian/csnx/blob/main/libs/%40guardian/libs/src/consent-management-platform/vendors.test.js) is failing in my PR #1507 

The unit test is not deterministic, checking the vendorlist matches sourcepoint should probably be done in e2e tests not unit tests.