### PR TITLE
Add web vital attribution data

### DIFF
--- a/.changeset/brave-dryers-fix.md
+++ b/.changeset/brave-dryers-fix.md
@@ -1,0 +1,5 @@
+---
+'@guardian/core-web-vitals': major
+---
+
+Update endpoint and send attribution data to big query

--- a/.changeset/brave-dryers-fix.md
+++ b/.changeset/brave-dryers-fix.md
@@ -1,5 +1,0 @@
----
-'@guardian/core-web-vitals': major
----
-
-Update endpoint and send attribution data to big query

--- a/.changeset/shiny-squids-protect.md
+++ b/.changeset/shiny-squids-protect.md
@@ -1,0 +1,5 @@
+---
+'@guardian/core-web-vitals': major
+---
+
+This major change adds attribution data on 3 core web vital metrics; CLS, INP, and LCP. It also updates the endpoint so that this data will now be sent to a new table in big query. We now send the stage as a value to big query, rather than using separate endpoints. In addition, null values have been removed in favour of undefined.

--- a/libs/@guardian/core-web-vitals/package.json
+++ b/libs/@guardian/core-web-vitals/package.json
@@ -33,14 +33,14 @@
 		"ts-jest": "29.1.1",
 		"tslib": "2.6.2",
 		"typescript": "5.3.3",
-		"web-vitals": "3.5.0",
+		"web-vitals": "4.2.0",
 		"wireit": "0.14.4"
 	},
 	"peerDependencies": {
 		"@guardian/libs": "^16.0.0",
 		"tslib": "^2.6.2",
 		"typescript": "~5.3.3",
-		"web-vitals": "^3.5.0"
+		"web-vitals": "^4.2.0"
 	},
 	"peerDependenciesMeta": {
 		"typescript": {

--- a/libs/@guardian/core-web-vitals/src/@types/CoreWebVitalsPayload.ts
+++ b/libs/@guardian/core-web-vitals/src/@types/CoreWebVitalsPayload.ts
@@ -1,14 +1,14 @@
 export type CoreWebVitalsPayload = {
-	page_view_id: string | null;
-	browser_id: string | null;
-	cls: null | number;
-	cls_target: null | string;
-	inp: null | number;
-	inp_target: null | string;
-	lcp: null | number;
-	lcp_target: null | string;
-	fid: null | number;
-	fcp: null | number;
-	ttfb: null | number;
-	stage: 'CODE' | 'PROD' | null;
+	page_view_id: string;
+	browser_id: string;
+	cls: number;
+	cls_target: string;
+	inp: number;
+	inp_target: string;
+	lcp: number;
+	lcp_target: string;
+	fid: number;
+	fcp: number;
+	ttfb: number;
+	stage: 'CODE' | 'PROD';
 };

--- a/libs/@guardian/core-web-vitals/src/@types/CoreWebVitalsPayload.ts
+++ b/libs/@guardian/core-web-vitals/src/@types/CoreWebVitalsPayload.ts
@@ -10,4 +10,5 @@ export type CoreWebVitalsPayload = {
 	fid: null | number;
 	fcp: null | number;
 	ttfb: null | number;
+	stage: 'CODE' | 'PROD' | null;
 };

--- a/libs/@guardian/core-web-vitals/src/@types/CoreWebVitalsPayload.ts
+++ b/libs/@guardian/core-web-vitals/src/@types/CoreWebVitalsPayload.ts
@@ -1,10 +1,13 @@
 export type CoreWebVitalsPayload = {
 	page_view_id: string | null;
 	browser_id: string | null;
-	fid: null | number;
 	cls: null | number;
+	cls_target: null | string;
+	inp: null | number;
+	inp_target: null | string;
 	lcp: null | number;
+	lcp_target: null | string;
+	fid: null | number;
 	fcp: null | number;
 	ttfb: null | number;
-	inp: null | number;
 };

--- a/libs/@guardian/core-web-vitals/src/index.test.ts
+++ b/libs/@guardian/core-web-vitals/src/index.test.ts
@@ -4,7 +4,7 @@ import type {
 	FIDMetric,
 	INPMetricWithAttribution,
 	LCPMetricWithAttribution,
-	ReportHandler,
+	ReportCallback,
 	TTFBMetric,
 } from 'web-vitals';
 import type { CoreWebVitalsPayload } from './@types/CoreWebVitalsPayload';
@@ -74,7 +74,7 @@ jest.mock('web-vitals/attribution', () => ({
 			id: 'inp',
 		} satisfies INPMetricWithAttribution);
 	},
-	onTTFB: (onReport: ReportHandler) => {
+	onTTFB: (onReport: ReportCallback) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.ttfb,
 			name: 'TTFB',
@@ -85,7 +85,7 @@ jest.mock('web-vitals/attribution', () => ({
 			navigationType: 'navigate',
 		} satisfies TTFBMetric);
 	},
-	onFCP: (onReport: ReportHandler) => {
+	onFCP: (onReport: ReportCallback) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.fcp,
 			name: 'FCP',
@@ -96,7 +96,7 @@ jest.mock('web-vitals/attribution', () => ({
 			navigationType: 'navigate',
 		} satisfies FCPMetric);
 	},
-	onFID: (onReport: ReportHandler) => {
+	onFID: (onReport: ReportCallback) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.fid,
 			name: 'FID',

--- a/libs/@guardian/core-web-vitals/src/index.test.ts
+++ b/libs/@guardian/core-web-vitals/src/index.test.ts
@@ -364,7 +364,7 @@ describe('web-vitals', () => {
 		const isDev = true;
 		await initCoreWebVitals({ browserId, pageViewId, isDev, sampling: 1 });
 
-		_.coreWebVitalsPayload.fcp = null; // simulate a failing FCP
+		_.coreWebVitalsPayload.fcp = undefined; // simulate a failing FCP
 
 		setVisibilityState('hidden');
 		global.dispatchEvent(new Event('visibilitychange'));

--- a/libs/@guardian/core-web-vitals/src/index.test.ts
+++ b/libs/@guardian/core-web-vitals/src/index.test.ts
@@ -170,14 +170,16 @@ describe('coreWebVitals', () => {
 		global.dispatchEvent(new Event('pagehide'));
 
 		expect(mockBeacon).toHaveBeenCalledTimes(0);
-		expect(coreWebVitalsPayload).toMatchObject({
-			fid: null,
-			fcp: null,
-			lcp: null,
-			ttfb: null,
-			cls: null,
-			inp: null,
-		});
+		expect(coreWebVitalsPayload).toEqual(
+			expect.not.objectContaining({
+				fid: expect.anything(),
+				fcp: expect.anything(),
+				lcp: expect.anything(),
+				ttfb: expect.anything(),
+				cls: expect.anything(),
+				inp: expect.anything(),
+			}),
+		);
 	});
 
 	it('sends a beacon if sampling at 0% but bypassed via hash', async () => {
@@ -261,7 +263,7 @@ describe('Warnings', () => {
 		expect(mockConsoleWarn).toHaveBeenCalledWith(
 			'browserId or pageViewId missing from Core Web Vitals.',
 			expect.any(String),
-			expect.objectContaining({ browserId: null }),
+			expect.objectContaining({ browserId: undefined }),
 		);
 	});
 
@@ -271,7 +273,7 @@ describe('Warnings', () => {
 		expect(mockConsoleWarn).toHaveBeenCalledWith(
 			'browserId or pageViewId missing from Core Web Vitals.',
 			expect.any(String),
-			expect.objectContaining({ pageViewId: null }),
+			expect.objectContaining({ pageViewId: undefined }),
 		);
 	});
 

--- a/libs/@guardian/core-web-vitals/src/index.test.ts
+++ b/libs/@guardian/core-web-vitals/src/index.test.ts
@@ -33,14 +33,14 @@ const pageViewId = defaultCoreWebVitalsPayload.page_view_id;
 jest.mock('web-vitals/attribution', () => ({
 	onCLS: (onReport: (metric: CLSMetricWithAttribution) => void) => {
 		onReport({
-			id: 'cls',
-			navigationType: 'navigate',
-			attribution: {
-				largestShiftValue: 0.1,
-			},
 			value: defaultCoreWebVitalsPayload.cls,
 			name: 'CLS',
+			id: 'cls',
+			attribution: {
+				largestShiftTarget: 'ad',
+			},
 			entries: [],
+			navigationType: 'navigate',
 			rating: 'good',
 			delta: defaultCoreWebVitalsPayload.cls,
 		} satisfies CLSMetricWithAttribution);
@@ -49,29 +49,32 @@ jest.mock('web-vitals/attribution', () => ({
 		onReport({
 			value: defaultCoreWebVitalsPayload.lcp,
 			name: 'LCP',
-			entries: [],
-			rating: 'good',
 			id: 'lcp',
-			navigationType: 'navigate',
-			delta: defaultCoreWebVitalsPayload.lcp,
 			attribution: {
+				element: 'mainMedia',
 				timeToFirstByte: 0,
 				resourceLoadDelay: 0,
 				resourceLoadTime: 0,
 				elementRenderDelay: 0,
 			},
+			entries: [],
+			navigationType: 'navigate',
+			rating: 'good',
+			delta: defaultCoreWebVitalsPayload.lcp,
 		} satisfies LCPMetricWithAttribution);
 	},
 	onINP: (onReport: (metric: INPMetricWithAttribution) => void) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.inp,
 			name: 'INP',
+			id: 'inp',
+			attribution: {
+				eventTarget: 'adSlot',
+			},
 			entries: [],
+			navigationType: 'navigate',
 			rating: 'good',
 			delta: defaultCoreWebVitalsPayload.inp,
-			attribution: {},
-			navigationType: 'navigate',
-			id: 'inp',
 		} satisfies INPMetricWithAttribution);
 	},
 	onTTFB: (onReport: ReportCallback) => {
@@ -80,9 +83,9 @@ jest.mock('web-vitals/attribution', () => ({
 			name: 'TTFB',
 			id: 'ttfb',
 			entries: [],
+			navigationType: 'navigate',
 			rating: 'good',
 			delta: defaultCoreWebVitalsPayload.ttfb,
-			navigationType: 'navigate',
 		} satisfies TTFBMetric);
 	},
 	onFCP: (onReport: ReportCallback) => {
@@ -91,9 +94,9 @@ jest.mock('web-vitals/attribution', () => ({
 			name: 'FCP',
 			id: 'fcp',
 			entries: [],
+			navigationType: 'navigate',
 			rating: 'good',
 			delta: defaultCoreWebVitalsPayload.fcp,
-			navigationType: 'navigate',
 		} satisfies FCPMetric);
 	},
 	onFID: (onReport: ReportCallback) => {
@@ -102,8 +105,8 @@ jest.mock('web-vitals/attribution', () => ({
 			name: 'FID',
 			id: 'fid',
 			entries: [],
-			navigationType: 'navigate',
 			rating: 'good',
+			navigationType: 'navigate',
 			delta: defaultCoreWebVitalsPayload.cls,
 		} satisfies FIDMetric);
 	},
@@ -338,7 +341,7 @@ describe('Endpoints', () => {
 
 		global.dispatchEvent(new Event('pagehide'));
 
-		expect(mockBeacon).toHaveBeenCalledWith(_.endpoint, expect.any(String));
+		expect(_.coreWebVitalsPayload.stage).toBe('CODE');
 	});
 
 	it('should use PROD URL if isDev is false', async () => {
@@ -347,7 +350,7 @@ describe('Endpoints', () => {
 
 		global.dispatchEvent(new Event('pagehide'));
 
-		expect(mockBeacon).toHaveBeenCalledWith(_.endpoint, expect.any(String));
+		expect(_.coreWebVitalsPayload.stage).toBe('PROD');
 	});
 });
 

--- a/libs/@guardian/core-web-vitals/src/index.test.ts
+++ b/libs/@guardian/core-web-vitals/src/index.test.ts
@@ -4,9 +4,8 @@ import type {
 	FIDMetric,
 	INPMetricWithAttribution,
 	LCPMetricWithAttribution,
-	ReportCallback,
 	TTFBMetric,
-} from 'web-vitals';
+} from 'web-vitals/attribution';
 import type { CoreWebVitalsPayload } from './@types/CoreWebVitalsPayload';
 import { _, bypassCoreWebVitalsSampling, initCoreWebVitals } from './index';
 
@@ -54,8 +53,8 @@ jest.mock('web-vitals/attribution', () => ({
 				element: 'mainMedia',
 				timeToFirstByte: 0,
 				resourceLoadDelay: 0,
-				resourceLoadTime: 0,
 				elementRenderDelay: 0,
+				resourceLoadDuration: 0,
 			},
 			entries: [],
 			navigationType: 'navigate',
@@ -69,7 +68,17 @@ jest.mock('web-vitals/attribution', () => ({
 			name: 'INP',
 			id: 'inp',
 			attribution: {
-				eventTarget: 'adSlot',
+				interactionTarget: 'adSlot',
+				interactionTargetElement: undefined,
+				interactionTime: 0,
+				nextPaintTime: 0,
+				interactionType: 'pointer',
+				processedEventEntries: [],
+				longAnimationFrameEntries: [],
+				inputDelay: 0,
+				processingDuration: 0,
+				presentationDelay: 0,
+				loadState: 'loading',
 			},
 			entries: [],
 			navigationType: 'navigate',
@@ -77,7 +86,7 @@ jest.mock('web-vitals/attribution', () => ({
 			delta: defaultCoreWebVitalsPayload.inp,
 		} satisfies INPMetricWithAttribution);
 	},
-	onTTFB: (onReport: ReportCallback) => {
+	onTTFB: (onReport: (metric: TTFBMetric) => void) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.ttfb,
 			name: 'TTFB',
@@ -88,7 +97,7 @@ jest.mock('web-vitals/attribution', () => ({
 			delta: defaultCoreWebVitalsPayload.ttfb,
 		} satisfies TTFBMetric);
 	},
-	onFCP: (onReport: ReportCallback) => {
+	onFCP: (onReport: (metric: FCPMetric) => void) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.fcp,
 			name: 'FCP',
@@ -99,7 +108,7 @@ jest.mock('web-vitals/attribution', () => ({
 			delta: defaultCoreWebVitalsPayload.fcp,
 		} satisfies FCPMetric);
 	},
-	onFID: (onReport: ReportCallback) => {
+	onFID: (onReport: (metric: FIDMetric) => void) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.fid,
 			name: 'FID',

--- a/libs/@guardian/core-web-vitals/src/index.ts
+++ b/libs/@guardian/core-web-vitals/src/index.ts
@@ -61,7 +61,7 @@ const onReport = (metric: MetricTypeWithAttribution) => {
 			break;
 		case 'INP':
 			coreWebVitalsPayload.inp = roundWithDecimals(metric.value);
-			coreWebVitalsPayload.inp_target = metric.attribution.eventTarget;
+			coreWebVitalsPayload.inp_target = metric.attribution.interactionTarget;
 			break;
 		case 'LCP':
 			// Browser support: Chromium

--- a/libs/@guardian/core-web-vitals/src/index.ts
+++ b/libs/@guardian/core-web-vitals/src/index.ts
@@ -87,8 +87,7 @@ const onReport = (metric: MetricTypeWithAttribution) => {
 		case 'LCP':
 			// Browser support: Chromium
 			coreWebVitalsPayload.lcp = roundWithDecimals(metric.value);
-			coreWebVitalsPayload.lcp_target =
-				metric.attribution.lcpEntry?.name ?? null;
+			coreWebVitalsPayload.lcp_target = metric.attribution.element ?? null;
 			break;
 		/** none-core web vital metrics */
 		case 'FCP':

--- a/libs/@guardian/core-web-vitals/src/index.ts
+++ b/libs/@guardian/core-web-vitals/src/index.ts
@@ -11,14 +11,12 @@ import type {
 import type { CoreWebVitalsPayload } from './@types/CoreWebVitalsPayload';
 import { roundWithDecimals } from './roundWithDecimals';
 
-enum Endpoints {
-	PROD = 'https://performance-events.guardianapis.com/core-web-vitals',
-	CODE = 'https://performance-events.code.dev-guardianapis.com/core-web-vitals',
-}
+const endpoint = 'https://feast-events.guardianapis.com/web-vitals';
 
 const coreWebVitalsPayload: CoreWebVitalsPayload = {
 	browser_id: null,
 	page_view_id: null,
+	stage: null,
 	cls: null,
 	cls_target: null,
 	inp: null,
@@ -31,12 +29,7 @@ const coreWebVitalsPayload: CoreWebVitalsPayload = {
 };
 
 const teamsForLogging: Set<TeamName> = new Set();
-let endpoint: Endpoints;
 let initialised = false;
-
-const setEndpoint = (isDev: boolean) => {
-	endpoint = isDev ? Endpoints.CODE : Endpoints.PROD;
-};
 
 let queued = false;
 const sendData = (): void => {
@@ -179,8 +172,7 @@ export const initCoreWebVitals = async ({
 		teamsForLogging.add(team);
 	}
 
-	setEndpoint(isDev);
-
+	coreWebVitalsPayload.stage = isDev ? 'CODE' : 'PROD';
 	coreWebVitalsPayload.browser_id = browserId;
 	coreWebVitalsPayload.page_view_id = pageViewId;
 
@@ -244,5 +236,5 @@ export const _ = {
 		removeEventListener('visibilitychange', listener);
 		removeEventListener('pagehide', listener);
 	},
-	Endpoints,
+	endpoint,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   axios@^1.0.0: 1.6.7
   semver@^5.0.0: 5.7.2
@@ -49,7 +45,7 @@ importers:
         version: 3.2.0(eslint@8.57.0)
       eslint-plugin-import:
         specifier: 2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.11.0)(eslint@8.57.0)
+        version: 2.29.1(@typescript-eslint/parser@7.11.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-react:
         specifier: 7.34.1
         version: 7.34.1(eslint@8.57.0)
@@ -91,7 +87,7 @@ importers:
         version: 0.7.0(prettier@3.3.2)(typescript@5.3.3)
       '@astrojs/svelte':
         specifier: 5.6.0
-        version: 5.6.0(astro@4.10.3)(svelte@4.2.12)(typescript@5.3.3)(vite@5.3.1)
+        version: 5.6.0(astro@4.10.3)(svelte@4.2.12)(typescript@5.3.3)(vite@5.3.2)
       '@guardian/libs':
         specifier: workspace:*
         version: link:../../libs/@guardian/libs
@@ -112,7 +108,7 @@ importers:
     devDependencies:
       storybook:
         specifier: 8.1.8
-        version: 8.1.8(react-dom@18.2.0)(react@18.2.0)
+        version: 8.1.8(react-dom@18.3.1)(react@18.3.1)
       wireit:
         specifier: 0.14.4
         version: 0.14.4
@@ -133,10 +129,10 @@ importers:
         version: 4.18.0
       rollup-plugin-dts:
         specifier: 6.1.0
-        version: 6.1.0(rollup@4.18.0)(typescript@5.3.3)
+        version: 6.1.0(rollup@4.18.0)(typescript@5.5.2)
       rollup-plugin-esbuild:
         specifier: 6.1.1
-        version: 6.1.1(esbuild@0.21.5)(rollup@4.18.0)
+        version: 6.1.1(esbuild@0.22.0)(rollup@4.18.0)
       rollup-plugin-node-externals:
         specifier: 7.1.2
         version: 7.1.2(rollup@4.18.0)
@@ -175,7 +171,7 @@ importers:
         version: 8.1.8(prettier@3.3.2)
       '@storybook/addon-essentials':
         specifier: 8.1.8
-        version: 8.1.8(@types/react@18.2.11)(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)
+        version: 8.1.8(@types/react@18.2.11)(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)
       '@storybook/addon-links':
         specifier: 8.1.8
         version: 8.1.8(react@18.2.0)
@@ -184,16 +180,16 @@ importers:
         version: 8.1.8
       '@storybook/manager-api':
         specifier: 8.1.8
-        version: 8.1.8(react-dom@18.2.0)(react@18.2.0)
+        version: 8.1.8(react-dom@18.3.1)(react@18.2.0)
       '@storybook/react':
         specifier: 8.1.8
-        version: 8.1.8(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        version: 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)(typescript@5.5.2)
       '@storybook/react-webpack5':
         specifier: 8.1.8
-        version: 8.1.8(esbuild@0.20.2)(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        version: 8.1.8(esbuild@0.20.2)(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)(typescript@5.5.2)
       '@storybook/theming':
         specifier: 8.1.8
-        version: 8.1.8(react-dom@18.2.0)(react@18.2.0)
+        version: 8.1.8(react-dom@18.3.1)(react@18.2.0)
       '@types/babel__core':
         specifier: 7.20.5
         version: 7.20.5
@@ -202,7 +198,7 @@ importers:
         version: 18.2.11
       babel-loader:
         specifier: 9.1.3
-        version: 9.1.3(@babel/core@7.24.0)(webpack@5.92.0)
+        version: 9.1.3(@babel/core@7.24.0)(webpack@5.92.1)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -351,8 +347,8 @@ importers:
         specifier: 5.3.3
         version: 5.3.3
       web-vitals:
-        specifier: 3.5.0
-        version: 3.5.0
+        specifier: 4.2.0
+        version: 4.2.0
       wireit:
         specifier: 0.14.4
         version: 0.14.4
@@ -389,7 +385,7 @@ importers:
         version: 3.2.0(eslint@8.56.0)
       eslint-plugin-import:
         specifier: 2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.11.0)(eslint@8.56.0)
+        version: 2.29.1(@typescript-eslint/parser@7.11.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
     devDependencies:
       eslint:
         specifier: 8.56.0
@@ -593,10 +589,10 @@ importers:
         version: 16.1.3(tslib@2.6.2)(typescript@5.3.3)
       '@storybook/manager-api':
         specifier: 8.1.8
-        version: 8.1.8(react-dom@18.2.0)(react@18.2.0)
+        version: 8.1.8(react-dom@18.3.1)(react@18.2.0)
       '@storybook/react':
         specifier: 8.1.8
-        version: 8.1.8(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        version: 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)(typescript@5.3.3)
       '@svgr/babel-preset':
         specifier: 8.1.0
         version: 8.1.0(@babel/core@7.24.0)
@@ -650,7 +646,7 @@ importers:
         version: 4.18.0
       storybook:
         specifier: 8.1.8
-        version: 8.1.8(react-dom@18.2.0)(react@18.2.0)
+        version: 8.1.8(react-dom@18.3.1)(react@18.2.0)
       ts-jest:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.24.0)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.3.3)
@@ -683,10 +679,10 @@ importers:
         version: 4.0.0(@emotion/react@11.11.3)(@types/react@18.2.11)(react@18.2.0)(tslib@2.6.2)(typescript@5.3.3)
       '@storybook/manager-api':
         specifier: 8.1.8
-        version: 8.1.8(react-dom@18.2.0)(react@18.2.0)
+        version: 8.1.8(react-dom@18.3.1)(react@18.2.0)
       '@storybook/react':
         specifier: 8.1.8
-        version: 8.1.8(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+        version: 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)(typescript@5.3.3)
       '@types/jest':
         specifier: 29.5.8
         version: 29.5.8
@@ -704,7 +700,7 @@ importers:
         version: 4.18.0
       storybook:
         specifier: 8.1.8
-        version: 8.1.8(react-dom@18.2.0)(react@18.2.0)
+        version: 8.1.8(react-dom@18.3.1)(react@18.2.0)
       ts-jest:
         specifier: 29.1.1
         version: 29.1.1(@babel/core@7.24.0)(esbuild@0.20.2)(jest@29.7.0)(typescript@5.3.3)
@@ -835,7 +831,7 @@ packages:
       prismjs: 1.29.0
     dev: true
 
-  /@astrojs/svelte@5.6.0(astro@4.10.3)(svelte@4.2.12)(typescript@5.3.3)(vite@5.3.1):
+  /@astrojs/svelte@5.6.0(astro@4.10.3)(svelte@4.2.12)(typescript@5.3.3)(vite@5.3.2):
     resolution: {integrity: sha512-rdHBlqMQE6UOA1ySF1t3sdb6pf44yP8Dd0TqxGO0yR4HAgbtKtW8XToJ3mQ1PmuRmf5fisH9xzt3EEx7NAQuZg==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=21.0.0}
     peerDependencies:
@@ -843,7 +839,7 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.90
       typescript: ^5.3.3
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.12)(vite@5.3.1)
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.12)(vite@5.3.2)
       astro: 4.10.3(@types/node@20.12.11)(typescript@5.3.3)
       svelte: 4.2.12
       svelte2tsx: 0.7.10(svelte@4.2.12)(typescript@5.3.3)
@@ -3828,7 +3824,7 @@ packages:
     resolution: {integrity: sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==}
     requiresBuild: true
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.6.3
     dev: true
     optional: true
 
@@ -3913,6 +3909,14 @@ packages:
     dependencies:
       react: 18.2.0
 
+  /@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.3.1):
+    resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.3.1
+    dev: true
+
   /@emotion/utils@1.2.1:
     resolution: {integrity: sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==}
 
@@ -3936,6 +3940,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.22.0:
+    resolution: {integrity: sha512-uvQR2crZ/zgzSHDvdygHyNI+ze9zwS8mqz0YtGXotSqvEE0UkYE9s+FZKQNTt1VtT719mfP3vHrUdCpxBNQZhQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.20.2:
     resolution: {integrity: sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==}
     engines: {node: '>=12'}
@@ -3947,6 +3960,15 @@ packages:
   /@esbuild/android-arm64@0.21.5:
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.22.0:
+    resolution: {integrity: sha512-UKhPb3o2gAB/bfXcl58ZXTn1q2oVu1rEu/bKrCtmm+Nj5MKUbrOwR5WAixE2v+lk0amWuwPvhnPpBRLIGiq7ig==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
@@ -3970,6 +3992,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.22.0:
+    resolution: {integrity: sha512-PBnyP+r8vJE4ifxsWys9l+Mc2UY/yYZOpX82eoyGISXXb3dRr0M21v+s4fgRKWMFPMSf/iyowqPW/u7ScSUkjQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.20.2:
     resolution: {integrity: sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==}
     engines: {node: '>=12'}
@@ -3981,6 +4012,15 @@ packages:
   /@esbuild/android-x64@0.21.5:
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.22.0:
+    resolution: {integrity: sha512-IjTYtvIrjhR41Ijy2dDPgYjQHWG/x/A4KXYbs1fiU3efpRdoxMChK3oEZV6GPzVEzJqxFgcuBaiX1kwEvWUxSw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
@@ -4004,6 +4044,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.22.0:
+    resolution: {integrity: sha512-mqt+Go4y9wRvEz81bhKd9RpHsQR1LwU8Xm6jZRUV/xpM7cIQFbFH6wBCLPTNsdELBvfoHeumud7X78jQQJv2TA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.20.2:
     resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
     engines: {node: '>=12'}
@@ -4015,6 +4064,15 @@ packages:
   /@esbuild/darwin-x64@0.21.5:
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.22.0:
+    resolution: {integrity: sha512-vTaTQ9OgYc3VTaWtOE5pSuDT6H3d/qSRFRfSBbnxFfzAvYoB3pqKXA0LEbi/oT8GUOEAutspfRMqPj2ezdFaMw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -4038,6 +4096,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.22.0:
+    resolution: {integrity: sha512-0e1ZgoobJzaGnR4reD7I9rYZ7ttqdh1KPvJWnquUoDJhL0rYwdneeLailBzd2/4g/U5p4e5TIHEWa68NF2hFpQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.20.2:
     resolution: {integrity: sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==}
     engines: {node: '>=12'}
@@ -4049,6 +4116,15 @@ packages:
   /@esbuild/freebsd-x64@0.21.5:
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.22.0:
+    resolution: {integrity: sha512-BFgyYwlCwRWyPQJtkzqq2p6pJbiiWgp0P9PNf7a5FQ1itKY4czPuOMAlFVItirSmEpRPCeImuwePNScZS0pL5Q==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
@@ -4072,6 +4148,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.22.0:
+    resolution: {integrity: sha512-V/K2rctCUgC0PCXpN7AqT4hoazXKgIYugFGu/myk2+pfe6jTW2guz/TBwq4cZ7ESqusR/IzkcQaBkcjquuBWsw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.20.2:
     resolution: {integrity: sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==}
     engines: {node: '>=12'}
@@ -4083,6 +4168,15 @@ packages:
   /@esbuild/linux-arm@0.21.5:
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.22.0:
+    resolution: {integrity: sha512-KEMWiA9aGuPUD4BH5yjlhElLgaRXe+Eri6gKBoDazoPBTo1BXc/e6IW5FcJO9DoL19FBeCxgONyh95hLDNepIg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
@@ -4106,6 +4200,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.22.0:
+    resolution: {integrity: sha512-r2ZZqkOMOrpUhzNwxI7uLAHIDwkfeqmTnrv1cjpL/rjllPWszgqmprd/om9oviKXUBpMqHbXmppvjAYgISb26Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64@0.20.2:
     resolution: {integrity: sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==}
     engines: {node: '>=12'}
@@ -4117,6 +4220,15 @@ packages:
   /@esbuild/linux-loong64@0.21.5:
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.22.0:
+    resolution: {integrity: sha512-qaowLrV/YOMAL2RfKQ4C/VaDzAuLDuylM2sd/LH+4OFirMl6CuDpRlCq4u49ZBaVV8pkI/Y+hTdiibvQRhojCA==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
@@ -4140,6 +4252,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.22.0:
+    resolution: {integrity: sha512-hgrezzjQTRxjkQ5k08J6rtZN5PNnkWx/Rz6Kmj9gnsdCAX1I4Dn4ZPqvFRkXo55Q3pnVQJBwbdtrTO7tMGtyVA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.20.2:
     resolution: {integrity: sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==}
     engines: {node: '>=12'}
@@ -4151,6 +4272,15 @@ packages:
   /@esbuild/linux-ppc64@0.21.5:
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.22.0:
+    resolution: {integrity: sha512-ewxg6FLLUio883XgSjfULEmDl3VPv/TYNnRprVAS3QeGFLdCYdx1tIudBcd7n9jIdk82v1Ajov4jx87qW7h9+g==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
@@ -4174,6 +4304,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.22.0:
+    resolution: {integrity: sha512-Az5XbgSJC2lE8XK8pdcutsf9RgdafWdTpUK/+6uaDdfkviw/B4JCwAfh1qVeRWwOohwdsl4ywZrWBNWxwrPLFg==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.20.2:
     resolution: {integrity: sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==}
     engines: {node: '>=12'}
@@ -4185,6 +4324,15 @@ packages:
   /@esbuild/linux-s390x@0.21.5:
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.22.0:
+    resolution: {integrity: sha512-8j4a2ChT9+V34NNNY9c/gMldutaJFmfMacTPq4KfNKwv2fitBCLYjee7c+Vxaha2nUhPK7cXcZpJtJ3+Y7ZdVQ==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
@@ -4208,6 +4356,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.22.0:
+    resolution: {integrity: sha512-JUQyOnpbAkkRFOk/AhsEemz5TfWN4FJZxVObUlnlNCbe7QBl61ZNfM4cwBXayQA6laMJMUcqLHaYQHAB6YQ95Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.20.2:
     resolution: {integrity: sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==}
     engines: {node: '>=12'}
@@ -4225,6 +4382,24 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64@0.22.0:
+    resolution: {integrity: sha512-11PoCoHXo4HFNbLsXuMB6bpMPWGDiw7xETji6COdJss4SQZLvcgNoeSqWtATRm10Jj1uEHiaIk4N0PiN6x4Fcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.22.0:
+    resolution: {integrity: sha512-Ezlhu/YyITmXwKSB+Zu/QqD7cxrjrpiw85cc0Rbd3AWr2wsgp+dWbWOE8MqHaLW9NKMZvuL0DhbJbvzR7F6Zvg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openbsd-x64@0.20.2:
     resolution: {integrity: sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==}
     engines: {node: '>=12'}
@@ -4236,6 +4411,15 @@ packages:
   /@esbuild/openbsd-x64@0.21.5:
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.22.0:
+    resolution: {integrity: sha512-ufjdW5tFJGUjlH9j/5cCE9lrwRffyZh+T4vYvoDKoYsC6IXbwaFeV/ENxeNXcxotF0P8CDzoICXVSbJaGBhkrw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
@@ -4259,6 +4443,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64@0.22.0:
+    resolution: {integrity: sha512-zY6ly/AoSmKnmNTowDJsK5ehra153/5ZhqxNLfq9NRsTTltetr+yHHcQ4RW7QDqw4JC8A1uC1YmeSfK9NRcK1w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-arm64@0.20.2:
     resolution: {integrity: sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==}
     engines: {node: '>=12'}
@@ -4270,6 +4463,15 @@ packages:
   /@esbuild/win32-arm64@0.21.5:
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.22.0:
+    resolution: {integrity: sha512-Kml5F7tv/1Maam0pbbCrvkk9vj046dPej30kFzlhXnhuCtYYBP6FGy/cLbc5yUT1lkZznGLf2OvuvmLjscO5rw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -4293,6 +4495,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.22.0:
+    resolution: {integrity: sha512-IOgwn+mYTM3RrcydP4Og5IpXh+ftN8oF+HELTXSmbWBlujuci4Qa3DTeO+LEErceisI7KUSfEIiX+WOUlpELkw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.20.2:
     resolution: {integrity: sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==}
     engines: {node: '>=12'}
@@ -4304,6 +4515,15 @@ packages:
   /@esbuild/win32-x64@0.21.5:
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.22.0:
+    resolution: {integrity: sha512-4bDHJrk2WHBXJPhy1y80X7/5b5iZTZP3LGcKIlAP1J+KqZ4zQAPMLEzftGyjjfcKbA4JDlPt/+2R/F1ZTeRgrw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -4333,6 +4553,7 @@ packages:
     dependencies:
       eslint: 8.57.0
       eslint-visitor-keys: 3.4.3
+    dev: true
 
   /@eslint-community/regexpp@4.10.1:
     resolution: {integrity: sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==}
@@ -4361,6 +4582,7 @@ packages:
   /@eslint/js@8.57.0:
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
 
   /@fal-works/esbuild-plugin-global-externals@2.1.2:
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
@@ -5102,6 +5324,39 @@ packages:
       react-remove-scroll: 2.5.5(@types/react@18.2.11)(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-dialog@1.0.5(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.11)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.11)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.11)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.4(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.11)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.11)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.11)(react@18.2.0)
+      '@types/react': 18.2.11
+      aria-hidden: 1.2.4
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.2.11)(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-dismissable-layer@1.0.5(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==}
     peerDependencies:
@@ -5124,6 +5379,30 @@ packages:
       '@types/react': 18.2.11
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-dismissable-layer@1.0.5(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.11)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.11)(react@18.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.11)(react@18.2.0)
+      '@types/react': 18.2.11
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
     dev: false
 
   /@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.11)(react@18.2.0):
@@ -5162,6 +5441,28 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-focus-scope@1.0.4(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.11)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.11)(react@18.2.0)
+      '@types/react': 18.2.11
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-id@1.0.1(@types/react@18.2.11)(react@18.2.0):
     resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
     peerDependencies:
@@ -5197,6 +5498,26 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-portal@1.0.4(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@radix-ui/react-primitive': 1.0.3(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0)
+      '@types/react': 18.2.11
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-presence@1.0.1(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
     peerDependencies:
@@ -5218,6 +5539,27 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-presence@1.0.1(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.11)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.11)(react@18.2.0)
+      '@types/react': 18.2.11
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-primitive@1.0.3(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
     peerDependencies:
@@ -5236,6 +5578,26 @@ packages:
       '@types/react': 18.2.11
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-primitive@1.0.3(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.11)(react@18.2.0)
+      '@types/react': 18.2.11
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
     dev: false
 
   /@radix-ui/react-slot@1.0.2(@types/react@18.2.11)(react@18.2.0):
@@ -5551,10 +5913,10 @@ packages:
       ts-dedent: 2.2.0
     dev: false
 
-  /@storybook/addon-controls@8.1.8(@types/react@18.2.11)(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/addon-controls@8.1.8(@types/react@18.2.11)(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0):
     resolution: {integrity: sha512-o/0WUSlWd6Erf37D9xOnRk7GYMOYf0eI1O7MQdPBSOpI+I77684vCp35D/WcamK3lqz0sAewF5tM14tuo3ATZw==}
     dependencies:
-      '@storybook/blocks': 8.1.8(@types/react@18.2.11)(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/blocks': 8.1.8(@types/react@18.2.11)(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)
       dequal: 2.0.3
       lodash: 4.17.21
       ts-dedent: 2.2.0
@@ -5598,12 +5960,12 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/addon-essentials@8.1.8(@types/react@18.2.11)(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/addon-essentials@8.1.8(@types/react@18.2.11)(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0):
     resolution: {integrity: sha512-qAVuighthkhYEgM977vj3sk4mZEOP+JGt+qYLT4nIjuucNm9aXyUOQovIiLQeAwtj+zvwSJ7diFDlQW3eYq+hQ==}
     dependencies:
       '@storybook/addon-actions': 8.1.8
       '@storybook/addon-backgrounds': 8.1.8
-      '@storybook/addon-controls': 8.1.8(@types/react@18.2.11)(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/addon-controls': 8.1.8(@types/react@18.2.11)(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)
       '@storybook/addon-docs': 8.1.8(prettier@3.3.2)
       '@storybook/addon-highlight': 8.1.8
       '@storybook/addon-measure': 8.1.8
@@ -5611,7 +5973,7 @@ packages:
       '@storybook/addon-toolbars': 8.1.8
       '@storybook/addon-viewport': 8.1.8
       '@storybook/core-common': 8.1.8(prettier@3.3.2)
-      '@storybook/manager-api': 8.1.8(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/manager-api': 8.1.8(react-dom@18.3.1)(react@18.2.0)
       '@storybook/node-logger': 8.1.8
       '@storybook/preview-api': 8.1.8
       ts-dedent: 2.2.0
@@ -5714,6 +6076,51 @@ packages:
       - supports-color
     dev: false
 
+  /@storybook/blocks@8.1.8(@types/react@18.2.11)(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-nx18ism4YCuLFOmI6mQ+EJD1XABcbDdAyeheZPwkwB+fKkseNiOy7C/Mqio7ReYIncvlML6CCUyFm/OSEZkHkQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@storybook/channels': 8.1.8
+      '@storybook/client-logger': 8.1.8
+      '@storybook/components': 8.1.8(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0)
+      '@storybook/core-events': 8.1.8
+      '@storybook/csf': 0.1.8
+      '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.2.9(react-dom@18.3.1)(react@18.2.0)
+      '@storybook/manager-api': 8.1.8(react-dom@18.3.1)(react@18.2.0)
+      '@storybook/preview-api': 8.1.8
+      '@storybook/theming': 8.1.8(react-dom@18.3.1)(react@18.2.0)
+      '@storybook/types': 8.1.8
+      '@types/lodash': 4.17.0
+      color-convert: 2.0.1
+      dequal: 2.0.3
+      lodash: 4.17.21
+      markdown-to-jsx: 7.3.2(react@18.2.0)
+      memoizerific: 1.11.3
+      polished: 4.3.1
+      react: 18.2.0
+      react-colorful: 5.6.1(react-dom@18.3.1)(react@18.2.0)
+      react-dom: 18.3.1(react@18.2.0)
+      telejson: 7.2.0
+      tocbot: 4.25.0
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - encoding
+      - prettier
+      - supports-color
+    dev: false
+
   /@storybook/builder-manager@8.1.8(prettier@3.3.2):
     resolution: {integrity: sha512-M4qpETmQNUTg6KEt4nVONjF2dXlVV1V+Mxf9saiinoj+PCyHdz+BmYYmiGtopUPxJ2YGvTL1nGykkyH57HutrQ==}
     dependencies:
@@ -5737,7 +6144,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-webpack5@8.1.8(esbuild@0.20.2)(prettier@3.3.2)(typescript@5.3.3):
+  /@storybook/builder-webpack5@8.1.8(esbuild@0.20.2)(prettier@3.3.2)(typescript@5.5.2):
     resolution: {integrity: sha512-L02ZG8583WqAhcW8+gKVKO99kb8ThhwSKMmtCk9XR++CCpO7kgR0N/lGJr79f2OYFuM6WQhfO/FRtER/7o45lw==}
     peerDependencies:
       typescript: '*'
@@ -5762,7 +6169,7 @@ packages:
       css-loader: 6.10.0(webpack@5.92.0)
       es-module-lexer: 1.5.3
       express: 4.19.2
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.3.3)(webpack@5.92.0)
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.5.2)(webpack@5.92.0)
       fs-extra: 11.2.0
       html-webpack-plugin: 5.6.0(webpack@5.92.0)
       magic-string: 0.30.10
@@ -5772,7 +6179,7 @@ packages:
       style-loader: 3.3.4(webpack@5.92.0)
       terser-webpack-plugin: 5.3.10(esbuild@0.20.2)(webpack@5.92.0)
       ts-dedent: 2.2.0
-      typescript: 5.3.3
+      typescript: 5.5.2
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
@@ -5800,7 +6207,7 @@ packages:
       telejson: 7.2.0
       tiny-invariant: 1.3.3
 
-  /@storybook/cli@8.1.8(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/cli@8.1.8(react-dom@18.3.1)(react@18.2.0):
     resolution: {integrity: sha512-GrU8zcLK0l/Jo9xQ42iEBqF0YL83gZF/GDTV+9MVMU1JtBtFldomvyGzT9J3TwvPgzC+rCmlk16rY1M2vc5klg==}
     hasBin: true
     dependencies:
@@ -5810,7 +6217,57 @@ packages:
       '@storybook/codemod': 8.1.8
       '@storybook/core-common': 8.1.8(prettier@3.3.2)
       '@storybook/core-events': 8.1.8
-      '@storybook/core-server': 8.1.8(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/core-server': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)
+      '@storybook/csf-tools': 8.1.8
+      '@storybook/node-logger': 8.1.8
+      '@storybook/telemetry': 8.1.8(prettier@3.3.2)
+      '@storybook/types': 8.1.8
+      '@types/semver': 7.5.8
+      '@yarnpkg/fslib': 2.10.3
+      '@yarnpkg/libzip': 2.3.0
+      chalk: 4.1.2
+      commander: 6.2.1
+      cross-spawn: 7.0.3
+      detect-indent: 6.1.0
+      envinfo: 7.11.1
+      execa: 5.1.1
+      find-up: 5.0.0
+      fs-extra: 11.2.0
+      get-npm-tarball-url: 2.1.0
+      giget: 1.2.1
+      globby: 14.0.1
+      jscodeshift: 0.15.2(@babel/preset-env@7.24.7)
+      leven: 3.1.0
+      ora: 5.4.1
+      prettier: 3.3.2
+      prompts: 2.4.2
+      read-pkg-up: 7.0.1
+      semver: 7.5.4
+      strip-json-comments: 3.1.1
+      tempy: 3.1.0
+      tiny-invariant: 1.3.3
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - react
+      - react-dom
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@storybook/cli@8.1.8(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-GrU8zcLK0l/Jo9xQ42iEBqF0YL83gZF/GDTV+9MVMU1JtBtFldomvyGzT9J3TwvPgzC+rCmlk16rY1M2vc5klg==}
+    hasBin: true
+    dependencies:
+      '@babel/core': 7.24.6
+      '@babel/types': 7.24.7
+      '@ndelangen/get-tarball': 3.0.9
+      '@storybook/codemod': 8.1.8
+      '@storybook/core-common': 8.1.8(prettier@3.3.2)
+      '@storybook/core-events': 8.1.8
+      '@storybook/core-server': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1)
       '@storybook/csf-tools': 8.1.8
       '@storybook/node-logger': 8.1.8
       '@storybook/telemetry': 8.1.8(prettier@3.3.2)
@@ -5900,6 +6357,29 @@ packages:
       - '@types/react-dom'
     dev: false
 
+  /@storybook/components@8.1.8(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-DEfAtDEeISkic8jFm/rFQeVGdA0evVkbiOof+insJxzh6KnIfnZVmJysX02xoUhOCIMjo59c7x0nmUf7NlYsMw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    dependencies:
+      '@radix-ui/react-dialog': 1.0.5(@types/react@18.2.11)(react-dom@18.3.1)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.11)(react@18.2.0)
+      '@storybook/client-logger': 8.1.8
+      '@storybook/csf': 0.1.8
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.2.9(react-dom@18.3.1)(react@18.2.0)
+      '@storybook/theming': 8.1.8(react-dom@18.3.1)(react@18.2.0)
+      '@storybook/types': 8.1.8
+      memoizerific: 1.11.3
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+      util-deprecate: 1.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+    dev: false
+
   /@storybook/core-common@8.1.8(prettier@3.3.2):
     resolution: {integrity: sha512-RcJUTGjvVCuGtz7GifY8sMHLUvmsg8moDOgwwkOJ+9QdgInyuZeqLzNI7BjOv2CYCK1sy7x0eU7B4CWD8LwnwA==}
     peerDependencies:
@@ -5948,7 +6428,7 @@ packages:
       '@storybook/csf': 0.1.8
       ts-dedent: 2.2.0
 
-  /@storybook/core-server@8.1.8(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0):
+  /@storybook/core-server@8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0):
     resolution: {integrity: sha512-v2V7FC/y/lrKPxcseIwPavjdCCDHphpj+A23Jmp822tqYn+I4nYRvE74QKyn5dfLrdn52nz8KrUFwjhuacj10Q==}
     dependencies:
       '@aw-web-design/x-default-browser': 1.4.126
@@ -5964,7 +6444,65 @@ packages:
       '@storybook/docs-mdx': 3.1.0-next.0
       '@storybook/global': 5.0.0
       '@storybook/manager': 8.1.8
-      '@storybook/manager-api': 8.1.8(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/manager-api': 8.1.8(react-dom@18.3.1)(react@18.2.0)
+      '@storybook/node-logger': 8.1.8
+      '@storybook/preview-api': 8.1.8
+      '@storybook/telemetry': 8.1.8(prettier@3.3.2)
+      '@storybook/types': 8.1.8
+      '@types/detect-port': 1.3.5
+      '@types/diff': 5.2.1
+      '@types/node': 18.19.3
+      '@types/pretty-hrtime': 1.0.3
+      '@types/semver': 7.5.8
+      better-opn: 3.0.2
+      chalk: 4.1.2
+      cli-table3: 0.6.3
+      compression: 1.7.4
+      detect-port: 1.5.1
+      diff: 5.2.0
+      express: 4.19.2
+      fs-extra: 11.2.0
+      globby: 14.0.1
+      lodash: 4.17.21
+      open: 8.4.2
+      pretty-hrtime: 1.0.3
+      prompts: 2.4.2
+      read-pkg-up: 7.0.1
+      semver: 7.5.4
+      telejson: 7.2.0
+      tiny-invariant: 1.3.3
+      ts-dedent: 2.2.0
+      util: 0.12.5
+      util-deprecate: 1.0.2
+      watchpack: 2.4.1
+      ws: 8.16.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - prettier
+      - react
+      - react-dom
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /@storybook/core-server@8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-v2V7FC/y/lrKPxcseIwPavjdCCDHphpj+A23Jmp822tqYn+I4nYRvE74QKyn5dfLrdn52nz8KrUFwjhuacj10Q==}
+    dependencies:
+      '@aw-web-design/x-default-browser': 1.4.126
+      '@babel/core': 7.24.7
+      '@babel/parser': 7.24.7
+      '@discoveryjs/json-ext': 0.5.7
+      '@storybook/builder-manager': 8.1.8(prettier@3.3.2)
+      '@storybook/channels': 8.1.8
+      '@storybook/core-common': 8.1.8(prettier@3.3.2)
+      '@storybook/core-events': 8.1.8
+      '@storybook/csf': 0.1.8
+      '@storybook/csf-tools': 8.1.8
+      '@storybook/docs-mdx': 3.1.0-next.0
+      '@storybook/global': 5.0.0
+      '@storybook/manager': 8.1.8
+      '@storybook/manager-api': 8.1.8(react-dom@18.3.1)(react@18.3.1)
       '@storybook/node-logger': 8.1.8
       '@storybook/preview-api': 8.1.8
       '@storybook/telemetry': 8.1.8(prettier@3.3.2)
@@ -6087,6 +6625,28 @@ packages:
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@storybook/icons@1.2.9(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-cOmylsz25SYXaJL/gvTk/dl3pyk7yBFRfeXTsHvTA3dfhoU/LWSq0NKL9nM7WBasJyn6XPSGnLS4RtKXLw5EUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+
+  /@storybook/icons@1.2.9(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-cOmylsz25SYXaJL/gvTk/dl3pyk7yBFRfeXTsHvTA3dfhoU/LWSq0NKL9nM7WBasJyn6XPSGnLS4RtKXLw5EUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: true
 
   /@storybook/manager-api@8.1.8(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-mVUGMp2Z0lnuIZL8wgb++Id1tGTBtaFtB89w89U/Y5Ii8UMv2tukNiDY37HTkkVIvRz0sm9bJa94GNDrUubnTw==}
@@ -6109,6 +6669,52 @@ packages:
     transitivePeerDependencies:
       - react
       - react-dom
+    dev: false
+
+  /@storybook/manager-api@8.1.8(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-mVUGMp2Z0lnuIZL8wgb++Id1tGTBtaFtB89w89U/Y5Ii8UMv2tukNiDY37HTkkVIvRz0sm9bJa94GNDrUubnTw==}
+    dependencies:
+      '@storybook/channels': 8.1.8
+      '@storybook/client-logger': 8.1.8
+      '@storybook/core-events': 8.1.8
+      '@storybook/csf': 0.1.8
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.2.9(react-dom@18.3.1)(react@18.2.0)
+      '@storybook/router': 8.1.8
+      '@storybook/theming': 8.1.8(react-dom@18.3.1)(react@18.2.0)
+      '@storybook/types': 8.1.8
+      dequal: 2.0.3
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      store2: 2.14.3
+      telejson: 7.2.0
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  /@storybook/manager-api@8.1.8(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-mVUGMp2Z0lnuIZL8wgb++Id1tGTBtaFtB89w89U/Y5Ii8UMv2tukNiDY37HTkkVIvRz0sm9bJa94GNDrUubnTw==}
+    dependencies:
+      '@storybook/channels': 8.1.8
+      '@storybook/client-logger': 8.1.8
+      '@storybook/core-events': 8.1.8
+      '@storybook/csf': 0.1.8
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.2.9(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/router': 8.1.8
+      '@storybook/theming': 8.1.8(react-dom@18.3.1)(react@18.3.1)
+      '@storybook/types': 8.1.8
+      dequal: 2.0.3
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      store2: 2.14.3
+      telejson: 7.2.0
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - react
+      - react-dom
+    dev: true
 
   /@storybook/manager@8.1.8:
     resolution: {integrity: sha512-3d1qAIzx9TQslolwZSRvlgZ78bxL3RtesUq1NYtC/nDQ7M8Yb+X3taIk8iE/AXa2wlJ8dQ4vU5grLl/oWQeTJg==}
@@ -6117,7 +6723,7 @@ packages:
   /@storybook/node-logger@8.1.8:
     resolution: {integrity: sha512-7woDHnwd8HdssbEQnfpwZu+zNjp9X6vqdPHhxhwAYsYt3x+m0Y8LP0sMJk8w/gQygelUoJsZLFZsJ2pifLXLCg==}
 
-  /@storybook/preset-react-webpack@8.1.8(esbuild@0.20.2)(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3):
+  /@storybook/preset-react-webpack@8.1.8(esbuild@0.20.2)(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)(typescript@5.5.2):
     resolution: {integrity: sha512-JS4XRqVmRqUY0i/NjkfKNZ08wvuBq2Lexs1Np/8CFrgenT5EeqZPQkvW955zkQT17jHQ8WgTyygVaXKh+TSSRQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6131,8 +6737,8 @@ packages:
       '@storybook/core-webpack': 8.1.8(prettier@3.3.2)
       '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
       '@storybook/node-logger': 8.1.8
-      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.92.0)
+      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)(typescript@5.5.2)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.2)(webpack@5.92.0)
       '@types/node': 18.19.3
       '@types/semver': 7.5.8
       find-up: 5.0.0
@@ -6140,11 +6746,11 @@ packages:
       magic-string: 0.30.10
       react: 18.2.0
       react-docgen: 7.0.3
-      react-dom: 18.2.0(react@18.2.0)
+      react-dom: 18.3.1(react@18.2.0)
       resolve: 1.22.8
       semver: 7.5.4
       tsconfig-paths: 4.2.0
-      typescript: 5.3.3
+      typescript: 5.5.2
       webpack: 5.92.0(esbuild@0.20.2)
     transitivePeerDependencies:
       - '@swc/core'
@@ -6178,7 +6784,7 @@ packages:
     resolution: {integrity: sha512-xUAV/7dLRXfCRp8j/Y4c9IG8YVZ3W+Ps6OAIXWoMjHRDNdEAItka2WnOlZWjDFNHSxOR7vOh0oraYPKgBV8edQ==}
     dev: false
 
-  /@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.92.0):
+  /@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.2)(webpack@5.92.0):
     resolution: {integrity: sha512-KUqXC3oa9JuQ0kZJLBhVdS4lOneKTOopnNBK4tUAgoxWQ3u/IjzdueZjFr7gyBrXMoU6duutk3RQR9u8ZpYJ4Q==}
     peerDependencies:
       typescript: '>= 4.x'
@@ -6189,9 +6795,9 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
       micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2(typescript@5.3.3)
+      react-docgen-typescript: 2.2.2(typescript@5.5.2)
       tslib: 2.6.2
-      typescript: 5.3.3
+      typescript: 5.5.2
       webpack: 5.92.0(esbuild@0.20.2)
     transitivePeerDependencies:
       - supports-color
@@ -6205,8 +6811,18 @@ packages:
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
-  /@storybook/react-webpack5@8.1.8(esbuild@0.20.2)(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3):
+  /@storybook/react-dom-shim@8.1.8(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-6lzFv/H5szDCy4D7Ob7gDAS9hTfFH9Cds+LEB6dRAsCC7ZMF56hp79AZZWkT3XXTNGXcy8w4+bI7Ntk3l4+rrA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+
+  /@storybook/react-webpack5@8.1.8(esbuild@0.20.2)(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)(typescript@5.5.2):
     resolution: {integrity: sha512-XpZL2D7Zgl2iPcg3yTSiEGX6BuHQSOEeXNqDkWti2xqwGRYhczaSp3oi+P5cSUYAGY9hn3BBOzFNUpOMrBNG6Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6217,14 +6833,14 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 8.1.8(esbuild@0.20.2)(prettier@3.3.2)(typescript@5.3.3)
-      '@storybook/preset-react-webpack': 8.1.8(esbuild@0.20.2)(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
-      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3)
+      '@storybook/builder-webpack5': 8.1.8(esbuild@0.20.2)(prettier@3.3.2)(typescript@5.5.2)
+      '@storybook/preset-react-webpack': 8.1.8(esbuild@0.20.2)(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)(typescript@5.5.2)
+      '@storybook/react': 8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)(typescript@5.5.2)
       '@storybook/types': 8.1.8
       '@types/node': 18.19.3
       react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      typescript: 5.3.3
+      react-dom: 18.3.1(react@18.2.0)
+      typescript: 5.5.2
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -6236,7 +6852,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@storybook/react@8.1.8(prettier@3.3.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.3.3):
+  /@storybook/react@8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)(typescript@5.3.3):
     resolution: {integrity: sha512-QFwyccbyZGcTpYk6BVChSSemeZ3mmnpp62Ca60j6JO+zbtZv3tTr4PFo79lkWwtz+jpfj0CX8hyYdT1p3r77YA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -6251,7 +6867,7 @@ packages:
       '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
       '@storybook/global': 5.0.0
       '@storybook/preview-api': 8.1.8
-      '@storybook/react-dom-shim': 8.1.8(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/react-dom-shim': 8.1.8(react-dom@18.3.1)(react@18.2.0)
       '@storybook/types': 8.1.8
       '@types/escodegen': 0.0.6
       '@types/estree': 0.0.51
@@ -6264,8 +6880,8 @@ packages:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-element-to-jsx-string: 15.0.0(react-dom@18.2.0)(react@18.2.0)
+      react-dom: 18.3.1(react@18.2.0)
+      react-element-to-jsx-string: 15.0.0(react-dom@18.3.1)(react@18.2.0)
       semver: 7.5.4
       ts-dedent: 2.2.0
       type-fest: 2.19.0
@@ -6275,6 +6891,48 @@ packages:
       - encoding
       - prettier
       - supports-color
+    dev: true
+
+  /@storybook/react@8.1.8(prettier@3.3.2)(react-dom@18.3.1)(react@18.2.0)(typescript@5.5.2):
+    resolution: {integrity: sha512-QFwyccbyZGcTpYk6BVChSSemeZ3mmnpp62Ca60j6JO+zbtZv3tTr4PFo79lkWwtz+jpfj0CX8hyYdT1p3r77YA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      typescript: '>= 4.2.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@storybook/client-logger': 8.1.8
+      '@storybook/docs-tools': 8.1.8(prettier@3.3.2)
+      '@storybook/global': 5.0.0
+      '@storybook/preview-api': 8.1.8
+      '@storybook/react-dom-shim': 8.1.8(react-dom@18.3.1)(react@18.2.0)
+      '@storybook/types': 8.1.8
+      '@types/escodegen': 0.0.6
+      '@types/estree': 0.0.51
+      '@types/node': 18.19.3
+      acorn: 7.4.1
+      acorn-jsx: 5.3.2(acorn@7.4.1)
+      acorn-walk: 7.2.0
+      escodegen: 2.1.0
+      html-tags: 3.3.1
+      lodash: 4.17.21
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+      react-element-to-jsx-string: 15.0.0(react-dom@18.3.1)(react@18.2.0)
+      semver: 7.5.4
+      ts-dedent: 2.2.0
+      type-fest: 2.19.0
+      typescript: 5.5.2
+      util-deprecate: 1.0.2
+    transitivePeerDependencies:
+      - encoding
+      - prettier
+      - supports-color
+    dev: false
 
   /@storybook/router@8.1.8:
     resolution: {integrity: sha512-7OzLdeCE+a8Ypk4Ne/2DU3s81GDNISnKIaFJ2DAuLSJbmF/LzvL39H/gyHXqmFqXWeSuCdBS0V37OEgejlZIAQ==}
@@ -6317,6 +6975,44 @@ packages:
       memoizerific: 1.11.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@storybook/theming@8.1.8(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-QhRMSRpnWVD1IB5sTZXVI35ETSQdwGh4/g8gKlGol8MN2Behd7CFgFAj2UL4jpPgjhnioH0U4rwwLkRfDlkR6Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
+      '@storybook/client-logger': 8.1.8
+      '@storybook/global': 5.0.0
+      memoizerific: 1.11.3
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+
+  /@storybook/theming@8.1.8(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-QhRMSRpnWVD1IB5sTZXVI35ETSQdwGh4/g8gKlGol8MN2Behd7CFgFAj2UL4jpPgjhnioH0U4rwwLkRfDlkR6Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.3.1)
+      '@storybook/client-logger': 8.1.8
+      '@storybook/global': 5.0.0
+      memoizerific: 1.11.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: true
 
   /@storybook/types@8.1.8:
     resolution: {integrity: sha512-bWg6WkhnhkWBIu03lUKlX2eOYSjDzpzoulzLh1H4Tl1JReGed+cHbIpdIU6lke2aJyb2BNyzoyudUHKBBGaOzg==}
@@ -6325,7 +7021,7 @@ packages:
       '@types/express': 4.17.21
       file-system-cache: 2.3.0
 
-  /@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1)(svelte@4.2.12)(vite@5.3.1):
+  /@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1)(svelte@4.2.12)(vite@5.3.2):
     resolution: {integrity: sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
@@ -6333,30 +7029,30 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.12)(vite@5.3.1)
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.12)(vite@5.3.2)
       debug: 4.3.5
       svelte: 4.2.12
-      vite: 5.3.1(@types/node@20.12.11)
+      vite: 5.3.2(@types/node@20.12.11)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@5.3.1):
+  /@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.12)(vite@5.3.2):
     resolution: {integrity: sha512-rimpFEAboBBHIlzISibg94iP09k/KYdHgVhJlcsTfn7KMBhc70jFX/GRWkRdFCc2fdnk+4+Bdfej23cMDnJS6A==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1)(svelte@4.2.12)(vite@5.3.1)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1)(svelte@4.2.12)(vite@5.3.2)
       debug: 4.3.5
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.10
       svelte: 4.2.12
       svelte-hmr: 0.16.0(svelte@4.2.12)
-      vite: 5.3.1(@types/node@20.12.11)
-      vitefu: 0.2.5(vite@5.3.1)
+      vite: 5.3.2(@types/node@20.12.11)
+      vitefu: 0.2.5(vite@5.3.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6957,7 +7653,6 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/parser@7.11.0(eslint@8.57.0)(typescript@5.3.3):
     resolution: {integrity: sha512-yimw99teuaXVWsBcPO1Ais02kwJ1jmNA1KxE7ng0aT7ndr1pT1wqj0OJnsYVGKKlc4QJai86l/025L6z8CljOg==}
@@ -6980,6 +7675,7 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/scope-manager@5.62.0:
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
@@ -7866,7 +8562,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /babel-loader@9.1.3(@babel/core@7.24.0)(webpack@5.92.0):
+  /babel-loader@9.1.3(@babel/core@7.24.0)(webpack@5.92.1):
     resolution: {integrity: sha512-xG3ST4DglodGf8qSwv0MdeWLhrDsw/32QMdTO5T1ZIp9gQur0HkCyFs7Awskr10JKXFXwpAhiCuYX5oGXnRGbw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -7876,7 +8572,7 @@ packages:
       '@babel/core': 7.24.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.92.0(esbuild@0.20.2)
+      webpack: 5.92.1(esbuild@0.20.2)
     dev: false
 
   /babel-plugin-istanbul@6.1.1:
@@ -8140,6 +8836,17 @@ packages:
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
 
+  /browserslist@4.23.1:
+    resolution: {integrity: sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001639
+      electron-to-chromium: 1.4.815
+      node-releases: 2.0.14
+      update-browserslist-db: 1.0.16(browserslist@4.23.1)
+    dev: false
+
   /bs-logger@0.2.6:
     resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
     engines: {node: '>= 6'}
@@ -8194,7 +8901,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.6.2
+      tslib: 2.6.3
     dev: false
 
   /camelcase-keys@6.2.2:
@@ -8221,6 +8928,10 @@ packages:
 
   /caniuse-lite@1.0.30001600:
     resolution: {integrity: sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==}
+
+  /caniuse-lite@1.0.30001639:
+    resolution: {integrity: sha512-eFHflNTBIlFwP2AIKaYuBQN/apnUoKNhBdza8ZnW/h2di4LCZ4xFqYlxUxo+LQ76KFI1PGcC1QDxMbxTZpSCAg==}
+    dev: false
 
   /case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
@@ -9193,6 +9904,10 @@ packages:
   /electron-to-chromium@1.4.715:
     resolution: {integrity: sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg==}
 
+  /electron-to-chromium@1.4.815:
+    resolution: {integrity: sha512-OvpTT2ItpOXJL7IGcYakRjHCt8L5GrrN/wHCQsRB4PQa1X9fe+X9oen245mIId7s14xvArCGSTIq644yPUKKLg==}
+    dev: false
+
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
     engines: {node: '>=12'}
@@ -9238,7 +9953,6 @@ packages:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
-    dev: false
 
   /enhanced-resolve@5.17.0:
     resolution: {integrity: sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==}
@@ -9378,6 +10092,10 @@ packages:
   /es-module-lexer@1.5.3:
     resolution: {integrity: sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==}
 
+  /es-module-lexer@1.5.4:
+    resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
+    dev: false
+
   /es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
     engines: {node: '>= 0.4'}
@@ -9480,6 +10198,38 @@ packages:
       '@esbuild/win32-x64': 0.21.5
     dev: true
 
+  /esbuild@0.22.0:
+    resolution: {integrity: sha512-zNYA6bFZsVnsU481FnGAQjLDW0Pl/8BGG7EvAp15RzUvGC+ME7hf1q7LvIfStEQBz/iEHuBJCYcOwPmNCf1Tlw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.22.0
+      '@esbuild/android-arm': 0.22.0
+      '@esbuild/android-arm64': 0.22.0
+      '@esbuild/android-x64': 0.22.0
+      '@esbuild/darwin-arm64': 0.22.0
+      '@esbuild/darwin-x64': 0.22.0
+      '@esbuild/freebsd-arm64': 0.22.0
+      '@esbuild/freebsd-x64': 0.22.0
+      '@esbuild/linux-arm': 0.22.0
+      '@esbuild/linux-arm64': 0.22.0
+      '@esbuild/linux-ia32': 0.22.0
+      '@esbuild/linux-loong64': 0.22.0
+      '@esbuild/linux-mips64el': 0.22.0
+      '@esbuild/linux-ppc64': 0.22.0
+      '@esbuild/linux-riscv64': 0.22.0
+      '@esbuild/linux-s390x': 0.22.0
+      '@esbuild/linux-x64': 0.22.0
+      '@esbuild/netbsd-x64': 0.22.0
+      '@esbuild/openbsd-arm64': 0.22.0
+      '@esbuild/openbsd-x64': 0.22.0
+      '@esbuild/sunos-x64': 0.22.0
+      '@esbuild/win32-arm64': 0.22.0
+      '@esbuild/win32-ia32': 0.22.0
+      '@esbuild/win32-x64': 0.22.0
+    dev: true
+
   /escalade@3.1.2:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
@@ -9560,7 +10310,6 @@ packages:
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-module-utils@2.8.0(@typescript-eslint/parser@7.11.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
@@ -9590,65 +10339,6 @@ packages:
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.11.0)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@7.11.0)(eslint-import-resolver-node@0.3.9)(eslint@8.56.0):
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 7.11.0(eslint@8.57.0)(typescript@5.3.3)
-      debug: 3.2.7
-      eslint: 8.56.0
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@7.11.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 7.11.0(eslint@8.57.0)(typescript@5.3.3)
-      debug: 3.2.7
-      eslint: 8.57.0
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /eslint-plugin-eslint-comments@3.2.0(eslint@8.56.0):
     resolution: {integrity: sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==}
@@ -9713,81 +10403,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
-
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.11.0)(eslint@8.56.0):
-    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 7.11.0(eslint@8.57.0)(typescript@5.3.3)
-      array-includes: 3.1.7
-      array.prototype.findlastindex: 1.2.3
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.56.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.11.0)(eslint-import-resolver-node@0.3.9)(eslint@8.56.0)
-      hasown: 2.0.2
-      is-core-module: 2.13.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.7
-      object.groupby: 1.0.1
-      object.values: 1.1.7
-      semver: 6.3.1
-      tsconfig-paths: 3.15.0
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: false
-
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.11.0)(eslint@8.57.0):
-    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 7.11.0(eslint@8.57.0)(typescript@5.3.3)
-      array-includes: 3.1.7
-      array.prototype.findlastindex: 1.2.3
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.57.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.11.0)(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
-      hasown: 2.0.2
-      is-core-module: 2.13.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.7
-      object.groupby: 1.0.1
-      object.values: 1.1.7
-      semver: 6.3.1
-      tsconfig-paths: 3.15.0
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
 
   /eslint-plugin-react-hooks@4.6.2(eslint@8.57.0):
     resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
@@ -9959,6 +10574,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
@@ -10306,7 +10922,7 @@ packages:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  /fork-ts-checker-webpack-plugin@8.0.0(typescript@5.3.3)(webpack@5.92.0):
+  /fork-ts-checker-webpack-plugin@8.0.0(typescript@5.5.2)(webpack@5.92.0):
     resolution: {integrity: sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==}
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
     peerDependencies:
@@ -10325,7 +10941,7 @@ packages:
       schema-utils: 3.3.0
       semver: 7.5.4
       tapable: 2.2.1
-      typescript: 5.3.3
+      typescript: 5.5.2
       webpack: 5.92.0(esbuild@0.20.2)
     dev: false
 
@@ -13477,7 +14093,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.6.3
     dev: false
 
   /parent-module@1.0.1:
@@ -13753,6 +14369,15 @@ packages:
       picocolors: 1.0.1
       source-map-js: 1.2.0
 
+  /postcss@8.4.39:
+    resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.1
+      source-map-js: 1.2.0
+    dev: true
+
   /preferred-pm@3.1.3:
     resolution: {integrity: sha512-MkXsENfftWSRpzCzImcp4FRsCc3y1opwB73CfCNWyzMqArju2CrlMHlqB7VexKiPEOjGMbttv1r9fSCn5S610w==}
     engines: {node: '>=10'}
@@ -13959,12 +14584,22 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /react-docgen-typescript@2.2.2(typescript@5.3.3):
+  /react-colorful@5.6.1(react-dom@18.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+    dev: false
+
+  /react-docgen-typescript@2.2.2(typescript@5.5.2):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 5.3.3
+      typescript: 5.5.2
     dev: false
 
   /react-docgen@7.0.3:
@@ -13994,7 +14629,26 @@ packages:
       react: 18.2.0
       scheduler: 0.23.0
 
-  /react-element-to-jsx-string@15.0.0(react-dom@18.2.0)(react@18.2.0):
+  /react-dom@18.3.1(react@18.2.0):
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.2.0
+      scheduler: 0.23.2
+
+  /react-dom@18.3.1(react@18.3.1):
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+    dev: true
+
+  /react-element-to-jsx-string@15.0.0(react-dom@18.3.1)(react@18.2.0):
     resolution: {integrity: sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==}
     peerDependencies:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
@@ -14003,7 +14657,7 @@ packages:
       '@base2/pretty-print-object': 1.0.1
       is-plain-object: 5.0.0
       react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      react-dom: 18.3.1(react@18.2.0)
       react-is: 18.1.0
 
   /react-is@16.13.1:
@@ -14076,6 +14730,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+
+  /react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: true
 
   /read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -14485,7 +15146,7 @@ packages:
     dependencies:
       glob: 7.2.3
 
-  /rollup-plugin-dts@6.1.0(rollup@4.18.0)(typescript@5.3.3):
+  /rollup-plugin-dts@6.1.0(rollup@4.18.0)(typescript@5.5.2):
     resolution: {integrity: sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -14494,12 +15155,12 @@ packages:
     dependencies:
       magic-string: 0.30.8
       rollup: 4.18.0
-      typescript: 5.3.3
+      typescript: 5.5.2
     optionalDependencies:
       '@babel/code-frame': 7.24.7
     dev: true
 
-  /rollup-plugin-esbuild@6.1.1(esbuild@0.21.5)(rollup@4.18.0):
+  /rollup-plugin-esbuild@6.1.1(esbuild@0.22.0)(rollup@4.18.0):
     resolution: {integrity: sha512-CehMY9FAqJD5OUaE/Mi1r5z0kNeYxItmRO2zG4Qnv2qWKF09J2lTy5GUzjJR354ZPrLkCj4fiBN41lo8PzBUhw==}
     engines: {node: '>=14.18.0'}
     peerDependencies:
@@ -14509,7 +15170,7 @@ packages:
       '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
       debug: 4.3.4
       es-module-lexer: 1.4.2
-      esbuild: 0.21.5
+      esbuild: 0.22.0
       get-tsconfig: 4.7.5
       rollup: 4.18.0
     transitivePeerDependencies:
@@ -14592,6 +15253,11 @@ packages:
 
   /scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
+    dependencies:
+      loose-envify: 1.4.0
+
+  /scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
     dependencies:
       loose-envify: 1.4.0
 
@@ -14960,11 +15626,26 @@ packages:
   /store2@2.14.3:
     resolution: {integrity: sha512-4QcZ+yx7nzEFiV4BMLnr/pRa5HYzNITX2ri0Zh6sT9EyQHbBHacC6YigllUPU9X3D0f/22QCgfokpKs52YRrUg==}
 
-  /storybook@8.1.8(react-dom@18.2.0)(react@18.2.0):
+  /storybook@8.1.8(react-dom@18.3.1)(react@18.2.0):
     resolution: {integrity: sha512-2ld3JEmPWy3KOksfF0Reyiq5SC+dYBzV2XW2/YTkNkLTkyNofhdPeq71COGcB0Lq2PHZkZyNin8htQWbh0LLNg==}
     hasBin: true
     dependencies:
-      '@storybook/cli': 8.1.8(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/cli': 8.1.8(react-dom@18.3.1)(react@18.2.0)
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - react
+      - react-dom
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /storybook@8.1.8(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-2ld3JEmPWy3KOksfF0Reyiq5SC+dYBzV2XW2/YTkNkLTkyNofhdPeq71COGcB0Lq2PHZkZyNin8htQWbh0LLNg==}
+    hasBin: true
+    dependencies:
+      '@storybook/cli': 8.1.8(react-dom@18.3.1)(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - bufferutil
@@ -15235,7 +15916,6 @@ packages:
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
-    dev: false
 
   /tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
@@ -15323,6 +16003,31 @@ packages:
       serialize-javascript: 6.0.2
       terser: 5.29.2
       webpack: 5.92.0(esbuild@0.20.2)
+    dev: false
+
+  /terser-webpack-plugin@5.3.10(esbuild@0.20.2)(webpack@5.92.1):
+    resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      esbuild: 0.20.2
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.29.2
+      webpack: 5.92.1(esbuild@0.20.2)
     dev: false
 
   /terser@5.29.2:
@@ -15501,6 +16206,9 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
+  /tslib@2.6.3:
+    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
+
   /tsutils@3.21.0(typescript@5.3.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -15641,6 +16349,11 @@ packages:
 
   /typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  /typescript@5.5.2:
+    resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -15851,6 +16564,17 @@ packages:
       escalade: 3.1.2
       picocolors: 1.0.1
 
+  /update-browserslist-db@1.0.16(browserslist@4.23.1):
+    resolution: {integrity: sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.23.1
+      escalade: 3.1.2
+      picocolors: 1.0.1
+    dev: false
+
   /update-section@0.3.3:
     resolution: {integrity: sha512-BpRZMZpgXLuTiKeiu7kK0nIPwGdyrqrs6EDSaXtjD/aQ2T+qVo9a5hRC3HN3iJjCMxNT/VxoLGQ7E/OzE5ucnw==}
     dev: true
@@ -16023,6 +16747,42 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /vite@5.3.2(@types/node@20.12.11):
+    resolution: {integrity: sha512-6lA7OBHBlXUxiJxbO5aAY2fsHHzDr1q7DvXYnyZycRs2Dz+dXBWuhpWHvmljTRTpQC2uvGmUFFkSHF2vGo90MA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.12.11
+      esbuild: 0.21.5
+      postcss: 8.4.39
+      rollup: 4.18.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /vitefu@0.2.5(vite@5.3.1):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
     peerDependencies:
@@ -16032,6 +16792,17 @@ packages:
         optional: true
     dependencies:
       vite: 5.3.1(@types/node@20.12.11)
+    dev: true
+
+  /vitefu@0.2.5(vite@5.3.2):
+    resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      vite: 5.3.2(@types/node@20.12.11)
     dev: true
 
   /volar-service-css@0.0.45(@volar/language-service@2.2.5):
@@ -16211,8 +16982,8 @@ packages:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
     dev: true
 
-  /web-vitals@3.5.0:
-    resolution: {integrity: sha512-f5YnCHVG9Y6uLCePD4tY8bO/Ge15NPEQWtvm3tPzDKygloiqtb4SVqRHBcrIAqo2ztqX5XueqDn97zHF0LdT6w==}
+  /web-vitals@4.2.0:
+    resolution: {integrity: sha512-ohj72kbtVWCpKYMxcbJ+xaOBV3En76hW47j52dG+tEGG36LZQgfFw5yHl9xyjmosy3XUMn8d/GBUAy4YPM839w==}
     dev: true
 
   /webidl-conversions@3.0.1:
@@ -16293,6 +17064,46 @@ packages:
       schema-utils: 3.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.10(esbuild@0.20.2)(webpack@5.92.0)
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: false
+
+  /webpack@5.92.1(esbuild@0.20.2):
+    resolution: {integrity: sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.12.0
+      acorn-import-attributes: 1.9.5(acorn@8.12.0)
+      browserslist: 4.23.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.17.0
+      es-module-lexer: 1.5.4
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(esbuild@0.20.2)(webpack@5.92.1)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -16614,3 +17425,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## What are you changing?
Updates web-vitals to 

1. Send attribution data with CLS, LCP and INP
2. A new endpoint. The data will now go to the [events collector](https://github.com/guardian/events-collector). The events collector does not have separate endpoints for CODE and PROD environments. Instead, this stage is determined by the isDev parameter and added to the payload to allow us to separate the dataset by stage in big query. 

## Why?
Additional attribution data will help with diagnosing web vital issues on DCR. As well as this, the events collector provides a more agnostic schema with a focus on anonymity of data and is a more fitting pipeline for this dataset.
