### PR TITLE
Remove timeline from format

### DIFF
--- a/.changeset/spicy-dolphins-lay.md
+++ b/.changeset/spicy-dolphins-lay.md
@@ -2,4 +2,6 @@
 '@guardian/libs': major
 ---
 
-Remove timeline from the format
+Removes `Timeline` from `ArticleFormat.design`.
+
+Timelines are now distinct elements, rather than a part of `ArticleFormat`. 

--- a/.changeset/spicy-dolphins-lay.md
+++ b/.changeset/spicy-dolphins-lay.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': major
+---
+
+Remove timeline from the format

--- a/libs/@guardian/libs/src/format/ArticleDesign.ts
+++ b/libs/@guardian/libs/src/format/ArticleDesign.ts
@@ -24,6 +24,5 @@ export enum ArticleDesign {
 	Correction,
 	FullPageInteractive,
 	NewsletterSignup,
-	Timeline,
 	Profile,
 }


### PR DESCRIPTION
## What are you changing?
Remove timeline from Format. 

## Why?
Timelines are now a distinct element, rather than a format design. As such, we would like to remove the timeline design to help enforce usage of the new element and reduce confusion in the codebase.