### PR TITLE
getConsentFor handle unknown ids

### DIFF
--- a/.changeset/plenty-grapes-cross.md
+++ b/.changeset/plenty-grapes-cross.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': patch
+---
+
+Fix vendor data removal and more strictly type arguments for `getConsentFor`

--- a/libs/@guardian/libs/src/consent-management-platform/getConsentFor.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/getConsentFor.ts
@@ -8,7 +8,7 @@ export const getConsentFor: GetConsentFor = (
 ): boolean => {
 	const sourcepointIds = VendorIDs[vendor];
 
-	if (typeof sourcepointIds === 'undefined' || Array.isArray(sourcepointIds)) {
+	if (typeof sourcepointIds === 'undefined' || sourcepointIds.length === 0) {
 		throw new Error(
 			`Vendor '${vendor}' not found, or with no Sourcepoint ID. ` +
 				'If it should be added, raise an issue at https://github.com/guardian/consent-management-platform/issues',

--- a/libs/@guardian/libs/src/consent-management-platform/getConsentFor.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/getConsentFor.ts
@@ -8,10 +8,7 @@ export const getConsentFor: GetConsentFor = (
 ): boolean => {
 	const sourcepointIds = VendorIDs[vendor];
 
-	if (
-		typeof sourcepointIds === 'undefined' ||
-		(Array.isArray(sourcepointIds) && sourcepointIds.length === 0)
-	) {
+	if (typeof sourcepointIds === 'undefined' || Array.isArray(sourcepointIds)) {
 		throw new Error(
 			`Vendor '${vendor}' not found, or with no Sourcepoint ID. ` +
 				'If it should be added, raise an issue at https://github.com/guardian/consent-management-platform/issues',

--- a/libs/@guardian/libs/src/consent-management-platform/vendorDataManager.test.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/vendorDataManager.test.ts
@@ -4,7 +4,10 @@ import { onConsentChange } from './onConsentChange';
 import type { ConsentState, OnConsentChangeCallback } from './types';
 import type { TCFv2ConsentState } from './types/tcfv2';
 import { initVendorDataManager } from './vendorDataManager';
-import { vendorStorageIds } from './vendorStorageIds';
+import {
+	deprecatedVendorStorageIds,
+	vendorStorageIds,
+} from './vendorStorageIds';
 
 jest.mock('./onConsentChange');
 
@@ -38,6 +41,11 @@ jest.mock('./vendorStorageIds', () => ({
 			cookies: ['ipsosCookie1', 'ipsosCookie2'],
 			localStorage: ['ipsosLocalStorage1', 'ipsosLocalStorage2'],
 			sessionStorage: ['ipsosSessionStorage1'],
+		},
+	},
+	deprecatedVendorStorageIds: {
+		'google-analytics': {
+			cookies: ['someCookie'],
 		},
 	},
 }));
@@ -92,6 +100,10 @@ describe('initVendorDataManager', () => {
 
 		vendorStorageIds.ipsos.localStorage.forEach((name) => {
 			expect(storage.local.remove).not.toHaveBeenCalledWith(name);
+		});
+
+		deprecatedVendorStorageIds['google-analytics'].cookies.forEach((name) => {
+			expect(removeCookie).toHaveBeenCalledWith({ name });
 		});
 	});
 });

--- a/libs/@guardian/libs/src/consent-management-platform/vendorStorageIds.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/vendorStorageIds.ts
@@ -1,5 +1,11 @@
 import type { VendorName } from './vendors';
 
+export type VendorData = {
+	cookies?: string[];
+	localStorage?: string[];
+	sessionStorage?: string[];
+};
+
 /**
  * This is a list of vendors that store data in localStorage or cookies along with the keys they use (that we know of).
  */
@@ -59,18 +65,15 @@ export const vendorStorageIds = {
 		localStorage: ['_psegs', '_pubcid_exp'],
 	},
 	googletag: { cookies: ['__gpi', '__gads'] },
+} satisfies Partial<Record<VendorName, VendorData>>;
+
+/**
+ * These are vendors that are no longer in use and no longer exist in sourcepoint so we should remove their data.
+ */
+export const deprecatedVendorStorageIds = {
 	'google-analytics': {
 		cookies: ['_gid', '_ga'],
 	},
-} satisfies Partial<
-	Record<
-		VendorName,
-		{
-			cookies?: string[];
-			localStorage?: string[];
-			sessionStorage?: string[];
-		}
-	>
->;
+} satisfies Partial<Record<string, VendorData>>;
 
 export type VendorWithData = keyof typeof vendorStorageIds;

--- a/libs/@guardian/libs/src/consent-management-platform/vendors.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/vendors.ts
@@ -11,9 +11,7 @@
  * Important: Keep in sync with list of vendors in README.md
  * *********************/
 
-type VendorIDType = Record<string, string[]>;
-
-export const TCFV2VendorIDs: VendorIDType = {
+export const TCFV2VendorIDs = {
 	// keep the list in README.md up to date with these values
 	a9: ['5f369a02b8e05c308701f829'],
 	acast: ['5f203dcb1f0dea790562e20f'],
@@ -37,20 +35,20 @@ export const TCFV2VendorIDs: VendorIDType = {
 	teads: ['5eab3d5ab8e05c2bbe33f399'],
 	twitter: ['5e71760b69966540e4554f01'],
 	'youtube-player': ['5e7ac3fae30e7d1bc1ebf5e8'],
-};
+} as const;
 
-export const MiscVendorID: VendorIDType = {
+export const MiscVendorID = {
 	prebid: ['5f92a62aa22863685f4daa4c'],
-};
+} as const;
 
-export const AusVendorIDs: VendorIDType = {
+export const AusVendorIDs = {
 	redplanet: ['not-tcfv2-vendor'],
-};
+} as const;
 
-export const VendorIDs: VendorIDType = {
+export const VendorIDs = {
 	...TCFV2VendorIDs,
 	...AusVendorIDs,
 	...MiscVendorID,
-};
+} as const;
 
 export type VendorName = keyof typeof VendorIDs;

--- a/libs/@guardian/libs/src/consent-management-platform/vendors.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/vendors.ts
@@ -11,6 +11,8 @@
  * Important: Keep in sync with list of vendors in README.md
  * *********************/
 
+type VendorIDType = Record<string, string[]>;
+
 export const TCFV2VendorIDs = {
 	// keep the list in README.md up to date with these values
 	a9: ['5f369a02b8e05c308701f829'],
@@ -35,15 +37,15 @@ export const TCFV2VendorIDs = {
 	teads: ['5eab3d5ab8e05c2bbe33f399'],
 	twitter: ['5e71760b69966540e4554f01'],
 	'youtube-player': ['5e7ac3fae30e7d1bc1ebf5e8'],
-} as const;
+} satisfies VendorIDType;
 
 export const MiscVendorID = {
 	prebid: ['5f92a62aa22863685f4daa4c'],
-} as const;
+} satisfies VendorIDType;
 
 export const AusVendorIDs = {
 	redplanet: ['not-tcfv2-vendor'],
-} as const;
+} satisfies VendorIDType;
 
 export const VendorIDs = {
 	...TCFV2VendorIDs,


### PR DESCRIPTION
## What are you changing?
move `google-analytics` to a new part of `vendorDataManager` that will remove its keys even if the id is no longer in the vendorlist.

This is currently throwing an error as the `vendorDataManager` checks for consent before removing a key.

This also narrows the type of `getConsentFor` and the vendorlist to catch errors in the future.

## Why?
If we remove a vendor we still want to be removing it's data from cookies/localStorage.

