### PR TITLE
Ignore `coverage` in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
 	"bumpVersionsWithWorkspaceProtocolOnly": true,
-	"ignore": ["github-pages", "@configs/*"],
+	"ignore": ["github-pages", "@configs/*", "coverage"],
 	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
 		"onlyUpdatePeerDependentsWhenOutOfRange": true
 	}


### PR DESCRIPTION
## What are you changing?

set changesets to ignore the `coverage` package

## Why?

it's breaking canaries in #1507 
