### PR TITLE
Remove google analytics vendor

### DIFF
--- a/libs/@guardian/libs/src/consent-management-platform/vendors.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/vendors.ts
@@ -20,7 +20,6 @@ export const TCFV2VendorIDs: VendorIDType = {
 	braze: ['5ed8c49c4b8ce4571c7ad801'],
 	comscore: ['5efefe25b8e05c06542b2a77'],
 	criteo: ['5e98e7f1b8e05c111d01b462'],
-	'google-analytics': ['5e542b3a4cd8884eb41b5a72'],
 	'google-mobile-ads': ['5f1aada6b8e05c306c0597d7'],
 	'google-tag-manager': ['5e952f6107d9d20c88e7c975'],
 	googletag: ['5f1aada6b8e05c306c0597d7'],


### PR DESCRIPTION
## What are you changing?
- Removing the google analytics vendor from the list of tcfv2 vendors.

## Why?

- This vendor has been removed from the tcfv2 vendor list in Sourcepoint.
