### PR TITLE
Use correct tests attribute on the window for sourcepoint AB test

### DIFF
--- a/.changeset/spicy-numbers-beam.md
+++ b/.changeset/spicy-numbers-beam.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': patch
+---
+
+Fix issue with sourcepoint AB test

--- a/@types/window.d.ts
+++ b/@types/window.d.ts
@@ -17,9 +17,9 @@ declare global {
 				subscriptions: () => string[];
 			};
 			config?: {
+				tests?: ServerSideTests;
 				page?: {
 					isPreview: boolean;
-					abTests?: ServerSideTests;
 				};
 				stage?: string;
 				isDev?: boolean;

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -56,7 +56,7 @@ export const init = (framework: ConsentFramework, pubData = {}): void => {
 	const frameworkMessageType: string = framework == 'tcfv2' ? 'gdpr' : 'ccpa';
 
 	const isInPropertyIdABTest =
-		window.guardian?.config?.page?.abTests?.useSourcepointPropertyIdVariant ===
+		window.guardian?.config?.tests?.useSourcepointPropertyIdVariant ===
 		'variant';
 
 	log('cmp', `framework: ${framework}`);


### PR DESCRIPTION
## What are you changing?
use `window.guardian.config.tests` instead of `window.guardian.config.page.abTests`

## Why?
The latter is only available in DCR, and this needs to run across all pages including frontend rendered ones.
