### PR TITLE
Convert stories to Component Story Format

### DIFF
--- a/libs/@guardian/source/.eslintrc.cjs
+++ b/libs/@guardian/source/.eslintrc.cjs
@@ -50,8 +50,12 @@ module.exports = {
 		{
 			files: ['**/*.stories.tsx'],
 			rules: {
-				// storybook require this
+				// Storybook require this
 				'import/no-default-export': 'off',
+				// The CSF3 custom `render` function is lowercase. This breaks the rule
+				// that component names must start with a capital letter.
+				// https://github.com/storybookjs/storybook/issues/21115
+				'react-hooks/rules-of-hooks': 'off',
 			},
 		},
 	],

--- a/libs/@guardian/source/src/react-components/accordion/Accordion.stories.tsx
+++ b/libs/@guardian/source/src/react-components/accordion/Accordion.stories.tsx
@@ -1,78 +1,72 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
-import type { AccordionProps } from './Accordion';
 import { Accordion } from './Accordion';
 import { AccordionRow } from './AccordionRow';
 
 const meta: Meta<typeof Accordion> = {
 	title: 'React Components/Accordion',
 	component: Accordion,
+};
+
+export default meta;
+type Story = StoryObj<typeof Accordion>;
+
+const AccordionTemplate: Story = {
+	render: ({ hideToggleLabel, theme }) => (
+		<Accordion hideToggleLabel={hideToggleLabel} theme={theme}>
+			<AccordionRow label="Collecting from multiple newsagents" theme={theme}>
+				Present your card to a newsagent each time you collect the paper. The
+				newsagent will scan your card and will be reimbursed for each
+				transaction automatically.
+			</AccordionRow>
+			<AccordionRow label="Delivery from your retailer" theme={theme}>
+				Simply give your preferred store / retailer the barcode printed on your
+				subscription letter.
+			</AccordionRow>
+		</Accordion>
+	),
+};
+
+export const WithCTALabelsDefaultTheme: Story = {
+	...AccordionTemplate,
 	args: {
 		hideToggleLabel: false,
 	},
 };
 
-export default meta;
-
-const Template: StoryFn<typeof Accordion> = (args: AccordionProps) => (
-	<Accordion {...args}>
-		<AccordionRow {...args} label="Collecting from multiple newsagents">
-			Present your card to a newsagent each time you collect the paper. The
-			newsagent will scan your card and will be reimbursed for each transaction
-			automatically.
-		</AccordionRow>
-		<AccordionRow {...args} label="Delivery from your retailer">
-			Simply give your preferred store / retailer the barcode printed on your
-			subscription letter.
-		</AccordionRow>
-	</Accordion>
-);
-
-export const WithCTALabelsDefaultTheme: StoryFn<typeof Accordion> =
-	Template.bind({});
-
-// *****************************************************************************
-
-export const WithoutCTALabelsDefaultTheme: StoryFn<typeof Accordion> =
-	Template.bind({});
-WithoutCTALabelsDefaultTheme.args = {
-	hideToggleLabel: true,
-};
-
-// *****************************************************************************
-
-export const WithCTALabelsCustomTheme: StoryFn<typeof Accordion> =
-	Template.bind({});
-WithCTALabelsCustomTheme.args = {
-	theme: {
-		textCta: palette.neutral[86],
-		textLabel: palette.neutral[86],
-		textBody: palette.neutral[86],
-		border: palette.neutral[60],
-		iconFill: palette.neutral[86],
+export const WithoutCTALabelsDefaultTheme: Story = {
+	...AccordionTemplate,
+	args: {
+		hideToggleLabel: true,
 	},
 };
-WithCTALabelsCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
-	},
-};
-// *****************************************************************************
 
-export const WithoutCTALabelsCustomTheme: StoryFn<typeof Accordion> =
-	Template.bind({});
-WithoutCTALabelsCustomTheme.args = {
-	hideToggleLabel: true,
-	theme: {
-		textLabel: palette.neutral[86],
-		textBody: palette.neutral[86],
-		textCta: palette.neutral[86],
-		border: palette.neutral[60],
-		iconFill: palette.neutral[86],
+export const WithCTALabelsCustomTheme: Story = {
+	...AccordionTemplate,
+	args: {
+		...WithCTALabelsDefaultTheme.args,
+		theme: {
+			textCta: palette.neutral[86],
+			textLabel: palette.neutral[86],
+			textBody: palette.neutral[86],
+			border: palette.neutral[60],
+			iconFill: palette.neutral[86],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };
-WithoutCTALabelsCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const WithOutCTALabelsCustomTheme: Story = {
+	...AccordionTemplate,
+	args: {
+		...WithCTALabelsCustomTheme.args,
+		hideToggleLabel: true,
+	},
+	parameters: {
+		...WithCTALabelsCustomTheme.parameters,
 	},
 };

--- a/libs/@guardian/source/src/react-components/accordion/Accordion.stories.tsx
+++ b/libs/@guardian/source/src/react-components/accordion/Accordion.stories.tsx
@@ -11,15 +11,18 @@ const meta: Meta<typeof Accordion> = {
 export default meta;
 type Story = StoryObj<typeof Accordion>;
 
-const AccordionTemplate: Story = {
-	render: ({ hideToggleLabel, theme }) => (
-		<Accordion hideToggleLabel={hideToggleLabel} theme={theme}>
-			<AccordionRow label="Collecting from multiple newsagents" theme={theme}>
+const Template: Story = {
+	render: (args) => (
+		<Accordion hideToggleLabel={args.hideToggleLabel} theme={args.theme}>
+			<AccordionRow
+				label="Collecting from multiple newsagents"
+				theme={args.theme}
+			>
 				Present your card to a newsagent each time you collect the paper. The
 				newsagent will scan your card and will be reimbursed for each
 				transaction automatically.
 			</AccordionRow>
-			<AccordionRow label="Delivery from your retailer" theme={theme}>
+			<AccordionRow label="Delivery from your retailer" theme={args.theme}>
 				Simply give your preferred store / retailer the barcode printed on your
 				subscription letter.
 			</AccordionRow>
@@ -28,21 +31,21 @@ const AccordionTemplate: Story = {
 };
 
 export const WithCTALabelsDefaultTheme: Story = {
-	...AccordionTemplate,
+	...Template,
 	args: {
 		hideToggleLabel: false,
 	},
 };
 
 export const WithoutCTALabelsDefaultTheme: Story = {
-	...AccordionTemplate,
+	...Template,
 	args: {
 		hideToggleLabel: true,
 	},
 };
 
 export const WithCTALabelsCustomTheme: Story = {
-	...AccordionTemplate,
+	...Template,
 	args: {
 		...WithCTALabelsDefaultTheme.args,
 		theme: {
@@ -61,7 +64,7 @@ export const WithCTALabelsCustomTheme: Story = {
 };
 
 export const WithoutCTALabelsCustomTheme: Story = {
-	...AccordionTemplate,
+	...Template,
 	args: {
 		...WithCTALabelsCustomTheme.args,
 		hideToggleLabel: true,

--- a/libs/@guardian/source/src/react-components/accordion/Accordion.stories.tsx
+++ b/libs/@guardian/source/src/react-components/accordion/Accordion.stories.tsx
@@ -60,7 +60,7 @@ export const WithCTALabelsCustomTheme: Story = {
 	},
 };
 
-export const WithOutCTALabelsCustomTheme: Story = {
+export const WithoutCTALabelsCustomTheme: Story = {
 	...AccordionTemplate,
 	args: {
 		...WithCTALabelsCustomTheme.args,

--- a/libs/@guardian/source/src/react-components/brand/SvgGuardianBestWebsiteLogo.stories.tsx
+++ b/libs/@guardian/source/src/react-components/brand/SvgGuardianBestWebsiteLogo.stories.tsx
@@ -1,5 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/react';
-import type { SvgGuardianBestWebsiteLogoProps } from './SvgGuardianBestWebsiteLogo';
+import type { Meta, StoryObj } from '@storybook/react';
 import { SvgGuardianBestWebsiteLogo } from './SvgGuardianBestWebsiteLogo';
 
 const meta: Meta<typeof SvgGuardianBestWebsiteLogo> = {
@@ -13,10 +12,6 @@ const meta: Meta<typeof SvgGuardianBestWebsiteLogo> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof SvgGuardianBestWebsiteLogo>;
 
-const Template: StoryFn<typeof SvgGuardianBestWebsiteLogo> = (
-	args: SvgGuardianBestWebsiteLogoProps,
-) => <SvgGuardianBestWebsiteLogo {...args} />;
-
-export const Default: StoryFn<typeof SvgGuardianBestWebsiteLogo> =
-	Template.bind({});
+export const Default: Story = {};

--- a/libs/@guardian/source/src/react-components/brand/SvgGuardianLiveLogo.stories.tsx
+++ b/libs/@guardian/source/src/react-components/brand/SvgGuardianLiveLogo.stories.tsx
@@ -1,5 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/react';
-import type { SvgGuardianLiveLogoProps } from './SvgGuardianLiveLogo';
+import type { Meta, StoryObj } from '@storybook/react';
 import { SvgGuardianLiveLogo } from './SvgGuardianLiveLogo';
 
 const meta: Meta<typeof SvgGuardianLiveLogo> = {
@@ -13,9 +12,6 @@ const meta: Meta<typeof SvgGuardianLiveLogo> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof SvgGuardianLiveLogo>;
 
-const Template: StoryFn<typeof SvgGuardianLiveLogo> = (
-	args: SvgGuardianLiveLogoProps,
-) => <SvgGuardianLiveLogo {...args} />;
-
-export const Default: StoryFn<typeof SvgGuardianLiveLogo> = Template.bind({});
+export const Default: Story = {};

--- a/libs/@guardian/source/src/react-components/brand/SvgGuardianLogo.stories.tsx
+++ b/libs/@guardian/source/src/react-components/brand/SvgGuardianLogo.stories.tsx
@@ -1,5 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/react';
-import type { SvgGuardianLogoProps } from './SvgGuardianLogo';
+import type { Meta, StoryObj } from '@storybook/react';
 import { SvgGuardianLogo } from './SvgGuardianLogo';
 
 const meta: Meta<typeof SvgGuardianLogo> = {
@@ -13,9 +12,6 @@ const meta: Meta<typeof SvgGuardianLogo> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof SvgGuardianLogo>;
 
-const Template: StoryFn<typeof SvgGuardianLogo> = (
-	args: SvgGuardianLogoProps,
-) => <SvgGuardianLogo {...args} />;
-
-export const Default: StoryFn<typeof SvgGuardianLogo> = Template.bind({});
+export const Default: Story = {};

--- a/libs/@guardian/source/src/react-components/brand/SvgRoundelBrand.stories.tsx
+++ b/libs/@guardian/source/src/react-components/brand/SvgRoundelBrand.stories.tsx
@@ -1,5 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/react';
-import type { SvgRoundelBrandProps } from './SvgRoundelBrand';
+import type { Meta, StoryObj } from '@storybook/react';
 import { SvgRoundelBrand } from './SvgRoundelBrand';
 
 const meta: Meta<typeof SvgRoundelBrand> = {
@@ -13,9 +12,6 @@ const meta: Meta<typeof SvgRoundelBrand> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof SvgRoundelBrand>;
 
-const Template: StoryFn<typeof SvgRoundelBrand> = (
-	args: SvgRoundelBrandProps,
-) => <SvgRoundelBrand {...args} />;
-
-export const Default: StoryFn<typeof SvgRoundelBrand> = Template.bind({});
+export const Default: Story = {};

--- a/libs/@guardian/source/src/react-components/brand/SvgRoundelBrandInverse.stories.tsx
+++ b/libs/@guardian/source/src/react-components/brand/SvgRoundelBrandInverse.stories.tsx
@@ -1,5 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/react';
-import type { SvgRoundelBrandInverseProps } from './SvgRoundelBrandInverse';
+import type { Meta, StoryObj } from '@storybook/react';
 import { SvgRoundelBrandInverse } from './SvgRoundelBrandInverse';
 
 const meta: Meta<typeof SvgRoundelBrandInverse> = {
@@ -13,11 +12,6 @@ const meta: Meta<typeof SvgRoundelBrandInverse> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof SvgRoundelBrandInverse>;
 
-const Template: StoryFn<typeof SvgRoundelBrandInverse> = (
-	args: SvgRoundelBrandInverseProps,
-) => <SvgRoundelBrandInverse {...args} />;
-
-export const Default: StoryFn<typeof SvgRoundelBrandInverse> = Template.bind(
-	{},
-);
+export const Default: Story = {};

--- a/libs/@guardian/source/src/react-components/brand/SvgRoundelDefault.stories.tsx
+++ b/libs/@guardian/source/src/react-components/brand/SvgRoundelDefault.stories.tsx
@@ -1,5 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/react';
-import type { SvgRoundelDefaultProps } from './SvgRoundelDefault';
+import type { Meta, StoryObj } from '@storybook/react';
 import { SvgRoundelDefault } from './SvgRoundelDefault';
 
 const meta: Meta<typeof SvgRoundelDefault> = {
@@ -13,9 +12,6 @@ const meta: Meta<typeof SvgRoundelDefault> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof SvgRoundelDefault>;
 
-const Template: StoryFn<typeof SvgRoundelDefault> = (
-	args: SvgRoundelDefaultProps,
-) => <SvgRoundelDefault {...args} />;
-
-export const Default: StoryFn<typeof SvgRoundelDefault> = Template.bind({});
+export const Default: Story = {};

--- a/libs/@guardian/source/src/react-components/brand/SvgRoundelInverse.stories.tsx
+++ b/libs/@guardian/source/src/react-components/brand/SvgRoundelInverse.stories.tsx
@@ -1,5 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/react';
-import type { SvgRoundelInverseProps } from './SvgRoundelInverse';
+import type { Meta, StoryObj } from '@storybook/react';
 import { SvgRoundelInverse } from './SvgRoundelInverse';
 
 const meta: Meta<typeof SvgRoundelInverse> = {
@@ -13,9 +12,6 @@ const meta: Meta<typeof SvgRoundelInverse> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof SvgRoundelInverse>;
 
-const Template: StoryFn<typeof SvgRoundelInverse> = (
-	args: SvgRoundelInverseProps,
-) => <SvgRoundelInverse {...args} />;
-
-export const Default: StoryFn<typeof SvgRoundelInverse> = Template.bind({});
+export const Default: Story = {};

--- a/libs/@guardian/source/src/react-components/button/Button.stories.tsx
+++ b/libs/@guardian/source/src/react-components/button/Button.stories.tsx
@@ -1,7 +1,6 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { SvgCross } from '../__generated__/icons/SvgCross';
-import type { ButtonProps } from './Button';
 import { Button } from './Button';
 import { themeButtonBrand, themeButtonBrandAlt } from './theme';
 import {
@@ -32,6 +31,11 @@ const themeParameters = {
 			default: 'brandAltBackground.primary',
 		},
 	},
+	custom: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
+	},
 };
 
 const meta: Meta<typeof Button> = {
@@ -39,390 +43,346 @@ const meta: Meta<typeof Button> = {
 	component: Button,
 	argTypes: {
 		icon: {
-			options: ['undefined', 'cross'],
+			options: ['None', 'Cross'],
 			mapping: {
-				undefined: undefined,
-				cross: <SvgCross />,
+				None: undefined,
+				Cross: <SvgCross />,
 			},
 			control: { type: 'radio' },
 		},
 	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const PrimaryPriorityDefaultTheme: Story = {
 	args: {
 		children: 'Subscribe now',
 		size: 'default',
 		hideLabel: false,
-		icon: undefined,
+		// @ts-expect-error - Name from control options which Storybook maps to `undefined`
+		icon: 'None',
 		priority: 'primary',
 		iconSide: 'left',
 		nudgeIcon: false,
 	},
 };
 
-export default meta;
-
-const Template: StoryFn<typeof Button> = (args: ButtonProps) => (
-	<Button {...args} />
-);
-
-// *****************************************************************************
-
-export const PrimaryPriorityDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-PrimaryPriorityDefaultTheme.args = {
-	priority: 'primary',
-};
-
-export const SecondaryPriorityDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-SecondaryPriorityDefaultTheme.args = {
-	priority: 'secondary',
-};
-
-export const TertiaryPriorityDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-TertiaryPriorityDefaultTheme.args = {
-	priority: 'tertiary',
-};
-
-export const SubduedPriorityDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-SubduedPriorityDefaultTheme.args = {
-	priority: 'subdued',
-};
-
-// *****************************************************************************
-
-export const PrimaryPriorityBrandTheme: StoryFn<typeof Button> = Template.bind(
-	{},
-);
-PrimaryPriorityBrandTheme.args = {
-	priority: 'primary',
-	theme: themeButtonBrand,
-};
-PrimaryPriorityBrandTheme.parameters = themeParameters.brand;
-
-export const SecondaryPriorityBrandTheme: StoryFn<typeof Button> =
-	Template.bind({});
-SecondaryPriorityBrandTheme.args = {
-	priority: 'secondary',
-	theme: themeButtonBrand,
-};
-SecondaryPriorityBrandTheme.parameters = themeParameters.brand;
-
-export const TertiaryPriorityBrandTheme: StoryFn<typeof Button> = Template.bind(
-	{},
-);
-TertiaryPriorityBrandTheme.args = {
-	priority: 'tertiary',
-	theme: themeButtonBrand,
-};
-TertiaryPriorityBrandTheme.parameters = themeParameters.brand;
-
-export const SubduedPriorityBrandTheme: StoryFn<typeof Button> = Template.bind(
-	{},
-);
-SubduedPriorityBrandTheme.args = {
-	priority: 'subdued',
-	theme: themeButtonBrand,
-};
-SubduedPriorityBrandTheme.parameters = themeParameters.brand;
-
-// *****************************************************************************
-
-export const PrimaryPriorityBrandAltTheme: StoryFn<typeof Button> =
-	Template.bind({});
-PrimaryPriorityBrandAltTheme.args = {
-	priority: 'primary',
-	theme: themeButtonBrandAlt,
-};
-PrimaryPriorityBrandAltTheme.parameters = themeParameters.brandAlt;
-
-export const SecondaryPriorityBrandAltTheme: StoryFn<typeof Button> =
-	Template.bind({});
-SecondaryPriorityBrandAltTheme.args = {
-	priority: 'secondary',
-	theme: themeButtonBrandAlt,
-};
-SecondaryPriorityBrandAltTheme.parameters = themeParameters.brandAlt;
-
-export const TertiaryPriorityBrandAltTheme: StoryFn<typeof Button> =
-	Template.bind({});
-TertiaryPriorityBrandAltTheme.args = {
-	priority: 'tertiary',
-	theme: themeButtonBrandAlt,
-};
-TertiaryPriorityBrandAltTheme.parameters = themeParameters.brandAlt;
-
-export const SubduedPriorityBrandAltTheme: StoryFn<typeof Button> =
-	Template.bind({});
-SubduedPriorityBrandAltTheme.args = {
-	priority: 'subdued',
-	theme: themeButtonBrandAlt,
-};
-SubduedPriorityBrandAltTheme.parameters = themeParameters.brandAlt;
-
-// *****************************************************************************
-
-export const PrimaryPriorityReaderRevenueTheme: StoryFn<typeof Button> =
-	Template.bind({});
-PrimaryPriorityReaderRevenueTheme.args = {
-	priority: 'primary',
-	theme: themeButtonReaderRevenue,
-};
-
-export const TertiaryPriorityReaderRevenueTheme: StoryFn<typeof Button> =
-	Template.bind({});
-TertiaryPriorityReaderRevenueTheme.args = {
-	priority: 'tertiary',
-	theme: themeButtonReaderRevenue,
-};
-
-// *****************************************************************************
-
-export const PrimaryPriorityReaderRevenueBrandTheme: StoryFn<typeof Button> =
-	Template.bind({});
-PrimaryPriorityReaderRevenueBrandTheme.args = {
-	priority: 'primary',
-	theme: themeButtonReaderRevenueBrand,
-};
-PrimaryPriorityReaderRevenueBrandTheme.parameters =
-	themeParameters.readerRevenueBrand;
-
-export const TertiaryPriorityReaderRevenueBrandTheme: StoryFn<typeof Button> =
-	Template.bind({});
-TertiaryPriorityReaderRevenueBrandTheme.args = {
-	priority: 'tertiary',
-	theme: themeButtonReaderRevenueBrand,
-};
-TertiaryPriorityReaderRevenueBrandTheme.parameters =
-	themeParameters.readerRevenueBrand;
-
-// *****************************************************************************
-
-export const PrimaryPriorityReaderRevenueBrandAltTheme: StoryFn<typeof Button> =
-	Template.bind({});
-PrimaryPriorityReaderRevenueBrandAltTheme.args = {
-	priority: 'primary',
-	theme: themeButtonReaderRevenueBrandAlt,
-};
-PrimaryPriorityReaderRevenueBrandAltTheme.parameters =
-	themeParameters.readerRevenueBrandAlt;
-
-export const TertiaryPriorityReaderRevenueBrandAltTheme: StoryFn<
-	typeof Button
-> = Template.bind({});
-TertiaryPriorityReaderRevenueBrandAltTheme.args = {
-	priority: 'tertiary',
-	theme: themeButtonReaderRevenueBrandAlt,
-};
-TertiaryPriorityReaderRevenueBrandAltTheme.parameters =
-	themeParameters.readerRevenueBrandAlt;
-
-// *****************************************************************************
-
-export const DefaultSizeDefaultTheme: StoryFn<typeof Button> = Template.bind(
-	{},
-);
-
-// *****************************************************************************
-
-export const SmallSizeDefaultTheme: StoryFn<typeof Button> = Template.bind({});
-SmallSizeDefaultTheme.args = {
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const XSmallSizeDefaultTheme: StoryFn<typeof Button> = Template.bind({});
-XSmallSizeDefaultTheme.args = {
-	size: 'xsmall',
-};
-
-// *****************************************************************************
-
-export const TextAndIconLeftDefaultSizeDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-TextAndIconLeftDefaultSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
-	icon: 'cross',
-	children: 'Close',
-};
-
-// *****************************************************************************
-
-export const TextAndIconRightDefaultSizeDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-TextAndIconRightDefaultSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
-	icon: 'cross',
-	iconSide: 'right',
-	children: 'Close',
-};
-
-// *****************************************************************************
-
-export const TextAndIconLeftSmallSizeDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-TextAndIconLeftSmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
-	icon: 'cross',
-	size: 'small',
-	children: 'Close',
-};
-
-// *****************************************************************************
-
-export const TextAndIconRightSmallSizeDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-TextAndIconRightSmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
-	icon: 'cross',
-	iconSide: 'right',
-	size: 'small',
-	children: 'Close',
-};
-
-// *****************************************************************************
-
-export const TextAndIconLeftXSmallSizeDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-TextAndIconLeftXSmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
-	icon: 'cross',
-	size: 'xsmall',
-	children: 'Close',
-};
-
-// *****************************************************************************
-
-export const TextAndIconRightXSmallSizeDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-TextAndIconRightXSmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
-	icon: 'cross',
-	iconSide: 'right',
-	size: 'xsmall',
-	children: 'Close',
-};
-
-// *****************************************************************************
-
-export const IconOnlyDefaultSizeDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-IconOnlyDefaultSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
-	icon: 'cross',
-	hideLabel: true,
-	children: 'Close subscription banner',
-};
-
-// *****************************************************************************
-
-export const IconOnlySmallSizeDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-IconOnlySmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
-	icon: 'cross',
-	hideLabel: true,
-	size: 'small',
-	children: 'Close subscription banner',
-};
-
-// *****************************************************************************
-
-export const IconOnlyXSmallSizeDefaultTheme: StoryFn<typeof Button> =
-	Template.bind({});
-IconOnlyXSmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'JSX element' to <SvgCross />
-	icon: 'cross',
-	hideLabel: true,
-	size: 'xsmall',
-	children: 'Close subscription banner',
-};
-
-// *****************************************************************************
-
-export const IsLoadingPrimary: StoryFn<typeof Button> = Template.bind({});
-IsLoadingPrimary.args = {
-	isLoading: true,
-};
-
-// *****************************************************************************
-
-export const IsLoadingPrimarySmall: StoryFn<typeof Button> = Template.bind({});
-IsLoadingPrimarySmall.args = {
-	isLoading: true,
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const IsLoadingPrimaryXSmall: StoryFn<typeof Button> = Template.bind({});
-IsLoadingPrimaryXSmall.args = {
-	isLoading: true,
-	size: 'xsmall',
-};
-
-// *****************************************************************************
-
-export const IsLoadingSecondary: StoryFn<typeof Button> = Template.bind({});
-IsLoadingSecondary.args = {
-	isLoading: true,
-	priority: 'secondary',
-};
-
-// *****************************************************************************
-
-export const IsLoadingTertiary: StoryFn<typeof Button> = Template.bind({});
-IsLoadingTertiary.args = {
-	isLoading: true,
-	priority: 'tertiary',
-};
-
-// *****************************************************************************
-
-export const IsLoadingSubdued: StoryFn<typeof Button> = Template.bind({});
-IsLoadingSubdued.args = {
-	isLoading: true,
-	priority: 'subdued',
-};
-
-// *****************************************************************************
-
-export const IsLoadingIconSideRight: StoryFn<typeof Button> = Template.bind({});
-IsLoadingIconSideRight.args = {
-	isLoading: true,
-	iconSide: 'right',
-};
-
-// *****************************************************************************
-
-export const IsLoadingDisabled: StoryFn<typeof Button> = Template.bind({});
-IsLoadingDisabled.args = {
-	isLoading: true,
-	disabled: true,
-};
-
-// *****************************************************************************
-
-export const IsLoadingLabelHidden: StoryFn<typeof Button> = Template.bind({});
-IsLoadingLabelHidden.args = {
-	isLoading: true,
-	hideLabel: true,
-};
-
-// *****************************************************************************
-
-export const CustomTheme: StoryFn<typeof Button> = Template.bind({});
-CustomTheme.args = {
-	theme: {
-		textPrimary: palette.brand[400],
-		backgroundPrimary: palette.brandAlt[400],
-		backgroundPrimaryHover: palette.brandAlt[200],
+export const SecondaryPriorityDefaultTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		priority: 'secondary',
 	},
 };
-CustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const TertiaryPriorityDefaultTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		priority: 'tertiary',
+	},
+};
+
+export const SubduedPriorityDefaultTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		priority: 'subdued',
+	},
+};
+
+export const PrimaryPriorityBrandTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		theme: themeButtonBrand,
+	},
+	parameters: {
+		...themeParameters.brand,
+	},
+};
+
+export const SecondaryPriorityBrandTheme: Story = {
+	args: {
+		...SecondaryPriorityDefaultTheme.args,
+		theme: themeButtonBrand,
+	},
+	parameters: {
+		...themeParameters.brand,
+	},
+};
+
+export const TertiaryPriorityBrandTheme: Story = {
+	args: {
+		...TertiaryPriorityDefaultTheme.args,
+		theme: themeButtonBrand,
+	},
+	parameters: {
+		...themeParameters.brand,
+	},
+};
+
+export const SubduedPriorityBrandTheme: Story = {
+	args: {
+		...SubduedPriorityDefaultTheme.args,
+		theme: themeButtonBrand,
+	},
+	parameters: {
+		...themeParameters.brand,
+	},
+};
+
+export const PrimaryPriorityBrandAltTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		theme: themeButtonBrandAlt,
+	},
+	parameters: {
+		...themeParameters.brandAlt,
+	},
+};
+
+export const SecondaryPriorityBrandAltTheme: Story = {
+	args: {
+		...SecondaryPriorityDefaultTheme.args,
+		theme: themeButtonBrandAlt,
+	},
+	parameters: {
+		...themeParameters.brandAlt,
+	},
+};
+
+export const TertiaryPriorityBrandAltTheme: Story = {
+	args: {
+		...TertiaryPriorityDefaultTheme.args,
+		theme: themeButtonBrandAlt,
+	},
+	parameters: {
+		...themeParameters.brandAlt,
+	},
+};
+
+export const SubduedPriorityBrandAltTheme: Story = {
+	args: {
+		...SubduedPriorityDefaultTheme.args,
+		theme: themeButtonBrandAlt,
+	},
+	parameters: {
+		...themeParameters.brandAlt,
+	},
+};
+
+export const PrimaryPriorityReaderRevenueTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		theme: themeButtonReaderRevenue,
+	},
+};
+
+export const TertiaryPriorityReaderRevenueTheme: Story = {
+	args: {
+		...TertiaryPriorityDefaultTheme.args,
+		theme: themeButtonReaderRevenue,
+	},
+};
+
+export const PrimaryPriorityReaderRevenueBrandTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		theme: themeButtonReaderRevenueBrand,
+	},
+	parameters: {
+		...themeParameters.readerRevenueBrand,
+	},
+};
+
+export const TertiaryPriorityReaderRevenueBrandTheme: Story = {
+	args: {
+		...TertiaryPriorityDefaultTheme.args,
+		theme: themeButtonReaderRevenueBrand,
+	},
+	parameters: {
+		...themeParameters.readerRevenueBrand,
+	},
+};
+
+export const PrimaryPriorityReaderRevenueBrandAltTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		theme: themeButtonReaderRevenueBrandAlt,
+	},
+	parameters: {
+		...themeParameters.readerRevenueBrandAlt,
+	},
+};
+
+export const TertiaryPriorityReaderRevenueBrandAltTheme: Story = {
+	args: {
+		...TertiaryPriorityDefaultTheme.args,
+		theme: themeButtonReaderRevenueBrandAlt,
+	},
+	parameters: {
+		...themeParameters.readerRevenueBrandAlt,
+	},
+};
+
+export const DefaultSizeDefaultTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+	},
+};
+
+export const SmallSizeDefaultTheme: Story = {
+	args: {
+		...DefaultSizeDefaultTheme.args,
+		size: 'small',
+	},
+};
+
+export const XSmallSizeDefaultTheme: Story = {
+	args: {
+		...DefaultSizeDefaultTheme.args,
+		size: 'xsmall',
+	},
+};
+
+export const TextAndIconLeftDefaultSizeDefaultTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		// @ts-expect-error - Name from control options which Storybook maps to `<SvgCross />`
+		icon: 'Cross',
+		children: 'Close',
+	},
+};
+
+export const TextAndIconRightDefaultSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconLeftDefaultSizeDefaultTheme.args,
+		iconSide: 'right',
+	},
+};
+
+export const TextAndIconLeftSmallSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconLeftDefaultSizeDefaultTheme.args,
+		size: 'small',
+	},
+};
+
+export const TextAndIconRightSmallSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconRightDefaultSizeDefaultTheme.args,
+		size: 'small',
+	},
+};
+
+export const TextAndIconLeftXSmallSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconLeftDefaultSizeDefaultTheme.args,
+		size: 'xsmall',
+	},
+};
+
+export const TextAndIconRightXSmallSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconRightDefaultSizeDefaultTheme.args,
+		size: 'xsmall',
+	},
+};
+
+export const IconOnlyDefaultSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconLeftDefaultSizeDefaultTheme.args,
+		hideLabel: true,
+		children: 'Close subscription banner',
+	},
+};
+
+export const IconOnlySmallSizeDefaultTheme: Story = {
+	args: {
+		...IconOnlyDefaultSizeDefaultTheme.args,
+		size: 'small',
+	},
+};
+
+export const IconOnlyXSmallSizeDefaultTheme: Story = {
+	args: {
+		...IconOnlyDefaultSizeDefaultTheme.args,
+		size: 'xsmall',
+	},
+};
+
+export const IsLoadingPrimary: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		isLoading: true,
+	},
+};
+
+export const IsLoadingPrimarySmall: Story = {
+	args: {
+		...IsLoadingPrimary.args,
+		size: 'small',
+	},
+};
+
+export const IsLoadingPrimaryXSmall: Story = {
+	args: {
+		...IsLoadingPrimary.args,
+		size: 'xsmall',
+	},
+};
+
+export const IsLoadingSecondary: Story = {
+	args: {
+		...IsLoadingPrimary.args,
+		priority: 'secondary',
+	},
+};
+
+export const IsLoadingTertiary: Story = {
+	args: {
+		...IsLoadingPrimary.args,
+		priority: 'tertiary',
+	},
+};
+
+export const IsLoadingSubdued: Story = {
+	args: {
+		...IsLoadingPrimary.args,
+		priority: 'subdued',
+	},
+};
+
+export const IsLoadingIconSideRight: Story = {
+	args: {
+		...IsLoadingPrimary.args,
+		iconSide: 'right',
+	},
+};
+
+export const IsLoadingDisabled: Story = {
+	args: {
+		...IsLoadingPrimary.args,
+		disabled: true,
+	},
+};
+
+export const IsLoadingLabelHidden: Story = {
+	args: {
+		...IsLoadingPrimary.args,
+		hideLabel: true,
+	},
+};
+
+export const CustomTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		theme: {
+			textPrimary: palette.brand[400],
+			backgroundPrimary: palette.brandAlt[400],
+			backgroundPrimaryHover: palette.brandAlt[200],
+		},
+	},
+	parameters: {
+		...themeParameters.custom,
 	},
 };

--- a/libs/@guardian/source/src/react-components/button/LinkButton.stories.tsx
+++ b/libs/@guardian/source/src/react-components/button/LinkButton.stories.tsx
@@ -1,27 +1,33 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { SvgArrowRightStraight } from '../__generated__/icons/SvgArrowRightStraight';
 import { LinkButton } from './LinkButton';
-import type { LinkButtonProps } from './LinkButton';
 
 const meta: Meta<typeof LinkButton> = {
 	title: 'React Components/LinkButton',
 	component: LinkButton,
 	argTypes: {
 		icon: {
-			options: ['undefined', 'arrow'],
+			options: ['None', 'Arrow'],
 			mapping: {
-				undefined: undefined,
-				arrow: <SvgArrowRightStraight />,
+				None: undefined,
+				Arrow: <SvgArrowRightStraight />,
 			},
 			control: { type: 'radio' },
 		},
 	},
+};
+
+export default meta;
+type Story = StoryObj<typeof LinkButton>;
+
+export const PrimaryPriorityDefaultTheme: Story = {
 	args: {
 		children: 'Subscribe now',
 		size: 'default',
 		hideLabel: false,
-		icon: undefined,
+		// @ts-expect-error - Name from control options which Storybook maps to `undefined`
+		icon: 'None',
 		priority: 'primary',
 		iconSide: 'left',
 		nudgeIcon: false,
@@ -29,178 +35,117 @@ const meta: Meta<typeof LinkButton> = {
 	},
 };
 
-export default meta;
-
-const Template: StoryFn<typeof LinkButton> = (args: LinkButtonProps) => (
-	<LinkButton {...args} />
-);
-
-// *****************************************************************************
-
-export const PrimaryPriorityDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-PrimaryPriorityDefaultTheme.args = {
-	priority: 'primary',
-};
-
-// *****************************************************************************
-
-export const SecondaryPriorityDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-SecondaryPriorityDefaultTheme.args = {
-	priority: 'secondary',
-};
-
-// *****************************************************************************
-
-export const TertiaryPriorityDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-TertiaryPriorityDefaultTheme.args = {
-	priority: 'tertiary',
-};
-
-// *****************************************************************************
-
-export const SubduedPriorityDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-SubduedPriorityDefaultTheme.args = {
-	priority: 'subdued',
-};
-
-// *****************************************************************************
-
-export const TextAndIconLeftDefaultSizeDefaultTheme: StoryFn<
-	typeof LinkButton
-> = Template.bind({});
-TextAndIconLeftDefaultSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-};
-
-// *****************************************************************************
-
-export const TextAndIconRightDefaultSizeDefaultTheme: StoryFn<
-	typeof LinkButton
-> = Template.bind({});
-TextAndIconRightDefaultSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-	iconSide: 'right',
-};
-
-// *****************************************************************************
-
-export const TextAndIconLeftSmallSizeDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-TextAndIconLeftSmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const TextAndIconRightSmallSizeDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-TextAndIconRightSmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-	iconSide: 'right',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const TextAndIconLeftXSmallSizeDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-TextAndIconLeftXSmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-	size: 'xsmall',
-};
-
-// *****************************************************************************
-
-export const TextAndIconRightXSmallSizeDefaultTheme: StoryFn<
-	typeof LinkButton
-> = Template.bind({});
-TextAndIconRightXSmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-	iconSide: 'right',
-	size: 'xsmall',
-};
-
-// *****************************************************************************
-
-export const TextAndIconLeftWithNudgeDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-TextAndIconLeftWithNudgeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-	nudgeIcon: true,
-};
-
-// *****************************************************************************
-
-export const TextAndIconRightWithNudgeDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-TextAndIconRightWithNudgeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-	iconSide: 'right',
-	nudgeIcon: true,
-};
-
-// *****************************************************************************
-
-export const IconOnlyDefaultSizeDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-IconOnlyDefaultSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-	hideLabel: true,
-};
-
-// *****************************************************************************
-
-export const IconOnlySmallSizeDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-IconOnlySmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-	size: 'small',
-	hideLabel: true,
-};
-
-// *****************************************************************************
-
-export const IconOnlyXSmallSizeDefaultTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-IconOnlyXSmallSizeDefaultTheme.args = {
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-	size: 'xsmall',
-	hideLabel: true,
-};
-
-// *****************************************************************************
-
-export const PrimaryPriorityCustomTheme: StoryFn<typeof LinkButton> =
-	Template.bind({});
-PrimaryPriorityCustomTheme.args = {
-	priority: 'primary',
-	iconSide: 'right',
-	// @ts-expect-error - Storybook maps 'arrow' to <SvgArrowRightStraight />
-	icon: 'arrow',
-	theme: {
-		textPrimary: palette.brand[400],
-		backgroundPrimary: palette.brandAlt[400],
-		backgroundPrimaryHover: palette.brandAlt[200],
+export const SecondaryPriorityDefaultTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		priority: 'secondary',
 	},
 };
-PrimaryPriorityCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const TertiaryPriorityDefaultTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		priority: 'tertiary',
+	},
+};
+
+export const SubduedPriorityDefaultTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		priority: 'subdued',
+	},
+};
+
+export const TextAndIconLeftDefaultSizeDefaultTheme: Story = {
+	args: {
+		...PrimaryPriorityDefaultTheme.args,
+		// @ts-expect-error - Name from control options which Storybook maps to `<SvgCross />`
+		icon: 'Arrow',
+	},
+};
+
+export const TextAndIconRightDefaultSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconLeftDefaultSizeDefaultTheme.args,
+		iconSide: 'right',
+	},
+};
+
+export const TextAndIconLeftSmallSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconLeftDefaultSizeDefaultTheme.args,
+		size: 'small',
+	},
+};
+
+export const TextAndIconRightSmallSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconRightDefaultSizeDefaultTheme.args,
+		size: 'small',
+	},
+};
+
+export const TextAndIconLeftXSmallSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconLeftDefaultSizeDefaultTheme.args,
+		size: 'xsmall',
+	},
+};
+
+export const TextAndIconRightXSmallSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconRightDefaultSizeDefaultTheme.args,
+		size: 'xsmall',
+	},
+};
+
+export const TextAndIconLeftWithNudgeDefaultTheme: Story = {
+	args: {
+		...TextAndIconLeftDefaultSizeDefaultTheme.args,
+		nudgeIcon: true,
+	},
+};
+
+export const TextAndIconRightWithNudgeDefaultTheme: Story = {
+	args: {
+		...TextAndIconRightDefaultSizeDefaultTheme.args,
+		nudgeIcon: true,
+	},
+};
+
+export const IconOnlyDefaultSizeDefaultTheme: Story = {
+	args: {
+		...TextAndIconLeftDefaultSizeDefaultTheme.args,
+		hideLabel: true,
+	},
+};
+
+export const IconOnlySmallSizeDefaultTheme: Story = {
+	args: {
+		...IconOnlyDefaultSizeDefaultTheme.args,
+		size: 'small',
+	},
+};
+
+export const IconOnlyXSmallSizeDefaultTheme: Story = {
+	args: {
+		...IconOnlyDefaultSizeDefaultTheme.args,
+		size: 'xsmall',
+	},
+};
+
+export const PrimaryPriorityCustomTheme: Story = {
+	args: {
+		...TextAndIconRightDefaultSizeDefaultTheme.args,
+		theme: {
+			textPrimary: palette.brand[400],
+			backgroundPrimary: palette.brandAlt[400],
+			backgroundPrimaryHover: palette.brandAlt[200],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/checkbox/Checkbox.stories.tsx
+++ b/libs/@guardian/source/src/react-components/checkbox/Checkbox.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof Checkbox> = {
 export default meta;
 type Story = StoryObj<typeof Checkbox>;
 
-const CheckboxTemplate: Story = {
+const Template: Story = {
 	render: (args) => {
 		const [checked, setChecked] = useState(args.checked);
 		return (
@@ -26,7 +26,7 @@ const CheckboxTemplate: Story = {
 };
 
 export const DefaultDefaultTheme: Story = {
-	...CheckboxTemplate,
+	...Template,
 	args: {
 		label: 'The Guardian Today',
 		checked: true,
@@ -35,7 +35,7 @@ export const DefaultDefaultTheme: Story = {
 };
 
 export const DefaultBrandTheme: Story = {
-	...CheckboxTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		theme: themeCheckboxBrand,
@@ -48,7 +48,7 @@ export const DefaultBrandTheme: Story = {
 };
 
 export const SupportingTextDefaultTheme: Story = {
-	...CheckboxTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'Supporting text',
@@ -56,7 +56,7 @@ export const SupportingTextDefaultTheme: Story = {
 };
 
 export const SupportingTextBrandTheme: Story = {
-	...CheckboxTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		supporting: 'Supporting text',
@@ -67,7 +67,7 @@ export const SupportingTextBrandTheme: Story = {
 };
 
 export const SupportingTextOnlyDefaultTheme: Story = {
-	...CheckboxTemplate,
+	...Template,
 	args: {
 		...SupportingTextDefaultTheme.args,
 		label: null,
@@ -75,7 +75,7 @@ export const SupportingTextOnlyDefaultTheme: Story = {
 };
 
 export const SupportingTextOnlyBrandTheme: Story = {
-	...CheckboxTemplate,
+	...Template,
 	args: {
 		...SupportingTextBrandTheme.args,
 		label: null,
@@ -86,7 +86,7 @@ export const SupportingTextOnlyBrandTheme: Story = {
 };
 
 export const IndeterminateDefaultTheme: Story = {
-	...CheckboxTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		checked: undefined,
@@ -95,7 +95,7 @@ export const IndeterminateDefaultTheme: Story = {
 };
 
 export const IndeterminateBrandTheme: Story = {
-	...CheckboxTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		checked: undefined,
@@ -107,7 +107,7 @@ export const IndeterminateBrandTheme: Story = {
 };
 
 export const UnlabelledDefaultTheme: Story = {
-	...CheckboxTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		label: null,
@@ -116,7 +116,7 @@ export const UnlabelledDefaultTheme: Story = {
 };
 
 export const DefaultCustomTheme: Story = {
-	...CheckboxTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		theme: {

--- a/libs/@guardian/source/src/react-components/checkbox/Checkbox.stories.tsx
+++ b/libs/@guardian/source/src/react-components/checkbox/Checkbox.stories.tsx
@@ -1,14 +1,32 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { useState } from 'react';
 import { palette } from '../../foundations';
-import type { CheckboxProps } from './Checkbox';
 import { Checkbox } from './Checkbox';
 import { themeCheckboxBrand } from './theme';
 
 const meta: Meta<typeof Checkbox> = {
 	title: 'React Components/Checkbox',
 	component: Checkbox,
-	argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof Checkbox>;
+
+const CheckboxTemplate: Story = {
+	render: (args) => {
+		const [checked, setChecked] = useState(args.checked);
+		return (
+			<Checkbox
+				{...args}
+				checked={checked}
+				onChange={(e) => setChecked(e.target.checked)}
+			/>
+		);
+	},
+};
+
+export const DefaultDefaultTheme: Story = {
+	...CheckboxTemplate,
 	args: {
 		label: 'The Guardian Today',
 		checked: true,
@@ -16,119 +34,103 @@ const meta: Meta<typeof Checkbox> = {
 	},
 };
 
-export default meta;
-const Template: StoryFn<CheckboxProps> = (args: CheckboxProps) => {
-	const [checked, setChecked] = useState(args.checked);
-
-	return (
-		<Checkbox
-			{...args}
-			checked={checked}
-			onChange={(e) => setChecked(e.target.checked)}
-		/>
-	);
-};
-
-export const DefaultDefaultTheme: StoryFn = Template.bind({});
-
-// *****************************************************************************
-
-export const DefaultBrandTheme: StoryFn = Template.bind({});
-DefaultBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const DefaultBrandTheme: Story = {
+	...CheckboxTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		theme: themeCheckboxBrand,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
 	},
 };
-DefaultBrandTheme.args = {
-	theme: themeCheckboxBrand,
-};
 
-// *****************************************************************************
-
-export const SupportingTextDefaultTheme: StoryFn = Template.bind({});
-SupportingTextDefaultTheme.args = {
-	supporting: 'Supporting text',
-};
-
-// *****************************************************************************
-
-export const SupportingTextBrandTheme: StoryFn = Template.bind({});
-SupportingTextBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const SupportingTextDefaultTheme: Story = {
+	...CheckboxTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'Supporting text',
 	},
 };
-SupportingTextBrandTheme.args = {
-	supporting: 'Supporting text',
-	theme: themeCheckboxBrand,
-};
 
-// *****************************************************************************
-
-export const SupportingTextOnlyDefaultTheme: StoryFn = Template.bind({});
-SupportingTextOnlyDefaultTheme.args = {
-	label: null,
-	supporting: 'Supporting text',
-};
-
-// *****************************************************************************
-
-export const SupportingTextOnlyBrandTheme: StoryFn = Template.bind({});
-SupportingTextOnlyBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const SupportingTextBrandTheme: Story = {
+	...CheckboxTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		supporting: 'Supporting text',
+	},
+	parameters: {
+		...DefaultBrandTheme.parameters,
 	},
 };
-SupportingTextOnlyBrandTheme.args = {
-	label: null,
-	supporting: 'Supporting text',
-	theme: themeCheckboxBrand,
-};
 
-// *****************************************************************************
-
-export const IndeterminateDefaultTheme: StoryFn = Template.bind({});
-IndeterminateDefaultTheme.args = {
-	checked: undefined,
-	indeterminate: true,
-};
-
-// *****************************************************************************
-
-export const IndeterminateBrandTheme: StoryFn = Template.bind({});
-IndeterminateBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const SupportingTextOnlyDefaultTheme: Story = {
+	...CheckboxTemplate,
+	args: {
+		...SupportingTextDefaultTheme.args,
+		label: null,
 	},
 };
-IndeterminateBrandTheme.args = {
-	indeterminate: true,
-	theme: themeCheckboxBrand,
-};
 
-// *****************************************************************************
-
-export const UnlabelledDefaultTheme: StoryFn = Template.bind({});
-UnlabelledDefaultTheme.args = {
-	label: null,
-	'aria-label': 'Checkbox',
-};
-
-// *****************************************************************************
-
-export const DefaultCustomTheme: StoryFn<CheckboxProps> = Template.bind({});
-DefaultCustomTheme.args = {
-	theme: {
-		fillSelected: palette.brand[800],
-		fillUnselected: palette.neutral[20],
-		borderSelected: palette.brand[800],
-		borderUnselected: palette.neutral[60],
-		borderHover: palette.brand[800],
-		textLabel: palette.neutral[86],
+export const SupportingTextOnlyBrandTheme: Story = {
+	...CheckboxTemplate,
+	args: {
+		...SupportingTextBrandTheme.args,
+		label: null,
+	},
+	parameters: {
+		...SupportingTextBrandTheme.parameters,
 	},
 };
-DefaultCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const IndeterminateDefaultTheme: Story = {
+	...CheckboxTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		checked: undefined,
+		indeterminate: true,
+	},
+};
+
+export const IndeterminateBrandTheme: Story = {
+	...CheckboxTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		checked: undefined,
+		indeterminate: true,
+	},
+	parameters: {
+		...DefaultBrandTheme.parameters,
+	},
+};
+
+export const UnlabelledDefaultTheme: Story = {
+	...CheckboxTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		label: null,
+		'aria-label': 'Checkbox',
+	},
+};
+
+export const DefaultCustomTheme: Story = {
+	...CheckboxTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		theme: {
+			fillSelected: palette.brand[800],
+			fillUnselected: palette.neutral[20],
+			borderSelected: palette.brand[800],
+			borderUnselected: palette.neutral[60],
+			borderHover: palette.brand[800],
+			textLabel: palette.neutral[86],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/checkbox/Checkbox.stories.tsx
+++ b/libs/@guardian/source/src/react-components/checkbox/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { palette } from '../../foundations';
 import { Checkbox } from './Checkbox';

--- a/libs/@guardian/source/src/react-components/checkbox/CheckboxGroup.stories.tsx
+++ b/libs/@guardian/source/src/react-components/checkbox/CheckboxGroup.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { palette } from '../../foundations';
 import { Checkbox } from './Checkbox';
-import { DefaultDefaultTheme as CheckboxDefaultTheme } from './Checkbox.stories';
+import * as CheckboxStories from './Checkbox.stories';
 import { CheckboxGroup } from './CheckboxGroup';
 import type { ThemeCheckbox } from './theme';
 import { themeCheckboxBrand, themeCheckboxGroupBrand } from './theme';
@@ -19,13 +19,15 @@ type Story = StoryObj<
 	}
 >;
 
-const CheckboxGroupTemplate: Story = {
+const Template: Story = {
 	render: (args) => {
-		const [checked, setChecked] = useState(CheckboxDefaultTheme.args?.checked);
+		const [checked, setChecked] = useState(
+			CheckboxStories.DefaultDefaultTheme.args?.checked,
+		);
 		return (
 			<CheckboxGroup {...args}>
 				<Checkbox
-					{...CheckboxDefaultTheme.args}
+					{...CheckboxStories.DefaultDefaultTheme.args}
 					theme={args.themeChild}
 					checked={checked}
 					onChange={(e) => setChecked(e.target.checked)}
@@ -36,7 +38,7 @@ const CheckboxGroupTemplate: Story = {
 };
 
 export const DefaultDefaultTheme: Story = {
-	...CheckboxGroupTemplate,
+	...Template,
 	args: {
 		name: 'your-newsletters',
 		label: 'Your newsletters',
@@ -47,7 +49,7 @@ export const DefaultDefaultTheme: Story = {
 };
 
 export const DefaultBrandTheme: Story = {
-	...CheckboxGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		theme: themeCheckboxGroupBrand,
@@ -61,7 +63,7 @@ export const DefaultBrandTheme: Story = {
 };
 
 export const VisuallyHideLegendDefaultTheme: Story = {
-	...CheckboxGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		hideLabel: true,
@@ -69,7 +71,7 @@ export const VisuallyHideLegendDefaultTheme: Story = {
 };
 
 export const VisuallyHideLegendBrandTheme: Story = {
-	...CheckboxGroupTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		hideLabel: true,
@@ -80,7 +82,7 @@ export const VisuallyHideLegendBrandTheme: Story = {
 };
 
 export const SupportingTextDefaultTheme: Story = {
-	...CheckboxGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'Pick the issues and topics that interest you',
@@ -88,7 +90,7 @@ export const SupportingTextDefaultTheme: Story = {
 };
 
 export const OptionalDefaultTheme: Story = {
-	...CheckboxGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		optional: true,
@@ -96,7 +98,7 @@ export const OptionalDefaultTheme: Story = {
 };
 
 export const SupportingTextBrandTheme: Story = {
-	...CheckboxGroupTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		supporting: 'Pick the issues and topics that interest you',
@@ -107,7 +109,7 @@ export const SupportingTextBrandTheme: Story = {
 };
 
 export const ErrorDefaultTheme: Story = {
-	...CheckboxGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'This newsletter is not available in your region',
@@ -115,7 +117,7 @@ export const ErrorDefaultTheme: Story = {
 };
 
 export const ErrorBrandTheme: Story = {
-	...CheckboxGroupTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		error: 'This newsletter is not available in your region',
@@ -126,7 +128,7 @@ export const ErrorBrandTheme: Story = {
 };
 
 export const ErrorCustomTheme: Story = {
-	...CheckboxGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'This newsletter is not available in your region',

--- a/libs/@guardian/source/src/react-components/checkbox/CheckboxGroup.stories.tsx
+++ b/libs/@guardian/source/src/react-components/checkbox/CheckboxGroup.stories.tsx
@@ -1,8 +1,8 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { useState } from 'react';
 import { palette } from '../../foundations';
 import { Checkbox } from './Checkbox';
-import CheckboxStories from './Checkbox.stories';
+import { DefaultDefaultTheme as CheckboxDefaultTheme } from './Checkbox.stories';
 import { CheckboxGroup } from './CheckboxGroup';
 import type { ThemeCheckbox } from './theme';
 import { themeCheckboxBrand, themeCheckboxGroupBrand } from './theme';
@@ -10,7 +10,33 @@ import { themeCheckboxBrand, themeCheckboxGroupBrand } from './theme';
 const meta: Meta<typeof CheckboxGroup> = {
 	title: 'React Components/CheckboxGroup',
 	component: CheckboxGroup,
-	argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<
+	React.ComponentProps<typeof CheckboxGroup> & {
+		themeChild?: Partial<ThemeCheckbox>;
+	}
+>;
+
+const CheckboxGroupTemplate: Story = {
+	render: (args) => {
+		const [checked, setChecked] = useState(CheckboxDefaultTheme.args?.checked);
+		return (
+			<CheckboxGroup {...args}>
+				<Checkbox
+					{...CheckboxDefaultTheme.args}
+					theme={args.themeChild}
+					checked={checked}
+					onChange={(e) => setChecked(e.target.checked)}
+				/>
+			</CheckboxGroup>
+		);
+	},
+};
+
+export const DefaultDefaultTheme: Story = {
+	...CheckboxGroupTemplate,
 	args: {
 		name: 'your-newsletters',
 		label: 'Your newsletters',
@@ -20,147 +46,107 @@ const meta: Meta<typeof CheckboxGroup> = {
 	},
 };
 
-export default meta;
-
-type CheckboxGroupPropsAndChildTheme = React.ComponentProps<
-	typeof CheckboxGroup
-> & {
-	themeChild?: Partial<ThemeCheckbox>;
-};
-
-const Template: StoryFn<CheckboxGroupPropsAndChildTheme> = (
-	args: CheckboxGroupPropsAndChildTheme,
-) => {
-	const [checked, setChecked] = useState(CheckboxStories.args?.checked);
-
-	return (
-		<CheckboxGroup {...args}>
-			<Checkbox
-				{...CheckboxStories.args}
-				theme={args.themeChild}
-				checked={checked}
-				onChange={(e) => setChecked(e.target.checked)}
-			/>
-		</CheckboxGroup>
-	);
-};
-
-export const DefaultDefaultTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
-	Template.bind({});
-
-// *****************************************************************************
-
-export const DefaultBrandTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
-	Template.bind({});
-DefaultBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const DefaultBrandTheme: Story = {
+	...CheckboxGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		theme: themeCheckboxGroupBrand,
+		themeChild: themeCheckboxBrand,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
 	},
 };
-DefaultBrandTheme.args = {
-	theme: themeCheckboxGroupBrand,
-	themeChild: themeCheckboxBrand,
-};
 
-// *****************************************************************************
-
-export const VisuallyHideLegendDefaultTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
-	Template.bind({});
-VisuallyHideLegendDefaultTheme.args = {
-	hideLabel: true,
-};
-
-// *****************************************************************************
-
-export const VisuallyHideLegendBrandTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
-	Template.bind({});
-VisuallyHideLegendBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const VisuallyHideLegendDefaultTheme: Story = {
+	...CheckboxGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		hideLabel: true,
 	},
 };
-VisuallyHideLegendBrandTheme.args = {
-	hideLabel: true,
-	theme: themeCheckboxGroupBrand,
-	themeChild: themeCheckboxBrand,
-};
 
-// *****************************************************************************
-
-export const SupportingTextDefaultTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
-	Template.bind({});
-SupportingTextDefaultTheme.args = {
-	supporting: 'Pick the issues and topics that interest you',
-};
-
-// *****************************************************************************
-
-export const OptionalDefaultTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
-	Template.bind({});
-OptionalDefaultTheme.args = {
-	optional: true,
-};
-
-// *****************************************************************************
-
-export const SupportingTextBrandTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
-	Template.bind({});
-SupportingTextBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const VisuallyHideLegendBrandTheme: Story = {
+	...CheckboxGroupTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		hideLabel: true,
+	},
+	parameters: {
+		...DefaultBrandTheme.parameters,
 	},
 };
-SupportingTextBrandTheme.args = {
-	supporting: 'Pick the issues and topics that interest you',
-	theme: themeCheckboxGroupBrand,
-	themeChild: themeCheckboxBrand,
-};
 
-// *****************************************************************************
-
-export const ErrorDefaultTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
-	Template.bind({});
-ErrorDefaultTheme.args = {
-	error: 'This newsletter is not available in your region',
-};
-
-// *****************************************************************************
-
-export const ErrorBrandTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
-	Template.bind({});
-ErrorBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const SupportingTextDefaultTheme: Story = {
+	...CheckboxGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'Pick the issues and topics that interest you',
 	},
 };
-ErrorBrandTheme.args = {
-	error: 'This newsletter is not available in your region',
-	theme: themeCheckboxGroupBrand,
-	themeChild: themeCheckboxBrand,
-};
 
-// *****************************************************************************
-
-export const ErrorCustomTheme: StoryFn<CheckboxGroupPropsAndChildTheme> =
-	Template.bind({});
-ErrorCustomTheme.args = {
-	error: 'This newsletter is not available in your region',
-	theme: {
-		textLabel: palette.neutral[86],
-		textError: palette.error[500],
-	},
-	themeChild: {
-		fillSelected: palette.brand[800],
-		fillUnselected: palette.neutral[20],
-		borderSelected: palette.brand[800],
-		borderUnselected: palette.neutral[60],
-		borderHover: palette.brand[800],
-		borderError: palette.error[500],
-		textLabel: palette.neutral[86],
+export const OptionalDefaultTheme: Story = {
+	...CheckboxGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		optional: true,
 	},
 };
-ErrorCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const SupportingTextBrandTheme: Story = {
+	...CheckboxGroupTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		supporting: 'Pick the issues and topics that interest you',
+	},
+	parameters: {
+		...DefaultBrandTheme.parameters,
+	},
+};
+
+export const ErrorDefaultTheme: Story = {
+	...CheckboxGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'This newsletter is not available in your region',
+	},
+};
+
+export const ErrorBrandTheme: Story = {
+	...CheckboxGroupTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		error: 'This newsletter is not available in your region',
+	},
+	parameters: {
+		...DefaultBrandTheme.parameters,
+	},
+};
+
+export const ErrorCustomTheme: Story = {
+	...CheckboxGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'This newsletter is not available in your region',
+		theme: {
+			textLabel: palette.neutral[86],
+			textError: palette.error[500],
+		},
+		themeChild: {
+			fillSelected: palette.brand[800],
+			fillUnselected: palette.neutral[20],
+			borderSelected: palette.brand[800],
+			borderUnselected: palette.neutral[60],
+			borderHover: palette.brand[800],
+			borderError: palette.error[500],
+			textLabel: palette.neutral[86],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/checkbox/CheckboxGroup.stories.tsx
+++ b/libs/@guardian/source/src/react-components/checkbox/CheckboxGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { palette } from '../../foundations';
 import { Checkbox } from './Checkbox';

--- a/libs/@guardian/source/src/react-components/choice-card/ChoiceCard.stories.tsx
+++ b/libs/@guardian/source/src/react-components/choice-card/ChoiceCard.stories.tsx
@@ -1,17 +1,11 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { palette } from '../../foundations';
 import { SvgCamera } from '../__generated__/icons/SvgCamera';
 import { ChoiceCard } from './ChoiceCard';
-import type { ChoiceCardProps } from './ChoiceCard';
 
 const meta: Meta<typeof ChoiceCard> = {
 	title: 'React Components/ChoiceCard',
 	component: ChoiceCard,
-	args: {
-		id: 'option-1-id',
-		value: 'option-1',
-		label: 'string',
-	},
 	argTypes: {
 		label: {
 			options: ['string', 'JSX element'],
@@ -36,64 +30,61 @@ const meta: Meta<typeof ChoiceCard> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof ChoiceCard>;
 
-const Template: StoryFn<typeof ChoiceCard> = (args: ChoiceCardProps) => (
-	<ChoiceCard {...args} />
-);
-
-// *****************************************************************************
-
-export const DefaultDefaultTheme: StoryFn<typeof ChoiceCard> = Template.bind(
-	{},
-);
-
-// *****************************************************************************
-
-export const CheckedDefaultTheme: StoryFn<typeof ChoiceCard> = Template.bind(
-	{},
-);
-CheckedDefaultTheme.args = {
-	checked: true,
-};
-
-// *****************************************************************************
-
-export const ErrorDefaultTheme: StoryFn<typeof ChoiceCard> = Template.bind({});
-ErrorDefaultTheme.args = {
-	error: true,
-};
-
-// *****************************************************************************
-
-export const IconDefaultTheme: StoryFn<typeof ChoiceCard> = Template.bind({});
-IconDefaultTheme.args = {
-	label: 'Camera',
-	// @ts-expect-error - Storybook maps 'JSX element' to <em>Option 1</em>
-	icon: 'JSX element',
-};
-
-// *****************************************************************************
-
-export const IconCustomTheme: StoryFn<typeof ChoiceCard> = Template.bind({});
-IconCustomTheme.args = {
-	label: 'Camera',
-	// @ts-expect-error - Storybook maps 'JSX element' to <em>Option 1</em>
-	icon: 'JSX element',
-	theme: {
-		textUnselected: palette.neutral[86],
-		borderUnselected: palette.neutral[86],
-		backgroundUnselected: palette.neutral[20],
-		textSelected: palette.brand[400],
-		borderSelected: palette.brand[800],
-		backgroundSelected: palette.neutral[100],
-		textHover: palette.brand[800],
-		borderHover: palette.brand[800],
-		backgroundHover: palette.neutral[20],
-		backgroundTick: palette.brand[400],
+export const DefaultDefaultTheme: Story = {
+	args: {
+		id: 'option-1-id',
+		value: 'option-1',
+		label: 'string',
 	},
 };
-IconCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const CheckedDefaultTheme: Story = {
+	args: {
+		...DefaultDefaultTheme.args,
+		checked: true,
+	},
+};
+
+export const ErrorDefaultTheme: Story = {
+	args: {
+		...DefaultDefaultTheme.args,
+		error: true,
+	},
+};
+
+export const IconDefaultTheme: Story = {
+	args: {
+		...DefaultDefaultTheme.args,
+		label: 'Camera',
+		// @ts-expect-error - Storybook maps `JSX element` to `<em>Option 1</em>`
+		icon: 'JSX element',
+	},
+};
+
+export const IconCustomTheme: Story = {
+	args: {
+		...DefaultDefaultTheme.args,
+		label: 'Camera',
+		// @ts-expect-error - Storybook maps 'JSX element' to <em>Option 1</em>
+		icon: 'JSX element',
+		theme: {
+			textUnselected: palette.neutral[86],
+			borderUnselected: palette.neutral[86],
+			backgroundUnselected: palette.neutral[20],
+			textSelected: palette.brand[400],
+			borderSelected: palette.brand[800],
+			backgroundSelected: palette.neutral[100],
+			textHover: palette.brand[800],
+			borderHover: palette.brand[800],
+			backgroundHover: palette.neutral[20],
+			backgroundTick: palette.brand[400],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/choice-card/ChoiceCard.stories.tsx
+++ b/libs/@guardian/source/src/react-components/choice-card/ChoiceCard.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { SvgCamera } from '../__generated__/icons/SvgCamera';
 import { ChoiceCard } from './ChoiceCard';

--- a/libs/@guardian/source/src/react-components/choice-card/ChoiceCardGroup.stories.tsx
+++ b/libs/@guardian/source/src/react-components/choice-card/ChoiceCardGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { breakpoints, palette } from '../../foundations';
 import { ChoiceCard } from './ChoiceCard';

--- a/libs/@guardian/source/src/react-components/choice-card/ChoiceCardGroup.stories.tsx
+++ b/libs/@guardian/source/src/react-components/choice-card/ChoiceCardGroup.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { breakpoints, palette } from '../../foundations';
 import { ChoiceCard } from './ChoiceCard';
-import ChoiceCardStories from './ChoiceCard.stories';
 import { ChoiceCardGroup } from './ChoiceCardGroup';
 import type { ThemeChoiceCard } from './theme';
 
@@ -28,11 +27,10 @@ type Story = StoryObj<
 	}
 >;
 
-const ChoiceCardGroupTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<ChoiceCardGroup {...args}>
 			<ChoiceCard
-				{...ChoiceCardStories.args}
 				id="abc1"
 				value="option-1"
 				label="Option 1"
@@ -40,7 +38,6 @@ const ChoiceCardGroupTemplate: Story = {
 				theme={args.themeChild}
 			/>
 			<ChoiceCard
-				{...ChoiceCardStories.args}
 				id="abc2"
 				value="option-2"
 				label="Option 2"
@@ -48,7 +45,6 @@ const ChoiceCardGroupTemplate: Story = {
 				theme={args.themeChild}
 			/>
 			<ChoiceCard
-				{...ChoiceCardStories.args}
 				id="abc3"
 				value="option-3"
 				label="Option 3"
@@ -56,7 +52,6 @@ const ChoiceCardGroupTemplate: Story = {
 				theme={args.themeChild}
 			/>
 			<ChoiceCard
-				{...ChoiceCardStories.args}
 				id="abc4"
 				value="option-4"
 				label="Option 4"
@@ -64,7 +59,6 @@ const ChoiceCardGroupTemplate: Story = {
 				theme={args.themeChild}
 			/>
 			<ChoiceCard
-				{...ChoiceCardStories.args}
 				id="abc5"
 				value="option-5"
 				label="Option 5"
@@ -72,7 +66,6 @@ const ChoiceCardGroupTemplate: Story = {
 				theme={args.themeChild}
 			/>
 			<ChoiceCard
-				{...ChoiceCardStories.args}
 				id="abc6"
 				value="option-6"
 				label="Option 6"
@@ -84,7 +77,7 @@ const ChoiceCardGroupTemplate: Story = {
 };
 
 export const DefaultDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		name: 'colours',
 		label: undefined,
@@ -95,7 +88,7 @@ export const DefaultDefaultTheme: Story = {
 };
 
 export const DefaultMobileDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 	},
@@ -108,7 +101,7 @@ export const DefaultMobileDefaultTheme: Story = {
 };
 
 export const DefaultTabletDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 	},
@@ -121,7 +114,7 @@ export const DefaultTabletDefaultTheme: Story = {
 };
 
 export const DefaultIn2ColumnsDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		columns: 2,
@@ -129,7 +122,7 @@ export const DefaultIn2ColumnsDefaultTheme: Story = {
 };
 
 export const DefaultIn3ColumnsDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		columns: 3,
@@ -137,7 +130,7 @@ export const DefaultIn3ColumnsDefaultTheme: Story = {
 };
 
 export const DefaultIn4ColumnsDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		columns: 4,
@@ -145,7 +138,7 @@ export const DefaultIn4ColumnsDefaultTheme: Story = {
 };
 
 export const DefaultIn5ColumnsDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		columns: 5,
@@ -153,7 +146,7 @@ export const DefaultIn5ColumnsDefaultTheme: Story = {
 };
 
 export const WithLabelDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		label: 'Choose an option',
@@ -161,7 +154,7 @@ export const WithLabelDefaultTheme: Story = {
 };
 
 export const WithSupportingDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...WithLabelDefaultTheme.args,
 		supporting: 'These are your options',
@@ -169,7 +162,7 @@ export const WithSupportingDefaultTheme: Story = {
 };
 
 export const WithErrorDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'Please select a choice card to continue',
@@ -177,7 +170,7 @@ export const WithErrorDefaultTheme: Story = {
 };
 
 export const WithLabelAndErrorDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...WithLabelDefaultTheme.args,
 		error: 'Please select a choice card to continue',
@@ -185,7 +178,7 @@ export const WithLabelAndErrorDefaultTheme: Story = {
 };
 
 export const WithLabelAndSupportingAndErrorDefaultTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...WithSupportingDefaultTheme.args,
 		error: 'Please select a choice card to continue',
@@ -274,6 +267,7 @@ export const ControlledMultiSelectDefaultTheme: Story = {
 };
 
 export const UnControlledMultiSelectDefaultTheme: Story = {
+	name: 'Un-controlled Multi Select',
 	render: (args) => (
 		<ChoiceCardGroup {...args}>
 			<ChoiceCard id="abc1" value="option-1" label="Option 1" defaultChecked />
@@ -284,10 +278,10 @@ export const UnControlledMultiSelectDefaultTheme: Story = {
 		...WithSupportingDefaultTheme.args,
 		multi: true,
 	},
-	name: 'Un-controlled Multi Select',
 };
 
 export const UnControlledSingleSelectDefaultTheme: Story = {
+	name: 'Un-controlled Single Select',
 	render: (args) => (
 		<ChoiceCardGroup {...args}>
 			<ChoiceCard id="abc1" value="option-1" label="Option 1" />
@@ -298,11 +292,10 @@ export const UnControlledSingleSelectDefaultTheme: Story = {
 		...WithSupportingDefaultTheme.args,
 		multi: false,
 	},
-	name: 'Un-controlled Single Select',
 };
 
 export const WithSupportingCustomTheme: Story = {
-	...ChoiceCardGroupTemplate,
+	...Template,
 	args: {
 		...WithSupportingDefaultTheme.args,
 		theme: {

--- a/libs/@guardian/source/src/react-components/choice-card/ChoiceCardGroup.stories.tsx
+++ b/libs/@guardian/source/src/react-components/choice-card/ChoiceCardGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { useState } from 'react';
 import { breakpoints, palette } from '../../foundations';
 import { ChoiceCard } from './ChoiceCard';
@@ -9,13 +9,6 @@ import type { ThemeChoiceCard } from './theme';
 const meta: Meta<typeof ChoiceCardGroup> = {
 	title: 'React Components/ChoiceCardGroup',
 	component: ChoiceCardGroup,
-	args: {
-		name: 'colours',
-		label: 'Choose an option',
-		supporting: 'These are your options',
-		multi: false,
-		hideLabel: false,
-	},
 	argTypes: {
 		columns: {
 			options: [undefined, 2, 3, 4, 5],
@@ -29,361 +22,310 @@ const meta: Meta<typeof ChoiceCardGroup> = {
 };
 
 export default meta;
+type Story = StoryObj<
+	React.ComponentProps<typeof ChoiceCardGroup> & {
+		themeChild?: Partial<ThemeChoiceCard>;
+	}
+>;
 
-type ChoiceCardGroupPropsAndChildTheme = React.ComponentProps<
-	typeof ChoiceCardGroup
-> & {
-	themeChild?: Partial<ThemeChoiceCard>;
+const ChoiceCardGroupTemplate: Story = {
+	render: (args) => (
+		<ChoiceCardGroup {...args}>
+			<ChoiceCard
+				{...ChoiceCardStories.args}
+				id="abc1"
+				value="option-1"
+				label="Option 1"
+				key={1}
+				theme={args.themeChild}
+			/>
+			<ChoiceCard
+				{...ChoiceCardStories.args}
+				id="abc2"
+				value="option-2"
+				label="Option 2"
+				key={2}
+				theme={args.themeChild}
+			/>
+			<ChoiceCard
+				{...ChoiceCardStories.args}
+				id="abc3"
+				value="option-3"
+				label="Option 3"
+				key={3}
+				theme={args.themeChild}
+			/>
+			<ChoiceCard
+				{...ChoiceCardStories.args}
+				id="abc4"
+				value="option-4"
+				label="Option 4"
+				key={4}
+				theme={args.themeChild}
+			/>
+			<ChoiceCard
+				{...ChoiceCardStories.args}
+				id="abc5"
+				value="option-5"
+				label="Option 5"
+				key={5}
+				theme={args.themeChild}
+			/>
+			<ChoiceCard
+				{...ChoiceCardStories.args}
+				id="abc6"
+				value="option-6"
+				label="Option 6"
+				key={6}
+				theme={args.themeChild}
+			/>
+		</ChoiceCardGroup>
+	),
 };
 
-const Template: StoryFn<ChoiceCardGroupPropsAndChildTheme> = (
-	args: ChoiceCardGroupPropsAndChildTheme,
-) => (
-	<ChoiceCardGroup {...args}>
-		<ChoiceCard
-			{...ChoiceCardStories.args}
-			id="abc1"
-			value="option-1"
-			label="Option 1"
-			key={1}
-			theme={args.themeChild}
-		/>
-		<ChoiceCard
-			{...ChoiceCardStories.args}
-			id="abc2"
-			value="option-2"
-			label="Option 2"
-			key={2}
-			theme={args.themeChild}
-		/>
-		<ChoiceCard
-			{...ChoiceCardStories.args}
-			id="abc3"
-			value="option-3"
-			label="Option 3"
-			key={3}
-			theme={args.themeChild}
-		/>
-		<ChoiceCard
-			{...ChoiceCardStories.args}
-			id="abc4"
-			value="option-4"
-			label="Option 4"
-			key={4}
-			theme={args.themeChild}
-		/>
-		<ChoiceCard
-			{...ChoiceCardStories.args}
-			id="abc5"
-			value="option-5"
-			label="Option 5"
-			key={5}
-			theme={args.themeChild}
-		/>
-		<ChoiceCard
-			{...ChoiceCardStories.args}
-			id="abc6"
-			value="option-6"
-			label="Option 6"
-			key={6}
-			theme={args.themeChild}
-		/>
-	</ChoiceCardGroup>
-);
-
-export const DefaultDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-DefaultDefaultTheme.args = {
-	label: undefined,
-	supporting: undefined,
-};
-
-// *****************************************************************************
-
-export const DefaultMobileDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-DefaultMobileDefaultTheme.args = {
-	label: undefined,
-	supporting: undefined,
-};
-DefaultMobileDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'mobileMedium' },
-	chromatic: {
-		viewports: [breakpoints.mobileMedium],
+export const DefaultDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		name: 'colours',
+		label: undefined,
+		supporting: undefined,
+		multi: false,
+		hideLabel: false,
 	},
 };
 
-// *****************************************************************************
-
-export const DefaultTabletDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-DefaultTabletDefaultTheme.args = {
-	label: undefined,
-	supporting: undefined,
-};
-DefaultTabletDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
+export const DefaultMobileDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+	},
+	parameters: {
+		viewport: { defaultViewport: 'mobileMedium' },
+		chromatic: {
+			viewports: [breakpoints.mobileMedium],
+		},
 	},
 };
 
-// *****************************************************************************
-
-export const DefaultIn2ColumnsDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-DefaultIn2ColumnsDefaultTheme.args = {
-	label: undefined,
-	supporting: undefined,
-	columns: 2,
-};
-
-// *****************************************************************************
-
-export const DefaultIn3ColumnsDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-DefaultIn3ColumnsDefaultTheme.args = {
-	label: undefined,
-	supporting: undefined,
-	columns: 3,
-};
-
-// *****************************************************************************
-
-export const DefaultIn4ColumnsDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-DefaultIn4ColumnsDefaultTheme.args = {
-	label: undefined,
-	supporting: undefined,
-	columns: 4,
-};
-
-// *****************************************************************************
-
-export const DefaultIn5ColumnsDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-DefaultIn5ColumnsDefaultTheme.args = {
-	label: undefined,
-	supporting: undefined,
-	columns: 5,
-};
-
-// *****************************************************************************
-
-export const WithLabelDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-WithLabelDefaultTheme.args = { supporting: undefined };
-
-// *****************************************************************************
-
-export const WithSupportingDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-
-// *****************************************************************************
-
-export const WithErrorDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-WithErrorDefaultTheme.args = {
-	error: 'Please select a choice card to continue',
-	label: undefined,
-	supporting: undefined,
-};
-
-// *****************************************************************************
-
-export const WithLabelAndErrorDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-WithLabelAndErrorDefaultTheme.args = {
-	error: 'Please select a choice card to continue',
-	supporting: undefined,
-};
-
-// *****************************************************************************
-
-export const WithLabelAndSupportingAndErrorDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-WithLabelAndSupportingAndErrorDefaultTheme.args = {
-	error: 'Please select a choice card to continue',
-};
-
-// *****************************************************************************
-
-export const WithWildlyVaryingLengthsDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-WithWildlyVaryingLengthsDefaultTheme.args = {
-	children: [
-		<ChoiceCard
-			id="abc1"
-			value="option-1"
-			label="A very, very, very, very, very, very, very long piece of text indeed"
-			key={1}
-		/>,
-		<ChoiceCard
-			id="abc2"
-			value="option-2"
-			label="Something probable"
-			key={2}
-		/>,
-		<ChoiceCard id="abc3" value="option-3" label="Short" key={3} />,
-	],
-};
-
-// *****************************************************************************
-
-export const WithWildlyVaryingLengthsMobileDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-WithWildlyVaryingLengthsMobileDefaultTheme.args =
-	WithWildlyVaryingLengthsDefaultTheme.args;
-WithWildlyVaryingLengthsMobileDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'mobile' },
-	chromatic: {
-		viewports: [breakpoints.mobile],
+export const DefaultTabletDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+	},
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
 	},
 };
 
-// *****************************************************************************
-
-export const WithWildlyVaryingLengthsTabletDefaultTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-WithWildlyVaryingLengthsTabletDefaultTheme.args =
-	WithWildlyVaryingLengthsDefaultTheme.args;
-WithWildlyVaryingLengthsTabletDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
+export const DefaultIn2ColumnsDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		columns: 2,
 	},
 };
 
-// *****************************************************************************
-
-export const ControlledMultiSelectDefaultTheme: StoryFn<
-	ChoiceCardGroupPropsAndChildTheme
-> = (args: ChoiceCardGroupPropsAndChildTheme) => {
-	const [state, setState] = useState({
-		opt1: true,
-		opt2: true,
-	});
-	return (
-		<>
-			<ChoiceCardGroup {...args}>
-				<ChoiceCard
-					id="abc1"
-					value="option-1"
-					label="Option 1"
-					checked={state.opt1}
-					onChange={() => setState({ ...state, opt1: !state.opt1 })}
-				/>
-				<ChoiceCard
-					id="abc2"
-					value="option-2"
-					label="Option 2"
-					checked={state.opt2}
-					onChange={() => setState({ ...state, opt2: !state.opt2 })}
-				/>
-			</ChoiceCardGroup>
-			<pre>
-				Option 1: {state.opt1 ? 'selected' : 'unselected'}
-				{'\n'}
-				Option 2: {state.opt2 ? 'selected' : 'unselected'}
-			</pre>
-		</>
-	);
-};
-ControlledMultiSelectDefaultTheme.args = {
-	multi: true,
-};
-
-// *****************************************************************************
-
-export const ControlledSingleSelectDefaultTheme: StoryFn<
-	ChoiceCardGroupPropsAndChildTheme
-> = (args: ChoiceCardGroupPropsAndChildTheme) => {
-	const [selected, setSelected] = useState<string | null>('option-2');
-
-	return (
-		<>
-			<ChoiceCardGroup {...args}>
-				<ChoiceCard
-					id="abc1"
-					value="option-1"
-					label="Option 1"
-					checked={selected === 'option-1'}
-					onChange={() => setSelected('option-1')}
-				/>
-				<ChoiceCard
-					id="abc2"
-					value="option-2"
-					label="Option 2"
-					checked={selected === 'option-2'}
-					onChange={() => setSelected('option-2')}
-				/>
-			</ChoiceCardGroup>
-			<pre>
-				Option 1: {selected === 'option-1' ? 'selected' : 'unselected'}
-				{'\n'}
-				Option 2: {selected === 'option-2' ? 'selected' : 'unselected'}
-			</pre>
-		</>
-	);
-};
-ControlledSingleSelectDefaultTheme.args = {
-	multi: false,
-};
-
-// *****************************************************************************
-
-export const UnControlledMultiSelectDefaultTheme: StoryFn<
-	ChoiceCardGroupPropsAndChildTheme
-> = (args: ChoiceCardGroupPropsAndChildTheme) => (
-	<ChoiceCardGroup {...args}>
-		<ChoiceCard id="abc1" value="option-1" label="Option 1" defaultChecked />
-		<ChoiceCard id="abc2" value="option-2" label="Option 2" defaultChecked />
-	</ChoiceCardGroup>
-);
-UnControlledMultiSelectDefaultTheme.args = {
-	multi: true,
-};
-UnControlledMultiSelectDefaultTheme.storyName = 'Un-controlled Multi Select';
-
-// *****************************************************************************
-
-export const UnControlledSingleSelectDefaultTheme: StoryFn<
-	ChoiceCardGroupPropsAndChildTheme
-> = (args: ChoiceCardGroupPropsAndChildTheme) => (
-	<ChoiceCardGroup {...args}>
-		<ChoiceCard id="abc1" value="option-1" label="Option 1" />
-		<ChoiceCard id="abc2" value="option-2" label="Option 2" defaultChecked />
-	</ChoiceCardGroup>
-);
-UnControlledSingleSelectDefaultTheme.args = {
-	multi: false,
-};
-UnControlledSingleSelectDefaultTheme.storyName = 'Un-controlled Single Select';
-
-// *****************************************************************************
-
-export const WithSupportingCustomTheme: StoryFn<ChoiceCardGroupPropsAndChildTheme> =
-	Template.bind({});
-WithSupportingCustomTheme.args = {
-	theme: {
-		textLabel: palette.neutral[86],
-		textSupporting: palette.neutral[60],
-	},
-	themeChild: {
-		textUnselected: palette.neutral[86],
-		borderUnselected: palette.neutral[86],
-		backgroundUnselected: palette.neutral[20],
-		textSelected: palette.brand[400],
-		borderSelected: palette.brand[800],
-		backgroundSelected: palette.neutral[100],
-		textHover: palette.brand[800],
-		borderHover: palette.brand[800],
-		backgroundHover: palette.neutral[20],
-		backgroundTick: palette.brand[400],
+export const DefaultIn3ColumnsDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		columns: 3,
 	},
 };
-WithSupportingCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const DefaultIn4ColumnsDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		columns: 4,
+	},
+};
+
+export const DefaultIn5ColumnsDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		columns: 5,
+	},
+};
+
+export const WithLabelDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		label: 'Choose an option',
+	},
+};
+
+export const WithSupportingDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...WithLabelDefaultTheme.args,
+		supporting: 'These are your options',
+	},
+};
+
+export const WithErrorDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'Please select a choice card to continue',
+	},
+};
+
+export const WithLabelAndErrorDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...WithLabelDefaultTheme.args,
+		error: 'Please select a choice card to continue',
+	},
+};
+
+export const WithLabelAndSupportingAndErrorDefaultTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...WithSupportingDefaultTheme.args,
+		error: 'Please select a choice card to continue',
+	},
+};
+
+export const WithWildlyVaryingLengthsDefaultTheme: Story = {
+	render: (args) => (
+		<ChoiceCardGroup {...args}>
+			<ChoiceCard
+				id="abc1"
+				value="option-1"
+				label="A very, very, very, very, very, very, very long piece of text indeed"
+				key={1}
+			/>
+			<ChoiceCard
+				id="abc2"
+				value="option-2"
+				label="Something probable"
+				key={2}
+			/>
+			<ChoiceCard id="abc3" value="option-3" label="Short" key={3} />
+		</ChoiceCardGroup>
+	),
+	args: {
+		...WithSupportingDefaultTheme.args,
+	},
+};
+
+export const WithWildlyVaryingLengthsMobileDefaultTheme: Story = {
+	...WithWildlyVaryingLengthsDefaultTheme,
+	parameters: {
+		viewport: { defaultViewport: 'mobile' },
+		chromatic: {
+			viewports: [breakpoints.mobile],
+		},
+	},
+};
+
+export const WithWildlyVaryingLengthsTabletDefaultTheme: Story = {
+	...WithWildlyVaryingLengthsDefaultTheme,
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
+	},
+};
+
+export const ControlledMultiSelectDefaultTheme: Story = {
+	render: (args) => {
+		const [state, setState] = useState({
+			opt1: true,
+			opt2: true,
+		});
+		return (
+			<>
+				<ChoiceCardGroup {...args}>
+					<ChoiceCard
+						id="abc1"
+						value="option-1"
+						label="Option 1"
+						checked={state.opt1}
+						onChange={() => setState({ ...state, opt1: !state.opt1 })}
+					/>
+					<ChoiceCard
+						id="abc2"
+						value="option-2"
+						label="Option 2"
+						checked={state.opt2}
+						onChange={() => setState({ ...state, opt2: !state.opt2 })}
+					/>
+				</ChoiceCardGroup>
+				<pre>
+					Option 1: {state.opt1 ? 'selected' : 'unselected'}
+					{'\n'}
+					Option 2: {state.opt2 ? 'selected' : 'unselected'}
+				</pre>
+			</>
+		);
+	},
+	args: {
+		...WithSupportingDefaultTheme.args,
+		multi: true,
+	},
+};
+
+export const UnControlledMultiSelectDefaultTheme: Story = {
+	render: (args) => (
+		<ChoiceCardGroup {...args}>
+			<ChoiceCard id="abc1" value="option-1" label="Option 1" defaultChecked />
+			<ChoiceCard id="abc2" value="option-2" label="Option 2" defaultChecked />
+		</ChoiceCardGroup>
+	),
+	args: {
+		...WithSupportingDefaultTheme.args,
+		multi: true,
+	},
+	name: 'Un-controlled Multi Select',
+};
+
+export const UnControlledSingleSelectDefaultTheme: Story = {
+	render: (args) => (
+		<ChoiceCardGroup {...args}>
+			<ChoiceCard id="abc1" value="option-1" label="Option 1" />
+			<ChoiceCard id="abc2" value="option-2" label="Option 2" defaultChecked />
+		</ChoiceCardGroup>
+	),
+	args: {
+		...WithSupportingDefaultTheme.args,
+		multi: false,
+	},
+	name: 'Un-controlled Single Select',
+};
+
+export const WithSupportingCustomTheme: Story = {
+	...ChoiceCardGroupTemplate,
+	args: {
+		...WithSupportingDefaultTheme.args,
+		theme: {
+			textLabel: palette.neutral[86],
+			textSupporting: palette.neutral[60],
+		},
+		themeChild: {
+			textUnselected: palette.neutral[86],
+			borderUnselected: palette.neutral[86],
+			backgroundUnselected: palette.neutral[20],
+			textSelected: palette.brand[400],
+			borderSelected: palette.brand[800],
+			backgroundSelected: palette.neutral[100],
+			textHover: palette.brand[800],
+			borderHover: palette.brand[800],
+			backgroundHover: palette.neutral[20],
+			backgroundTick: palette.brand[400],
+		},
+	},
+
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/columns/Columns.stories.tsx
+++ b/libs/@guardian/source/src/react-components/columns/Columns.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { HTMLAttributes } from 'react';
 import { breakpoints } from '../../foundations';
 import { Container } from '../container/Container';

--- a/libs/@guardian/source/src/react-components/columns/Columns.stories.tsx
+++ b/libs/@guardian/source/src/react-components/columns/Columns.stories.tsx
@@ -1,14 +1,9 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import type { HTMLAttributes } from 'react';
 import { breakpoints } from '../../foundations';
 import { Container } from '../container/Container';
 import { Column } from './Column';
 import { Columns } from './Columns';
-
-const style = { backgroundColor: 'rgba(255, 0, 0, 0.25)' };
-const Code = (args: HTMLAttributes<HTMLElement>) => (
-	<code style={{ whiteSpace: 'nowrap' }} {...args} />
-);
 
 const meta: Meta<typeof Column> = {
 	title: 'React Components/Columns',
@@ -16,466 +11,455 @@ const meta: Meta<typeof Column> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof Columns>;
 
-const Template: StoryFn<typeof Columns> = (args) => (
-	<Columns {...args} style={style}>
-		<Column style={style}>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut faucibus nibh
-			erat, eget rutrum ligula vehicula sit amet. Etiam scelerisque dapibus
-			pulvinar. Integer non accumsan justo. Duis et vehicula risus. Nulla ligula
-			eros, consequat sodales lectus eget, eleifend venenatis neque.
-		</Column>
-		<Column style={style}>
-			Interdum et malesuada fames ac ante ipsum primis in faucibus. Nulla
-			facilisi. Phasellus id aliquam odio. Aliquam tempus eu enim in fermentum.
-			Donec ut velit vel purus rutrum vulputate ut scelerisque lacus.
-		</Column>
-		<Column style={style}>
-			Pellentesque id ornare turpis. Aliquam laoreet aliquet pharetra. Donec nec
-			erat ac libero interdum sollicitudin. Nullam imperdiet ut dolor non
-			cursus. Integer et ante fringilla, luctus magna nec, consequat est.
-		</Column>
-		<Column style={style}>
-			Nunc nec dapibus quam. Praesent nec neque vel velit mollis tempor.
-			Suspendisse justo eros, pharetra et elit sit amet, hendrerit laoreet dui.
-			Curabitur ut libero nibh. Duis finibus sollicitudin tortor, ac viverra
-			urna commodo et.
-		</Column>
-		<Column style={style}>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Non igitur
-			potestis voluptate omnia dirigentes aut tueri aut retinere virtutem. Hoc
-			Hieronymus summum bonum esse dixit.
-		</Column>
-	</Columns>
+const style = { backgroundColor: 'rgba(255, 0, 0, 0.25)' };
+const Code = (args: HTMLAttributes<HTMLElement>) => (
+	<code style={{ whiteSpace: 'nowrap' }} {...args} />
 );
 
-export const Default: StoryFn<typeof Columns> = Template.bind({});
-Default.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
-	},
-	layout: 'fullscreen',
-	outline: true,
-};
-
-// *****************************************************************************
-
-export const CollapseUntilTabletWithNoSpacing: StoryFn<typeof Columns> =
-	Template.bind({});
-CollapseUntilTabletWithNoSpacing.args = {
-	collapseUntil: 'tablet',
-};
-CollapseUntilTabletWithNoSpacing.parameters = {
-	viewport: { defaultViewport: 'phablet' },
-	chromatic: {
-		viewports: [breakpoints.phablet],
-	},
-	layout: 'fullscreen',
-	outline: true,
-};
-
-// *****************************************************************************
-
-export const CollapseUntilTabletWithSpace1: StoryFn<typeof Columns> =
-	Template.bind({});
-CollapseUntilTabletWithSpace1.args = {
-	collapseUntil: 'tablet',
-	spaceY: 1,
-};
-CollapseUntilTabletWithSpace1.parameters = {
-	viewport: { defaultViewport: 'phablet' },
-	chromatic: {
-		viewports: [breakpoints.phablet],
-	},
-	layout: 'fullscreen',
-	outline: true,
-};
-
-// *****************************************************************************
-
-export const CollapseUntilTabletWithSpace2: StoryFn<typeof Columns> =
-	Template.bind({});
-CollapseUntilTabletWithSpace2.args = {
-	collapseUntil: 'tablet',
-	spaceY: 2,
-};
-CollapseUntilTabletWithSpace2.parameters = {
-	viewport: { defaultViewport: 'phablet' },
-	chromatic: {
-		viewports: [breakpoints.phablet],
-	},
-	layout: 'fullscreen',
-	outline: true,
-};
-
-// *****************************************************************************
-
-export const CollapseUntilTabletWithSpace3: StoryFn<typeof Columns> =
-	Template.bind({});
-CollapseUntilTabletWithSpace3.args = {
-	collapseUntil: 'tablet',
-	spaceY: 3,
-};
-CollapseUntilTabletWithSpace3.parameters = {
-	viewport: { defaultViewport: 'phablet' },
-	chromatic: {
-		viewports: [breakpoints.phablet],
-	},
-	layout: 'fullscreen',
-	outline: true,
-};
-
-// *****************************************************************************
-
-export const CollapseUntilTabletWithSpace4: StoryFn<typeof Columns> =
-	Template.bind({});
-CollapseUntilTabletWithSpace4.args = {
-	collapseUntil: 'tablet',
-	spaceY: 4,
-};
-CollapseUntilTabletWithSpace4.parameters = {
-	viewport: { defaultViewport: 'phablet' },
-	chromatic: {
-		viewports: [breakpoints.phablet],
-	},
-	layout: 'fullscreen',
-	outline: true,
-};
-
-// *****************************************************************************
-
-export const CollapseUntilTabletWithSpace5: StoryFn<typeof Columns> =
-	Template.bind({});
-CollapseUntilTabletWithSpace5.args = {
-	collapseUntil: 'tablet',
-	spaceY: 5,
-};
-CollapseUntilTabletWithSpace5.parameters = {
-	viewport: { defaultViewport: 'phablet' },
-	chromatic: {
-		viewports: [breakpoints.phablet],
-	},
-	layout: 'fullscreen',
-	outline: true,
-};
-
-// *****************************************************************************
-
-export const CollapseUntilTabletWithSpace6: StoryFn<typeof Columns> =
-	Template.bind({});
-CollapseUntilTabletWithSpace6.args = {
-	collapseUntil: 'tablet',
-	spaceY: 6,
-};
-CollapseUntilTabletWithSpace6.parameters = {
-	viewport: { defaultViewport: 'phablet' },
-	chromatic: {
-		viewports: [breakpoints.phablet],
-	},
-	layout: 'fullscreen',
-	outline: true,
-};
-
-// *****************************************************************************
-
-export const CollapseUntilTabletWithSpace9: StoryFn<typeof Columns> =
-	Template.bind({});
-CollapseUntilTabletWithSpace9.args = {
-	collapseUntil: 'tablet',
-	spaceY: 9,
-};
-CollapseUntilTabletWithSpace9.parameters = {
-	viewport: { defaultViewport: 'phablet' },
-	chromatic: {
-		viewports: [breakpoints.phablet],
-	},
-	layout: 'fullscreen',
-	outline: true,
-};
-
-// *****************************************************************************
-
-export const CollapseUntilTabletWithSpace12: StoryFn<typeof Columns> =
-	Template.bind({});
-CollapseUntilTabletWithSpace12.args = {
-	collapseUntil: 'tablet',
-	spaceY: 12,
-};
-CollapseUntilTabletWithSpace12.parameters = {
-	viewport: { defaultViewport: 'phablet' },
-	chromatic: {
-		viewports: [breakpoints.phablet],
-	},
-	layout: 'fullscreen',
-	outline: true,
-};
-
-// *****************************************************************************
-
-export const CollapseUntilTabletWithSpace24: StoryFn<typeof Columns> =
-	Template.bind({});
-CollapseUntilTabletWithSpace24.args = {
-	collapseUntil: 'tablet',
-	spaceY: 24,
-};
-CollapseUntilTabletWithSpace24.parameters = {
-	viewport: { defaultViewport: 'phablet' },
-	chromatic: {
-		viewports: [breakpoints.phablet],
-	},
-	layout: 'fullscreen',
-	outline: true,
-};
-
-// *****************************************************************************
-
-export const WithContainer: StoryFn<typeof Columns> = (args, ctx) => (
-	<Container style={style}>{Template(args, ctx)}</Container>
-);
-WithContainer.parameters = {
-	layout: 'fullscreen',
-};
-
-// *****************************************************************************
-
-export const ResponsiveAtPhablet: StoryFn<typeof Columns> = (args) => (
-	<Container style={style}>
-		<Columns {...args}>
-			<Column width={[1 / 2, 1 / 4]} style={style}>
-				<p>default 50% wide, 25% from tablet</p>
-				<Code>{'width={[1 / 2, 1 / 4]}'}</Code>
+const ColumnsTemplate: Story = {
+	render: (args) => (
+		<Columns {...args} style={style}>
+			<Column style={style}>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut faucibus
+				nibh erat, eget rutrum ligula vehicula sit amet. Etiam scelerisque
+				dapibus pulvinar. Integer non accumsan justo. Duis et vehicula risus.
+				Nulla ligula eros, consequat sodales lectus eget, eleifend venenatis
+				neque.
 			</Column>
-			<Column width={[1 / 2, 3 / 4]} style={style}>
-				<p>default 50% wide, 75% from tablet</p>
-				<Code>{'width={[1 / 2, 3 / 4]}'}</Code>
+			<Column style={style}>
+				Interdum et malesuada fames ac ante ipsum primis in faucibus. Nulla
+				facilisi. Phasellus id aliquam odio. Aliquam tempus eu enim in
+				fermentum. Donec ut velit vel purus rutrum vulputate ut scelerisque
+				lacus.
+			</Column>
+			<Column style={style}>
+				Pellentesque id ornare turpis. Aliquam laoreet aliquet pharetra. Donec
+				nec erat ac libero interdum sollicitudin. Nullam imperdiet ut dolor non
+				cursus. Integer et ante fringilla, luctus magna nec, consequat est.
+			</Column>
+			<Column style={style}>
+				Nunc nec dapibus quam. Praesent nec neque vel velit mollis tempor.
+				Suspendisse justo eros, pharetra et elit sit amet, hendrerit laoreet
+				dui. Curabitur ut libero nibh. Duis finibus sollicitudin tortor, ac
+				viverra urna commodo et.
+			</Column>
+			<Column style={style}>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Non igitur
+				potestis voluptate omnia dirigentes aut tueri aut retinere virtutem. Hoc
+				Hieronymus summum bonum esse dixit.
 			</Column>
 		</Columns>
-	</Container>
-);
-ResponsiveAtPhablet.parameters = {
-	viewport: { defaultViewport: 'phablet' },
-	chromatic: {
-		viewports: [breakpoints.phablet],
+	),
+};
+
+export const Default: Story = {
+	...ColumnsTemplate,
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
+		layout: 'fullscreen',
+		outline: true,
 	},
-	layout: 'fullscreen',
-	outline: true,
 };
 
-// *****************************************************************************
-
-export const ResponsiveAtTablet: StoryFn<typeof Columns> = (args) => (
-	<Container style={style}>
-		<Columns {...args}>
-			<Column width={[1 / 2, 1 / 4]} style={style}>
-				<p>default 50% wide, 25% from tablet</p>
-				<Code>{'width={[1 / 2, 1 / 4]}'}</Code>
-			</Column>
-			<Column width={[1 / 2, 3 / 4]} style={style}>
-				<p>default 50% wide, 75% from tablet</p>
-				<Code>{'width={[1 / 2, 3 / 4]}'}</Code>
-			</Column>
-		</Columns>
-	</Container>
-);
-ResponsiveAtTablet.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
+export const CollapseUntilTabletWithNoSpacing: Story = {
+	...ColumnsTemplate,
+	args: {
+		collapseUntil: 'tablet',
 	},
-	layout: 'fullscreen',
-};
-
-// *****************************************************************************
-
-export const ResponsiveHideAtTablet: StoryFn<typeof Columns> = (args) => (
-	<Container style={style}>
-		<Columns {...args}>
-			<Column width={[0, 1 / 4]} style={style}>
-				<p>hidden at mobile, 25% from tablet</p>
-				<Code>{'width={[0, 1 / 4]}'}</Code>
-			</Column>
-			<Column width={[1, 3 / 4]} style={style}>
-				<p>default 100% wide, 75% from tablet</p>
-				<Code>{'width={[1, 3 / 4]}'}</Code>
-			</Column>
-		</Columns>
-	</Container>
-);
-ResponsiveHideAtTablet.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
+	parameters: {
+		...Default.parameters,
+		viewport: { defaultViewport: 'phablet' },
+		chromatic: {
+			viewports: [breakpoints.phablet],
+		},
 	},
-	layout: 'fullscreen',
 };
 
-// *****************************************************************************
-
-export const ResponsiveHideAtMobile: StoryFn<typeof Columns> = (args) => (
-	<Container style={style}>
-		<Columns {...args}>
-			<Column width={[0, 1 / 4]} style={style}>
-				<p>hidden at mobile, 25% from tablet</p>
-				<Code>{'width={[0, 1 / 4]}'}</Code>
-			</Column>
-			<Column width={[1, 3 / 4]} style={style}>
-				<p>default 100% wide, 75% from tablet</p>
-				<Code>{'width={[1, 3 / 4]}'}</Code>
-			</Column>
-		</Columns>
-	</Container>
-);
-ResponsiveHideAtMobile.parameters = {
-	viewport: { defaultViewport: 'mobile' },
-	chromatic: {
-		viewports: [breakpoints.mobile],
+export const CollapseUntilTabletWithSpace1: Story = {
+	...ColumnsTemplate,
+	args: {
+		...CollapseUntilTabletWithNoSpacing.args,
+		spaceY: 1,
 	},
-	layout: 'fullscreen',
+	parameters: {
+		...CollapseUntilTabletWithNoSpacing.parameters,
+	},
 };
 
-// *****************************************************************************
-
-export const WithSpan: StoryFn<typeof Columns> = () => (
-	<>
-		<p>
-			Elements with a <Code>{'span'}</Code> prop will scale at our{' '}
-			<a href="https://theguardian.design/2a1e5182b/p/41be19-grids">
-				established breakpoints
-			</a>
-			:
-		</p>
-		<Container style={style}>
-			<Columns>
-				<Column style={style} span={1}>
-					<Code>{'span={1}'}</Code>
-				</Column>
-				<Column style={style} span={1}>
-					<Code>{'span={1}'}</Code>
-				</Column>
-				<Column style={style} span={2}>
-					<Code>{'span={2}'}</Code>
-				</Column>
-			</Columns>
-		</Container>
-		<p></p>
-		<Container style={style}>
-			<Columns>
-				<Column style={style} span={2}>
-					<Code>{'span={2}'}</Code>
-				</Column>
-				<Column style={style} />
-				<Column style={style} span={1}>
-					<Code>{'span={1}'}</Code>
-				</Column>
-			</Columns>
-		</Container>
-		<p>
-			An array of <Code>{'span'}</Code> values can be specified for relevant
-			breakpoints:
-		</p>
-		<Container style={style}>
-			<Columns>
-				<Column style={style} span={4}>
-					<Code>{'span={4}'}</Code>
-				</Column>
-				<Column style={style} span={[0, 4, 4]}>
-					<Code>{'span={[0, 4]}'}</Code>
-				</Column>
-				<Column style={style} span={[0, 4, 4, 6, 8]}>
-					<Code>{'span={[0, 0, 4, 6, 8]}'}</Code>
-				</Column>
-			</Columns>
-		</Container>
-		<p>
-			An element with a <Code>{'span'}</Code> will not extend beyond 100% of the
-			browser width:
-		</p>
-		<Container style={style}>
-			<Columns>
-				<Column style={style} span={12}>
-					<Code>{'span={12}'}</Code>
-				</Column>
-			</Columns>
-		</Container>
-		<p>
-			A <Code>{'span'}</Code> of 0 will cause the element not to be displayed.
-		</p>
-		<Container style={style}>
-			<Columns>
-				<Column style={style}>*</Column>
-				<Column style={style} span={[0, 0, 2]}>
-					<Code>{'span={[0, 0, 2]}'}</Code>
-				</Column>
-				<Column style={style} span={[0, 0, 2]}>
-					<Code>{'span={[0, 0, 2]}'}</Code>
-				</Column>
-			</Columns>
-		</Container>
-		<p>
-			<Code>{'span'}</Code> is overruled by <Code>{'width'}</Code> prop:
-		</p>
-		<Container style={style}>
-			<Columns>
-				<Column style={style} span={2} width={3 / 4}>
-					<Code>{'span={2} width={3 / 4}'}</Code>
-				</Column>
-				<Column style={style} width={1 / 4}>
-					<Code>{'width={1 / 4}'}</Code>
-				</Column>
-			</Columns>
-		</Container>
-	</>
-);
-WithSpan.parameters = {
-	layout: 'fullscreen',
+export const CollapseUntilTabletWithSpace2: Story = {
+	...ColumnsTemplate,
+	args: {
+		...CollapseUntilTabletWithNoSpacing.args,
+		spaceY: 2,
+	},
+	parameters: {
+		...CollapseUntilTabletWithNoSpacing.parameters,
+	},
 };
 
-// *****************************************************************************
+export const CollapseUntilTabletWithSpace3: Story = {
+	...ColumnsTemplate,
+	args: {
+		...CollapseUntilTabletWithNoSpacing.args,
+		spaceY: 3,
+	},
+	parameters: {
+		...CollapseUntilTabletWithNoSpacing.parameters,
+	},
+};
 
-export const WithWidth: StoryFn<typeof Columns> = () => (
-	<>
+export const CollapseUntilTabletWithSpace4: Story = {
+	...ColumnsTemplate,
+	args: {
+		...CollapseUntilTabletWithNoSpacing.args,
+		spaceY: 4,
+	},
+	parameters: {
+		...CollapseUntilTabletWithNoSpacing.parameters,
+	},
+};
+
+export const CollapseUntilTabletWithSpace5: Story = {
+	...ColumnsTemplate,
+	args: {
+		...CollapseUntilTabletWithNoSpacing.args,
+		spaceY: 5,
+	},
+	parameters: {
+		...CollapseUntilTabletWithNoSpacing.parameters,
+	},
+};
+
+export const CollapseUntilTabletWithSpace6: Story = {
+	...ColumnsTemplate,
+	args: {
+		...CollapseUntilTabletWithNoSpacing.args,
+		spaceY: 6,
+	},
+	parameters: {
+		...CollapseUntilTabletWithNoSpacing.parameters,
+	},
+};
+
+export const CollapseUntilTabletWithSpace9: Story = {
+	...ColumnsTemplate,
+	args: {
+		...CollapseUntilTabletWithNoSpacing.args,
+		spaceY: 9,
+	},
+	parameters: {
+		...CollapseUntilTabletWithNoSpacing.parameters,
+	},
+};
+
+export const CollapseUntilTabletWithSpace12: Story = {
+	...ColumnsTemplate,
+	args: {
+		...CollapseUntilTabletWithNoSpacing.args,
+		spaceY: 12,
+	},
+	parameters: {
+		...CollapseUntilTabletWithNoSpacing.parameters,
+	},
+};
+
+export const CollapseUntilTabletWithSpace24: Story = {
+	...ColumnsTemplate,
+	args: {
+		...CollapseUntilTabletWithNoSpacing.args,
+		spaceY: 24,
+	},
+	parameters: {
+		...CollapseUntilTabletWithNoSpacing.parameters,
+	},
+};
+
+export const WithContainer: Story = {
+	render: (args) => (
 		<Container style={style}>
-			<Columns>
-				<Column width={1 / 4} style={style}>
-					<Code>{'width={1 / 4}'}</Code>
+			<Columns {...args} style={style}>
+				<Column style={style}>
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut faucibus
+					nibh erat, eget rutrum ligula vehicula sit amet. Etiam scelerisque
+					dapibus pulvinar. Integer non accumsan justo. Duis et vehicula risus.
+					Nulla ligula eros, consequat sodales lectus eget, eleifend venenatis
+					neque.
 				</Column>
-				<Column style={style} />
-				<Column style={style} />
+				<Column style={style}>
+					Interdum et malesuada fames ac ante ipsum primis in faucibus. Nulla
+					facilisi. Phasellus id aliquam odio. Aliquam tempus eu enim in
+					fermentum. Donec ut velit vel purus rutrum vulputate ut scelerisque
+					lacus.
+				</Column>
+				<Column style={style}>
+					Pellentesque id ornare turpis. Aliquam laoreet aliquet pharetra. Donec
+					nec erat ac libero interdum sollicitudin. Nullam imperdiet ut dolor
+					non cursus. Integer et ante fringilla, luctus magna nec, consequat
+					est.
+				</Column>
+				<Column style={style}>
+					Nunc nec dapibus quam. Praesent nec neque vel velit mollis tempor.
+					Suspendisse justo eros, pharetra et elit sit amet, hendrerit laoreet
+					dui. Curabitur ut libero nibh. Duis finibus sollicitudin tortor, ac
+					viverra urna commodo et.
+				</Column>
+				<Column style={style}>
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Non igitur
+					potestis voluptate omnia dirigentes aut tueri aut retinere virtutem.
+					Hoc Hieronymus summum bonum esse dixit.
+				</Column>
 			</Columns>
 		</Container>
-		<p></p>
+	),
+	parameters: {
+		layout: 'fullscreen',
+	},
+};
+
+export const ResponsiveAtPhablet: Story = {
+	render: (args) => (
 		<Container style={style}>
-			<Columns>
-				<Column width={1 / 3} style={style}>
-					<Code>{'width={1 / 3}'}</Code>
+			<Columns {...args}>
+				<Column width={[1 / 2, 1 / 4]} style={style}>
+					<p>default 50% wide, 25% from tablet</p>
+					<Code>{'width={[1 / 2, 1 / 4]}'}</Code>
 				</Column>
-				<Column style={style} />
-				<Column style={style} />
+				<Column width={[1 / 2, 3 / 4]} style={style}>
+					<p>default 50% wide, 75% from tablet</p>
+					<Code>{'width={[1 / 2, 3 / 4]}'}</Code>
+				</Column>
 			</Columns>
 		</Container>
-		<p></p>
+	),
+	parameters: {
+		viewport: { defaultViewport: 'phablet' },
+		chromatic: {
+			viewports: [breakpoints.phablet],
+		},
+		layout: 'fullscreen',
+		outline: true,
+	},
+};
+
+export const ResponsiveAtTablet: Story = {
+	render: (args) => (
 		<Container style={style}>
-			<Columns>
-				<Column width={1 / 2} style={style}>
-					<Code>{'width={1 / 2}'}</Code>
+			<Columns {...args}>
+				<Column width={[1 / 2, 1 / 4]} style={style}>
+					<p>default 50% wide, 25% from tablet</p>
+					<Code>{'width={[1 / 2, 1 / 4]}'}</Code>
 				</Column>
-				<Column style={style} />
-				<Column style={style} />
+				<Column width={[1 / 2, 3 / 4]} style={style}>
+					<p>default 50% wide, 75% from tablet</p>
+					<Code>{'width={[1 / 2, 3 / 4]}'}</Code>
+				</Column>
 			</Columns>
 		</Container>
-		<p></p>
+	),
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
+		layout: 'fullscreen',
+	},
+};
+
+export const ResponsiveHideAtTablet: Story = {
+	render: (args) => (
 		<Container style={style}>
-			<Columns>
-				<Column width={3 / 4} style={style}>
-					<Code>{'width={3 / 4}'}</Code>
+			<Columns {...args}>
+				<Column width={[0, 1 / 4]} style={style}>
+					<p>hidden at mobile, 25% from tablet</p>
+					<Code>{'width={[0, 1 / 4]}'}</Code>
 				</Column>
-				<Column style={style} />
-				<Column style={style} />
+				<Column width={[1, 3 / 4]} style={style}>
+					<p>default 100% wide, 75% from tablet</p>
+					<Code>{'width={[1, 3 / 4]}'}</Code>
+				</Column>
 			</Columns>
 		</Container>
-	</>
-);
-WithWidth.parameters = {
-	layout: 'fullscreen',
+	),
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
+		layout: 'fullscreen',
+	},
+};
+
+export const ResponsiveHideAtMobile: Story = {
+	render: (args) => (
+		<Container style={style}>
+			<Columns {...args}>
+				<Column width={[0, 1 / 4]} style={style}>
+					<p>hidden at mobile, 25% from tablet</p>
+					<Code>{'width={[0, 1 / 4]}'}</Code>
+				</Column>
+				<Column width={[1, 3 / 4]} style={style}>
+					<p>default 100% wide, 75% from tablet</p>
+					<Code>{'width={[1, 3 / 4]}'}</Code>
+				</Column>
+			</Columns>
+		</Container>
+	),
+	parameters: {
+		viewport: { defaultViewport: 'mobile' },
+		chromatic: {
+			viewports: [breakpoints.mobile],
+		},
+		layout: 'fullscreen',
+	},
+};
+
+export const WithSpan: Story = {
+	render: () => (
+		<>
+			<p>
+				Elements with a <Code>{'span'}</Code> prop will scale at our{' '}
+				<a href="https://theguardian.design/2a1e5182b/p/41be19-grids">
+					established breakpoints
+				</a>
+				:
+			</p>
+			<Container style={style}>
+				<Columns>
+					<Column style={style} span={1}>
+						<Code>{'span={1}'}</Code>
+					</Column>
+					<Column style={style} span={1}>
+						<Code>{'span={1}'}</Code>
+					</Column>
+					<Column style={style} span={2}>
+						<Code>{'span={2}'}</Code>
+					</Column>
+				</Columns>
+			</Container>
+			<p></p>
+			<Container style={style}>
+				<Columns>
+					<Column style={style} span={2}>
+						<Code>{'span={2}'}</Code>
+					</Column>
+					<Column style={style} />
+					<Column style={style} span={1}>
+						<Code>{'span={1}'}</Code>
+					</Column>
+				</Columns>
+			</Container>
+			<p>
+				An array of <Code>{'span'}</Code> values can be specified for relevant
+				breakpoints:
+			</p>
+			<Container style={style}>
+				<Columns>
+					<Column style={style} span={4}>
+						<Code>{'span={4}'}</Code>
+					</Column>
+					<Column style={style} span={[0, 4, 4]}>
+						<Code>{'span={[0, 4]}'}</Code>
+					</Column>
+					<Column style={style} span={[0, 4, 4, 6, 8]}>
+						<Code>{'span={[0, 0, 4, 6, 8]}'}</Code>
+					</Column>
+				</Columns>
+			</Container>
+			<p>
+				An element with a <Code>{'span'}</Code> will not extend beyond 100% of
+				the browser width:
+			</p>
+			<Container style={style}>
+				<Columns>
+					<Column style={style} span={12}>
+						<Code>{'span={12}'}</Code>
+					</Column>
+				</Columns>
+			</Container>
+			<p>
+				A <Code>{'span'}</Code> of 0 will cause the element not to be displayed.
+			</p>
+			<Container style={style}>
+				<Columns>
+					<Column style={style}>*</Column>
+					<Column style={style} span={[0, 0, 2]}>
+						<Code>{'span={[0, 0, 2]}'}</Code>
+					</Column>
+					<Column style={style} span={[0, 0, 2]}>
+						<Code>{'span={[0, 0, 2]}'}</Code>
+					</Column>
+				</Columns>
+			</Container>
+			<p>
+				<Code>{'span'}</Code> is overruled by <Code>{'width'}</Code> prop:
+			</p>
+			<Container style={style}>
+				<Columns>
+					<Column style={style} span={2} width={3 / 4}>
+						<Code>{'span={2} width={3 / 4}'}</Code>
+					</Column>
+					<Column style={style} width={1 / 4}>
+						<Code>{'width={1 / 4}'}</Code>
+					</Column>
+				</Columns>
+			</Container>
+		</>
+	),
+	parameters: {
+		layout: 'fullscreen',
+	},
+};
+
+export const WithWidth: Story = {
+	render: () => (
+		<>
+			<Container style={style}>
+				<Columns>
+					<Column width={1 / 4} style={style}>
+						<Code>{'width={1 / 4}'}</Code>
+					</Column>
+					<Column style={style} />
+					<Column style={style} />
+				</Columns>
+			</Container>
+			<p></p>
+			<Container style={style}>
+				<Columns>
+					<Column width={1 / 3} style={style}>
+						<Code>{'width={1 / 3}'}</Code>
+					</Column>
+					<Column style={style} />
+					<Column style={style} />
+				</Columns>
+			</Container>
+			<p></p>
+			<Container style={style}>
+				<Columns>
+					<Column width={1 / 2} style={style}>
+						<Code>{'width={1 / 2}'}</Code>
+					</Column>
+					<Column style={style} />
+					<Column style={style} />
+				</Columns>
+			</Container>
+			<p></p>
+			<Container style={style}>
+				<Columns>
+					<Column width={3 / 4} style={style}>
+						<Code>{'width={3 / 4}'}</Code>
+					</Column>
+					<Column style={style} />
+					<Column style={style} />
+				</Columns>
+			</Container>
+		</>
+	),
+	parameters: {
+		layout: 'fullscreen',
+	},
 };

--- a/libs/@guardian/source/src/react-components/columns/Columns.stories.tsx
+++ b/libs/@guardian/source/src/react-components/columns/Columns.stories.tsx
@@ -18,7 +18,7 @@ const Code = (args: HTMLAttributes<HTMLElement>) => (
 	<code style={{ whiteSpace: 'nowrap' }} {...args} />
 );
 
-const ColumnsTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<Columns {...args} style={style}>
 			<Column style={style}>
@@ -55,7 +55,7 @@ const ColumnsTemplate: Story = {
 };
 
 export const Default: Story = {
-	...ColumnsTemplate,
+	...Template,
 	parameters: {
 		viewport: { defaultViewport: 'tablet' },
 		chromatic: {
@@ -67,7 +67,7 @@ export const Default: Story = {
 };
 
 export const CollapseUntilTabletWithNoSpacing: Story = {
-	...ColumnsTemplate,
+	...Template,
 	args: {
 		collapseUntil: 'tablet',
 	},
@@ -81,7 +81,7 @@ export const CollapseUntilTabletWithNoSpacing: Story = {
 };
 
 export const CollapseUntilTabletWithSpace1: Story = {
-	...ColumnsTemplate,
+	...Template,
 	args: {
 		...CollapseUntilTabletWithNoSpacing.args,
 		spaceY: 1,
@@ -92,7 +92,7 @@ export const CollapseUntilTabletWithSpace1: Story = {
 };
 
 export const CollapseUntilTabletWithSpace2: Story = {
-	...ColumnsTemplate,
+	...Template,
 	args: {
 		...CollapseUntilTabletWithNoSpacing.args,
 		spaceY: 2,
@@ -103,7 +103,7 @@ export const CollapseUntilTabletWithSpace2: Story = {
 };
 
 export const CollapseUntilTabletWithSpace3: Story = {
-	...ColumnsTemplate,
+	...Template,
 	args: {
 		...CollapseUntilTabletWithNoSpacing.args,
 		spaceY: 3,
@@ -114,7 +114,7 @@ export const CollapseUntilTabletWithSpace3: Story = {
 };
 
 export const CollapseUntilTabletWithSpace4: Story = {
-	...ColumnsTemplate,
+	...Template,
 	args: {
 		...CollapseUntilTabletWithNoSpacing.args,
 		spaceY: 4,
@@ -125,7 +125,7 @@ export const CollapseUntilTabletWithSpace4: Story = {
 };
 
 export const CollapseUntilTabletWithSpace5: Story = {
-	...ColumnsTemplate,
+	...Template,
 	args: {
 		...CollapseUntilTabletWithNoSpacing.args,
 		spaceY: 5,
@@ -136,7 +136,7 @@ export const CollapseUntilTabletWithSpace5: Story = {
 };
 
 export const CollapseUntilTabletWithSpace6: Story = {
-	...ColumnsTemplate,
+	...Template,
 	args: {
 		...CollapseUntilTabletWithNoSpacing.args,
 		spaceY: 6,
@@ -147,7 +147,7 @@ export const CollapseUntilTabletWithSpace6: Story = {
 };
 
 export const CollapseUntilTabletWithSpace9: Story = {
-	...ColumnsTemplate,
+	...Template,
 	args: {
 		...CollapseUntilTabletWithNoSpacing.args,
 		spaceY: 9,
@@ -158,7 +158,7 @@ export const CollapseUntilTabletWithSpace9: Story = {
 };
 
 export const CollapseUntilTabletWithSpace12: Story = {
-	...ColumnsTemplate,
+	...Template,
 	args: {
 		...CollapseUntilTabletWithNoSpacing.args,
 		spaceY: 12,
@@ -169,7 +169,7 @@ export const CollapseUntilTabletWithSpace12: Story = {
 };
 
 export const CollapseUntilTabletWithSpace24: Story = {
-	...ColumnsTemplate,
+	...Template,
 	args: {
 		...CollapseUntilTabletWithNoSpacing.args,
 		spaceY: 24,

--- a/libs/@guardian/source/src/react-components/container/Container.stories.tsx
+++ b/libs/@guardian/source/src/react-components/container/Container.stories.tsx
@@ -1,5 +1,4 @@
-import type { Meta, StoryFn } from '@storybook/react';
-import type { ContainerProps } from './Container';
+import type { StoryObj, Meta, StoryFn } from '@storybook/react';
 import { Container } from './Container';
 
 const meta: Meta<typeof Container> = {
@@ -12,63 +11,69 @@ const meta: Meta<typeof Container> = {
 			},
 		},
 	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Container>;
+
+const ContainerTemplate: Story = {
+	render: (args) => (
+		<Container {...args}>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliud igitur esse
+			censet gaudere, aliud non dolere. Quid turpius quam sapientis vitam ex
+			insipientium sermone pendere? Nam illud quidem adduci vix possum, ut ea,
+			quae senserit ille, tibi non vera videantur. At iam decimum annum in
+			spelunca iacet.
+		</Container>
+	),
+};
+
+export const Default: Story = {
+	...ContainerTemplate,
 	args: {
 		sideBorders: false,
 		topBorder: false,
 	},
 };
 
-export default meta;
-
-const Template: StoryFn<typeof Container> = (args: ContainerProps) => (
-	<Container {...args}>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliud igitur esse
-		censet gaudere, aliud non dolere. Quid turpius quam sapientis vitam ex
-		insipientium sermone pendere? Nam illud quidem adduci vix possum, ut ea,
-		quae senserit ille, tibi non vera videantur. At iam decimum annum in
-		spelunca iacet.
-	</Container>
-);
-
-export const Default: StoryFn<typeof Container> = Template.bind({});
-
-// *****************************************************************************
-
-export const WithSideBorders: StoryFn<typeof Container> = Template.bind({});
-WithSideBorders.args = {
-	sideBorders: true,
+export const WithSideBorders: Story = {
+	...ContainerTemplate,
+	args: {
+		...Default.args,
+		sideBorders: true,
+	},
 };
 
-// *****************************************************************************
-
-export const WithTopBorder: StoryFn<typeof Container> = Template.bind({});
-WithTopBorder.args = {
-	topBorder: true,
+export const WithTopBorder: Story = {
+	...ContainerTemplate,
+	args: {
+		...Default.args,
+		topBorder: true,
+	},
 };
 
-// *****************************************************************************
-
-export const WithBorderColour: StoryFn<typeof Container> = Template.bind({});
-WithBorderColour.args = {
-	sideBorders: true,
-	topBorder: true,
-	borderColor: 'red',
+export const WithBorderColour: Story = {
+	...ContainerTemplate,
+	args: {
+		...Default.args,
+		sideBorders: true,
+		topBorder: true,
+		borderColor: 'red',
+	},
 };
 
-// *****************************************************************************
-
-export const WithBackgroundColour: StoryFn<typeof Container> = Template.bind(
-	{},
-);
-WithBackgroundColour.args = {
-	backgroundColor: 'red',
+export const WithBackgroundColour: Story = {
+	...ContainerTemplate,
+	args: {
+		...Default.args,
+		backgroundColor: 'red',
+	},
 };
 
-// *****************************************************************************
-
-export const WithAsideElement: StoryFn<typeof Container> = Template.bind({});
-WithAsideElement.args = {
-	element: 'aside',
+export const WithAsideElement: Story = {
+	...ContainerTemplate,
+	args: {
+		...Default.args,
+		element: 'aside',
+	},
 };
-
-// *****************************************************************************

--- a/libs/@guardian/source/src/react-components/container/Container.stories.tsx
+++ b/libs/@guardian/source/src/react-components/container/Container.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { Container } from './Container';
 
 const meta: Meta<typeof Container> = {

--- a/libs/@guardian/source/src/react-components/container/Container.stories.tsx
+++ b/libs/@guardian/source/src/react-components/container/Container.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof Container> = {
 export default meta;
 type Story = StoryObj<typeof Container>;
 
-const ContainerTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<Container {...args}>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliud igitur esse
@@ -29,7 +29,7 @@ const ContainerTemplate: Story = {
 };
 
 export const Default: Story = {
-	...ContainerTemplate,
+	...Template,
 	args: {
 		sideBorders: false,
 		topBorder: false,
@@ -37,7 +37,7 @@ export const Default: Story = {
 };
 
 export const WithSideBorders: Story = {
-	...ContainerTemplate,
+	...Template,
 	args: {
 		...Default.args,
 		sideBorders: true,
@@ -45,7 +45,7 @@ export const WithSideBorders: Story = {
 };
 
 export const WithTopBorder: Story = {
-	...ContainerTemplate,
+	...Template,
 	args: {
 		...Default.args,
 		topBorder: true,
@@ -53,7 +53,7 @@ export const WithTopBorder: Story = {
 };
 
 export const WithBorderColour: Story = {
-	...ContainerTemplate,
+	...Template,
 	args: {
 		...Default.args,
 		sideBorders: true,
@@ -63,7 +63,7 @@ export const WithBorderColour: Story = {
 };
 
 export const WithBackgroundColour: Story = {
-	...ContainerTemplate,
+	...Template,
 	args: {
 		...Default.args,
 		backgroundColor: 'red',
@@ -71,7 +71,7 @@ export const WithBackgroundColour: Story = {
 };
 
 export const WithAsideElement: Story = {
-	...ContainerTemplate,
+	...Template,
 	args: {
 		...Default.args,
 		element: 'aside',

--- a/libs/@guardian/source/src/react-components/footer/BackToTop.stories.tsx
+++ b/libs/@guardian/source/src/react-components/footer/BackToTop.stories.tsx
@@ -1,13 +1,12 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { BackToTop } from './BackToTop';
 
 const meta: Meta<typeof BackToTop> = {
-	component: () => BackToTop,
 	title: 'React Components/BackToTop',
+	component: () => BackToTop,
 };
 
 export default meta;
+type Story = StoryObj<typeof BackToTop>;
 
-const Template: StoryFn<typeof BackToTop> = () => BackToTop;
-
-export const Default: StoryFn<typeof BackToTop> = Template.bind({});
+export const Default: Story = {};

--- a/libs/@guardian/source/src/react-components/footer/BackToTop.stories.tsx
+++ b/libs/@guardian/source/src/react-components/footer/BackToTop.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { BackToTop } from './BackToTop';
 
 const meta: Meta<typeof BackToTop> = {

--- a/libs/@guardian/source/src/react-components/footer/Footer.stories.tsx
+++ b/libs/@guardian/source/src/react-components/footer/Footer.stories.tsx
@@ -70,7 +70,7 @@ export const WithBackToTopTabletDefaultTheme: Story = {
 	},
 };
 
-export const WithBackToTopMobileDefaultTheme: StoryObj<typeof Footer> = {
+export const WithBackToTopMobileDefaultTheme: Story = {
 	args: {
 		...WithBackToTopDefaultTheme.args,
 	},

--- a/libs/@guardian/source/src/react-components/footer/Footer.stories.tsx
+++ b/libs/@guardian/source/src/react-components/footer/Footer.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { breakpoints } from '../../foundations';
 import { Footer } from './Footer';
 

--- a/libs/@guardian/source/src/react-components/footer/Footer.stories.tsx
+++ b/libs/@guardian/source/src/react-components/footer/Footer.stories.tsx
@@ -1,6 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { breakpoints } from '../../foundations';
-import type { FooterProps } from './Footer';
 import { Footer } from './Footer';
 
 const meta: Meta<typeof Footer> = {
@@ -29,122 +28,113 @@ const meta: Meta<typeof Footer> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof Footer>;
 
-const Template: StoryFn<typeof Footer> = (args: FooterProps) => (
-	<Footer {...args} />
-);
+export const DefaultDefaultTheme: Story = {
+	args: { children: 'with' },
+};
 
-export const DefaultDefaultTheme: StoryFn<typeof Footer> = Template.bind({});
-DefaultDefaultTheme.args = { children: 'with' };
-
-export const DefaultTabletDefaultTheme: StoryFn<typeof Footer> = Template.bind(
-	{},
-);
-DefaultTabletDefaultTheme.args = { children: 'with' };
-DefaultTabletDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
+export const DefaultTabletDefaultTheme: StoryObj<typeof Footer> = {
+	args: { ...DefaultDefaultTheme.args },
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
 	},
 };
 
-export const DefaultMobileDefaultTheme: StoryFn<typeof Footer> = Template.bind(
-	{},
-);
-DefaultMobileDefaultTheme.args = { children: 'with' };
-DefaultMobileDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'mobileMedium' },
-	chromatic: {
-		viewports: [breakpoints.mobileMedium],
+export const DefaultMobileDefaultTheme: Story = {
+	args: { ...DefaultDefaultTheme.args },
+	parameters: {
+		viewport: { defaultViewport: 'mobileMedium' },
+		chromatic: {
+			viewports: [breakpoints.mobileMedium],
+		},
 	},
 };
 
-export const WithBackToTopDefaultTheme: StoryFn<typeof Footer> = Template.bind(
-	{},
-);
-WithBackToTopDefaultTheme.args = { showBackToTop: true, children: 'with' };
-
-export const WithBackToTopTabletDefaultTheme: StoryFn<typeof Footer> =
-	Template.bind({});
-WithBackToTopTabletDefaultTheme.args = {
-	showBackToTop: true,
-	children: 'with',
+export const WithBackToTopDefaultTheme: Story = {
+	args: { ...DefaultDefaultTheme.args, showBackToTop: true },
 };
-WithBackToTopTabletDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
+
+export const WithBackToTopTabletDefaultTheme: Story = {
+	args: {
+		...WithBackToTopDefaultTheme.args,
+	},
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
 	},
 };
 
-export const WithBackToTopMobileDefaultTheme: StoryFn<typeof Footer> =
-	Template.bind({});
-WithBackToTopMobileDefaultTheme.args = {
-	showBackToTop: true,
-	children: 'with',
-};
-WithBackToTopMobileDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'mobileMedium' },
-	chromatic: {
-		viewports: [breakpoints.mobileMedium],
+export const WithBackToTopMobileDefaultTheme: StoryObj<typeof Footer> = {
+	args: {
+		...WithBackToTopDefaultTheme.args,
+	},
+	parameters: {
+		viewport: { defaultViewport: 'mobileMedium' },
+		chromatic: {
+			viewports: [breakpoints.mobileMedium],
+		},
 	},
 };
 
-export const WithoutChildrenDefaultTheme: StoryFn<typeof Footer> =
-	Template.bind({});
-WithoutChildrenDefaultTheme.args = { children: 'without' };
+export const WithoutChildrenDefaultTheme: Story = {
+	args: { children: 'without' },
+};
 
-export const WithoutChildrenTabletDefaultTheme: StoryFn<typeof Footer> =
-	Template.bind({});
-WithoutChildrenTabletDefaultTheme.args = { children: 'without' };
-WithoutChildrenTabletDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
+export const WithoutChildrenTabletDefaultTheme: Story = {
+	args: { ...WithoutChildrenDefaultTheme.args },
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
 	},
 };
 
-export const WithoutChildrenMobileDefaultTheme: StoryFn<typeof Footer> =
-	Template.bind({});
-WithoutChildrenMobileDefaultTheme.args = { children: 'without' };
-WithoutChildrenMobileDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'mobileMedium' },
-	chromatic: {
-		viewports: [breakpoints.mobileMedium],
+export const WithoutChildrenMobileDefaultTheme: Story = {
+	args: { ...WithoutChildrenDefaultTheme.args },
+	parameters: {
+		viewport: { defaultViewport: 'mobileMedium' },
+		chromatic: {
+			viewports: [breakpoints.mobileMedium],
+		},
 	},
 };
 
-export const WithoutChildrenWithBackToTopDefaultTheme: StoryFn<typeof Footer> =
-	Template.bind({});
-WithoutChildrenWithBackToTopDefaultTheme.args = {
-	showBackToTop: true,
-	children: 'without',
-};
-
-export const WithoutChildrenWithBackToTopTabletDefaultTheme: StoryFn<
-	typeof Footer
-> = Template.bind({});
-WithoutChildrenWithBackToTopTabletDefaultTheme.args = {
-	showBackToTop: true,
-	children: 'without',
-};
-WithoutChildrenWithBackToTopTabletDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
+export const WithoutChildrenWithBackToTopDefaultTheme: Story = {
+	args: {
+		...WithoutChildrenDefaultTheme.args,
+		showBackToTop: true,
 	},
 };
 
-export const WithoutChildrenWithBackToTopMobileDefaultTheme: StoryFn<
-	typeof Footer
-> = Template.bind({});
-WithoutChildrenWithBackToTopMobileDefaultTheme.args = {
-	showBackToTop: true,
-	children: 'without',
+export const WithoutChildrenWithBackToTopTabletDefaultTheme: Story = {
+	args: {
+		...WithoutChildrenDefaultTheme.args,
+		showBackToTop: true,
+	},
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
+	},
 };
-WithoutChildrenWithBackToTopMobileDefaultTheme.parameters = {
-	viewport: { defaultViewport: 'mobileMedium' },
-	chromatic: {
-		viewports: [breakpoints.mobileMedium],
+
+export const WithoutChildrenWithBackToTopMobileDefaultTheme: Story = {
+	args: {
+		...WithoutChildrenDefaultTheme.args,
+		showBackToTop: true,
+	},
+	parameters: {
+		viewport: { defaultViewport: 'mobileMedium' },
+		chromatic: {
+			viewports: [breakpoints.mobileMedium],
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/hide/Hide.stories.tsx
+++ b/libs/@guardian/source/src/react-components/hide/Hide.stories.tsx
@@ -1,6 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta, StoryFn } from '@storybook/react';
 import { breakpoints } from '../../foundations';
-import type { HideProps } from './Hide';
 import { Hide } from './Hide';
 
 const meta: Meta<typeof Hide> = {
@@ -17,69 +16,62 @@ const meta: Meta<typeof Hide> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof Hide>;
 
-const Template: StoryFn<typeof Hide> = (args: HideProps) => (
-	<Hide {...args}>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliud igitur esse
-		censet gaudere, aliud non dolere. Quid turpius quam sapientis vitam ex
-		insipientium sermone pendere? Nam illud quidem adduci vix possum, ut ea,
-		quae senserit ille, tibi non vera videantur. At iam decimum annum in
-		spelunca iacet.
-	</Hide>
-);
-
-// *****************************************************************************
-
-export const HiddenFromTabletAtMobile: StoryFn<typeof Hide> = Template.bind({});
-HiddenFromTabletAtMobile.args = {
-	from: 'tablet',
+const HideTemplate: Story = {
+	render: (args) => (
+		<Hide {...args}>
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliud igitur esse
+			censet gaudere, aliud non dolere. Quid turpius quam sapientis vitam ex
+			insipientium sermone pendere? Nam illud quidem adduci vix possum, ut ea,
+			quae senserit ille, tibi non vera videantur. At iam decimum annum in
+			spelunca iacet.
+		</Hide>
+	),
 };
-HiddenFromTabletAtMobile.parameters = {
-	viewport: { defaultViewport: 'mobile' },
-	chromatic: {
-		viewports: [breakpoints.mobile],
+
+export const HiddenFromTabletAtMobile: Story = {
+	...HideTemplate,
+	args: {
+		from: 'tablet',
+	},
+	parameters: {
+		viewport: { defaultViewport: 'mobile' },
+		chromatic: {
+			viewports: [breakpoints.mobile],
+		},
 	},
 };
 
-// *****************************************************************************
-
-export const HiddenFromTabletAtTablet: StoryFn<typeof Hide> = Template.bind({});
-HiddenFromTabletAtTablet.args = {
-	from: 'tablet',
-};
-HiddenFromTabletAtTablet.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
+export const HiddenFromTabletAtTablet: Story = {
+	...HiddenFromTabletAtMobile,
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
 	},
 };
 
-// *****************************************************************************
-
-export const HiddenUntilTabletAtMobile: StoryFn<typeof Hide> = Template.bind(
-	{},
-);
-HiddenUntilTabletAtMobile.args = {
-	until: 'tablet',
-};
-HiddenUntilTabletAtMobile.parameters = {
-	viewport: { defaultViewport: 'mobile' },
-	chromatic: {
-		viewports: [breakpoints.mobile],
+export const HiddenUntilTabletAtMobile: Story = {
+	...HideTemplate,
+	args: {
+		until: 'tablet',
+	},
+	parameters: {
+		viewport: { defaultViewport: 'mobile' },
+		chromatic: {
+			viewports: [breakpoints.mobile],
+		},
 	},
 };
 
-// *****************************************************************************
-
-export const HiddenUntilTabletAtTablet: StoryFn<typeof Hide> = Template.bind(
-	{},
-);
-HiddenUntilTabletAtTablet.args = {
-	until: 'tablet',
-};
-HiddenUntilTabletAtTablet.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
+export const HiddenUntilTabletAtTablet: Story = {
+	...HiddenUntilTabletAtMobile,
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/hide/Hide.stories.tsx
+++ b/libs/@guardian/source/src/react-components/hide/Hide.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { breakpoints } from '../../foundations';
 import { Hide } from './Hide';
 

--- a/libs/@guardian/source/src/react-components/hide/Hide.stories.tsx
+++ b/libs/@guardian/source/src/react-components/hide/Hide.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof Hide> = {
 export default meta;
 type Story = StoryObj<typeof Hide>;
 
-const HideTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<Hide {...args}>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliud igitur esse
@@ -31,7 +31,7 @@ const HideTemplate: Story = {
 };
 
 export const HiddenFromTabletAtMobile: Story = {
-	...HideTemplate,
+	...Template,
 	args: {
 		from: 'tablet',
 	},
@@ -54,7 +54,7 @@ export const HiddenFromTabletAtTablet: Story = {
 };
 
 export const HiddenUntilTabletAtMobile: Story = {
-	...HideTemplate,
+	...Template,
 	args: {
 		until: 'tablet',
 	},

--- a/libs/@guardian/source/src/react-components/hide/Hide.stories.tsx
+++ b/libs/@guardian/source/src/react-components/hide/Hide.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { breakpoints } from '../../foundations';
 import { Hide } from './Hide';
 

--- a/libs/@guardian/source/src/react-components/inline/Inline.stories.tsx
+++ b/libs/@guardian/source/src/react-components/inline/Inline.stories.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { breakpoints, palette, space } from '../../foundations';
-import type { InlineProps } from './Inline';
 import { Inline } from './Inline';
 
 const meta: Meta<typeof Inline> = {
@@ -10,6 +9,7 @@ const meta: Meta<typeof Inline> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof Inline>;
 
 const wrapper = css`
 	outline: 1px dashed ${palette.neutral[46]};
@@ -23,149 +23,159 @@ const box = css`
 	background: ${palette.news[600]};
 `;
 
-const Template: StoryFn<typeof Inline> = (args: InlineProps) => (
-	<div css={wrapper}>
-		<Inline {...args}>
-			{args.children ?? (
-				<>
-					<div css={box}>1</div>
-					<div css={box}>2</div>
-					<div css={box}>3</div>
-				</>
-			)}
-		</Inline>
-	</div>
-);
-
-export const NoSpace: StoryFn<typeof Inline> = Template.bind({});
-
-// *****************************************************************************
-
-export const Space0: StoryFn<typeof Inline> = Template.bind({});
-Space0.args = {
-	space: 0,
-};
-
-// *****************************************************************************
-
-export const Space1: StoryFn<typeof Inline> = Template.bind({});
-Space1.args = {
-	space: 1,
-};
-
-// *****************************************************************************
-
-export const Space2: StoryFn<typeof Inline> = Template.bind({});
-Space2.args = {
-	space: 2,
-};
-
-// *****************************************************************************
-
-export const Space3: StoryFn<typeof Inline> = Template.bind({});
-Space3.args = {
-	space: 3,
-};
-
-// *****************************************************************************
-
-export const Space4: StoryFn<typeof Inline> = Template.bind({});
-Space4.args = {
-	space: 4,
-};
-
-// *****************************************************************************
-
-export const Space5: StoryFn<typeof Inline> = Template.bind({});
-Space5.args = {
-	space: 5,
-};
-
-// *****************************************************************************
-
-export const Space6: StoryFn<typeof Inline> = Template.bind({});
-Space6.args = {
-	space: 6,
-};
-
-// *****************************************************************************
-
-export const Space8: StoryFn<typeof Inline> = Template.bind({});
-Space8.args = {
-	space: 8,
-};
-
-// *****************************************************************************
-
-export const Space9: StoryFn<typeof Inline> = Template.bind({});
-Space9.args = {
-	space: 9,
-};
-
-// *****************************************************************************
-
-export const Space10: StoryFn<typeof Inline> = Template.bind({});
-Space10.args = {
-	space: 10,
-};
-
-// *****************************************************************************
-
-export const Space12: StoryFn<typeof Inline> = Template.bind({});
-Space12.args = {
-	space: 12,
-};
-
-// *****************************************************************************
-
-export const Space14: StoryFn<typeof Inline> = Template.bind({});
-Space14.args = {
-	space: 14,
-};
-
-// *****************************************************************************
-
-export const Space16: StoryFn<typeof Inline> = Template.bind({});
-Space16.args = {
-	space: 16,
-};
-
-// *****************************************************************************
-
-export const Space18: StoryFn<typeof Inline> = Template.bind({});
-Space18.args = {
-	space: 18,
-};
-
-// *****************************************************************************
-
-export const Space24: StoryFn<typeof Inline> = Template.bind({});
-Space24.args = {
-	space: 24,
-};
-
-// *****************************************************************************
-
-export const MultipleChildElements: StoryFn<typeof Inline> = Template.bind({});
-MultipleChildElements.args = {
-	space: 2,
-	children: Array.from({ length: 24 }, (_, i) => (
-		<div key={i} css={box}>
-			{i + 1}
+const InlineTemplate: Story = {
+	render: (args) => (
+		<div css={wrapper}>
+			<Inline {...args}>
+				{args.children ?? (
+					<>
+						<div css={box}>1</div>
+						<div css={box}>2</div>
+						<div css={box}>3</div>
+					</>
+				)}
+			</Inline>
 		</div>
-	)),
+	),
 };
 
-// *****************************************************************************
-
-export const CollapseUntilTablet: StoryFn<typeof Inline> = Template.bind({});
-CollapseUntilTablet.args = {
-	space: 2,
-	collapseUntil: 'tablet',
+export const NoSpace: Story = {
+	...InlineTemplate,
 };
-CollapseUntilTablet.parameters = {
-	viewport: { defaultViewport: 'mobile' },
-	chromatic: {
-		viewports: [breakpoints.mobile],
+
+export const Space0: Story = {
+	...InlineTemplate,
+	args: {
+		space: 0,
+	},
+};
+
+export const Space1: Story = {
+	...InlineTemplate,
+	args: {
+		space: 1,
+	},
+};
+
+export const Space2: Story = {
+	...InlineTemplate,
+	args: {
+		space: 2,
+	},
+};
+
+export const Space3: Story = {
+	...InlineTemplate,
+	args: {
+		space: 3,
+	},
+};
+
+export const Space4: Story = {
+	...InlineTemplate,
+	args: {
+		space: 4,
+	},
+};
+
+export const Space5: Story = {
+	...InlineTemplate,
+	args: {
+		space: 5,
+	},
+};
+
+export const Space6: Story = {
+	...InlineTemplate,
+	args: {
+		space: 6,
+	},
+};
+
+export const Space8: Story = {
+	...InlineTemplate,
+	args: {
+		space: 8,
+	},
+};
+
+export const Space9: Story = {
+	...InlineTemplate,
+	args: {
+		space: 9,
+	},
+};
+
+export const Space10: Story = {
+	...InlineTemplate,
+	args: {
+		space: 10,
+	},
+};
+
+export const Space12: Story = {
+	...InlineTemplate,
+	args: {
+		space: 12,
+	},
+};
+
+export const Space14: Story = {
+	...InlineTemplate,
+	args: {
+		space: 14,
+	},
+};
+
+export const Space16: Story = {
+	...InlineTemplate,
+	args: {
+		space: 16,
+	},
+};
+
+export const Space18: Story = {
+	...InlineTemplate,
+	args: {
+		space: 18,
+	},
+};
+
+export const Space24: Story = {
+	...InlineTemplate,
+	args: {
+		space: 24,
+	},
+};
+
+export const MultipleChildElements: Story = {
+	...InlineTemplate,
+	render: (args) => (
+		<div css={wrapper}>
+			<Inline {...args}>
+				{Array.from({ length: 24 }, (_, i) => (
+					<div key={i} css={box}>
+						{i + 1}
+					</div>
+				))}
+			</Inline>
+		</div>
+	),
+	args: {
+		space: 2,
+	},
+};
+
+export const CollapseUntilTablet: Story = {
+	...InlineTemplate,
+	args: {
+		space: 2,
+		collapseUntil: 'tablet',
+	},
+	parameters: {
+		viewport: { defaultViewport: 'mobile' },
+		chromatic: {
+			viewports: [breakpoints.mobile],
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/inline/Inline.stories.tsx
+++ b/libs/@guardian/source/src/react-components/inline/Inline.stories.tsx
@@ -23,7 +23,7 @@ const box = css`
 	background: ${palette.news[600]};
 `;
 
-const InlineTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<div css={wrapper}>
 			<Inline {...args}>
@@ -40,116 +40,116 @@ const InlineTemplate: Story = {
 };
 
 export const NoSpace: Story = {
-	...InlineTemplate,
+	...Template,
 };
 
 export const Space0: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 0,
 	},
 };
 
 export const Space1: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 1,
 	},
 };
 
 export const Space2: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 2,
 	},
 };
 
 export const Space3: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 3,
 	},
 };
 
 export const Space4: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 4,
 	},
 };
 
 export const Space5: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 5,
 	},
 };
 
 export const Space6: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 6,
 	},
 };
 
 export const Space8: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 8,
 	},
 };
 
 export const Space9: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 9,
 	},
 };
 
 export const Space10: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 10,
 	},
 };
 
 export const Space12: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 12,
 	},
 };
 
 export const Space14: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 14,
 	},
 };
 
 export const Space16: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 16,
 	},
 };
 
 export const Space18: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 18,
 	},
 };
 
 export const Space24: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 24,
 	},
 };
 
 export const MultipleChildElements: Story = {
-	...InlineTemplate,
+	...Template,
 	render: (args) => (
 		<div css={wrapper}>
 			<Inline {...args}>
@@ -167,7 +167,7 @@ export const MultipleChildElements: Story = {
 };
 
 export const CollapseUntilTablet: Story = {
-	...InlineTemplate,
+	...Template,
 	args: {
 		space: 2,
 		collapseUntil: 'tablet',

--- a/libs/@guardian/source/src/react-components/inline/Inline.stories.tsx
+++ b/libs/@guardian/source/src/react-components/inline/Inline.stories.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { breakpoints, palette, space } from '../../foundations';
 import { Inline } from './Inline';
 

--- a/libs/@guardian/source/src/react-components/label/Label.stories.tsx
+++ b/libs/@guardian/source/src/react-components/label/Label.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { Label } from './Label';
 import { themeLabelBrand } from './theme';

--- a/libs/@guardian/source/src/react-components/label/Label.stories.tsx
+++ b/libs/@guardian/source/src/react-components/label/Label.stories.tsx
@@ -1,193 +1,188 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { palette } from '../../foundations';
-import type { LabelProps } from './@types/LabelProps';
 import { Label } from './Label';
 import { themeLabelBrand } from './theme';
 
 const meta: Meta<typeof Label> = {
 	title: 'React Components/Label',
+	component: Label,
+};
+
+export default meta;
+type Story = StoryObj<typeof Label>;
+
+const LabelTemplate: Story = {
+	render: (args) => (
+		<Label {...args}>
+			<input type="email" />
+		</Label>
+	),
+};
+
+export const DefaultDefaultTheme: Story = {
+	...LabelTemplate,
 	args: {
 		text: 'Email',
 		optional: false,
 		hideLabel: false,
 		size: 'medium',
 	},
-	component: Label,
 };
 
-export default meta;
-
-const Template: StoryFn<typeof Label> = (args: LabelProps) => (
-	<Label {...args}>
-		<input type="email" />
-	</Label>
-);
-
-// *****************************************************************************
-
-export const DefaultDefaultTheme: StoryFn<typeof Label> = Template.bind({});
-
-// *****************************************************************************
-
-export const WithSupportingTextDefaultTheme: StoryFn<typeof Label> =
-	Template.bind({});
-WithSupportingTextDefaultTheme.args = {
-	supporting: 'alex@example.com',
-};
-
-// *****************************************************************************
-
-export const WithOptionalDefaultTheme: StoryFn<typeof Label> = Template.bind(
-	{},
-);
-WithOptionalDefaultTheme.args = {
-	optional: true,
-};
-
-// *****************************************************************************
-
-export const WithHiddenLabelDefaultTheme: StoryFn<typeof Label> = Template.bind(
-	{},
-);
-WithHiddenLabelDefaultTheme.args = {
-	hideLabel: true,
-};
-
-// *****************************************************************************
-
-export const DefaultBrandTheme: StoryFn<typeof Label> = Template.bind({});
-DefaultBrandTheme.args = {
-	theme: themeLabelBrand,
-};
-DefaultBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const WithSupportingTextDefaultTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'alex@example.com',
 	},
 };
 
-// *****************************************************************************
-
-export const WithSupportingTextBrandTheme: StoryFn<typeof Label> =
-	Template.bind({});
-WithSupportingTextBrandTheme.args = {
-	supporting: 'alex@example.com',
-	theme: themeLabelBrand,
-};
-WithSupportingTextBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const WithOptionalDefaultTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		optional: true,
 	},
 };
 
-// *****************************************************************************
-
-export const WithOptionalBrandTheme: StoryFn<typeof Label> = Template.bind({});
-WithOptionalBrandTheme.args = {
-	optional: true,
-	theme: themeLabelBrand,
-};
-WithOptionalBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const WithHiddenLabelDefaultTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		hideLabel: true,
 	},
 };
 
-// *****************************************************************************
-
-export const WithHiddenLabelBrandTheme: StoryFn<typeof Label> = Template.bind(
-	{},
-);
-WithHiddenLabelBrandTheme.args = {
-	hideLabel: true,
-	theme: themeLabelBrand,
-};
-WithHiddenLabelBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const DefaultBrandTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		theme: themeLabelBrand,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
 	},
 };
 
-// *****************************************************************************
-
-export const DefaultSmallDefaultTheme: StoryFn<typeof Label> = Template.bind(
-	{},
-);
-DefaultSmallDefaultTheme.args = {
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const WithSupportingTextSmallDefaultTheme: StoryFn<typeof Label> =
-	Template.bind({});
-WithSupportingTextSmallDefaultTheme.args = {
-	supporting: 'alex@example.com',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const WithOptionalSmallDefaultTheme: StoryFn<typeof Label> =
-	Template.bind({});
-WithOptionalSmallDefaultTheme.args = {
-	optional: true,
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const DefaultSmallBrandTheme: StoryFn<typeof Label> = Template.bind({});
-DefaultSmallBrandTheme.args = {
-	size: 'small',
-	theme: themeLabelBrand,
-};
-DefaultSmallBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const WithSupportingTextBrandTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		supporting: 'alex@example.com',
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
 	},
 };
 
-// *****************************************************************************
-
-export const WithSupportingTextSmallBrandTheme: StoryFn<typeof Label> =
-	Template.bind({});
-WithSupportingTextSmallBrandTheme.args = {
-	supporting: 'alex@example.com',
-	size: 'small',
-	theme: themeLabelBrand,
-};
-WithSupportingTextSmallBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const WithOptionalBrandTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		optional: true,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
 	},
 };
 
-// *****************************************************************************
-
-export const WithOptionalSmallBrandTheme: StoryFn<typeof Label> = Template.bind(
-	{},
-);
-WithOptionalSmallBrandTheme.args = {
-	optional: true,
-	size: 'small',
-	theme: themeLabelBrand,
-};
-WithOptionalSmallBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const WithHiddenLabelBrandTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		hideLabel: true,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
 	},
 };
 
-// *****************************************************************************
-
-export const DefaultCustomTheme: StoryFn<typeof Label> = Template.bind({});
-DefaultCustomTheme.args = {
-	theme: {
-		textLabel: palette.neutral[86],
+export const DefaultSmallDefaultTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		size: 'small',
 	},
 };
-DefaultCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const WithSupportingTextSmallDefaultTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'alex@example.com',
+		size: 'small',
+	},
+};
+
+export const WithOptionalSmallDefaultTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		optional: true,
+		size: 'small',
+	},
+};
+
+export const DefaultSmallBrandTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		size: 'small',
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
+	},
+};
+
+export const WithSupportingTextSmallBrandTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		supporting: 'alex@example.com',
+		size: 'small',
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
+	},
+};
+
+export const WithOptionalSmallBrandTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		optional: true,
+		size: 'small',
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
+	},
+};
+
+export const DefaultCustomTheme: Story = {
+	...LabelTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		theme: {
+			textLabel: palette.neutral[86],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/label/Label.stories.tsx
+++ b/libs/@guardian/source/src/react-components/label/Label.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Label> = {
 export default meta;
 type Story = StoryObj<typeof Label>;
 
-const LabelTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<Label {...args}>
 			<input type="email" />
@@ -20,7 +20,7 @@ const LabelTemplate: Story = {
 };
 
 export const DefaultDefaultTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		text: 'Email',
 		optional: false,
@@ -30,7 +30,7 @@ export const DefaultDefaultTheme: Story = {
 };
 
 export const WithSupportingTextDefaultTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'alex@example.com',
@@ -38,7 +38,7 @@ export const WithSupportingTextDefaultTheme: Story = {
 };
 
 export const WithOptionalDefaultTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		optional: true,
@@ -46,7 +46,7 @@ export const WithOptionalDefaultTheme: Story = {
 };
 
 export const WithHiddenLabelDefaultTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		hideLabel: true,
@@ -54,7 +54,7 @@ export const WithHiddenLabelDefaultTheme: Story = {
 };
 
 export const DefaultBrandTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		theme: themeLabelBrand,
@@ -67,7 +67,7 @@ export const DefaultBrandTheme: Story = {
 };
 
 export const WithSupportingTextBrandTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		supporting: 'alex@example.com',
@@ -80,7 +80,7 @@ export const WithSupportingTextBrandTheme: Story = {
 };
 
 export const WithOptionalBrandTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		optional: true,
@@ -93,7 +93,7 @@ export const WithOptionalBrandTheme: Story = {
 };
 
 export const WithHiddenLabelBrandTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		hideLabel: true,
@@ -106,7 +106,7 @@ export const WithHiddenLabelBrandTheme: Story = {
 };
 
 export const DefaultSmallDefaultTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		size: 'small',
@@ -114,7 +114,7 @@ export const DefaultSmallDefaultTheme: Story = {
 };
 
 export const WithSupportingTextSmallDefaultTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'alex@example.com',
@@ -123,7 +123,7 @@ export const WithSupportingTextSmallDefaultTheme: Story = {
 };
 
 export const WithOptionalSmallDefaultTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		optional: true,
@@ -132,7 +132,7 @@ export const WithOptionalSmallDefaultTheme: Story = {
 };
 
 export const DefaultSmallBrandTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		size: 'small',
@@ -145,7 +145,7 @@ export const DefaultSmallBrandTheme: Story = {
 };
 
 export const WithSupportingTextSmallBrandTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		supporting: 'alex@example.com',
@@ -159,7 +159,7 @@ export const WithSupportingTextSmallBrandTheme: Story = {
 };
 
 export const WithOptionalSmallBrandTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		optional: true,
@@ -173,7 +173,7 @@ export const WithOptionalSmallBrandTheme: Story = {
 };
 
 export const DefaultCustomTheme: Story = {
-	...LabelTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		theme: {

--- a/libs/@guardian/source/src/react-components/label/Legend.stories.tsx
+++ b/libs/@guardian/source/src/react-components/label/Legend.stories.tsx
@@ -1,17 +1,11 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { palette } from '../../foundations';
-import type { LegendProps } from './@types/LegendProps';
 import { Legend } from './Legend';
-import { labelThemeBrand } from './theme';
+import { themeLabelBrand } from './theme';
 
 const meta: Meta<typeof Legend> = {
 	title: 'React Components/Legend',
-	args: {
-		text: 'Email',
-		supporting: 'undefined',
-		optional: false,
-		hideLabel: false,
-	},
+	component: Legend,
 	argTypes: {
 		supporting: {
 			options: ['undefined', 'text', 'component'],
@@ -27,132 +21,137 @@ const meta: Meta<typeof Legend> = {
 			control: { type: 'radio' },
 		},
 	},
-	component: Legend,
 };
 
 export default meta;
+type Story = StoryObj<typeof Legend>;
 
-const Template: StoryFn<typeof Legend> = (args: LegendProps) => (
-	<fieldset>
-		<Legend {...args} />
-	</fieldset>
-);
-
-// *****************************************************************************
-
-export const DefaultDefaultTheme: StoryFn<typeof Legend> = Template.bind({});
-
-// *****************************************************************************
-
-export const WithSupportingTextDefaultTheme: StoryFn<typeof Legend> =
-	Template.bind({});
-WithSupportingTextDefaultTheme.args = {
-	supporting: 'text',
+const LegendTemplate: Story = {
+	render: (args) => (
+		<fieldset>
+			<Legend {...args} />
+		</fieldset>
+	),
 };
 
-// *****************************************************************************
-
-export const WithSupportingComponentDefaultTheme: StoryFn<typeof Legend> =
-	Template.bind({});
-WithSupportingComponentDefaultTheme.args = {
-	supporting: 'component',
-};
-
-// *****************************************************************************
-
-export const WithOptionalDefaultTheme: StoryFn<typeof Legend> = Template.bind(
-	{},
-);
-WithOptionalDefaultTheme.args = {
-	optional: true,
-};
-
-// *****************************************************************************
-
-export const WithHiddenLabelDefaultTheme: StoryFn<typeof Legend> =
-	Template.bind({});
-WithHiddenLabelDefaultTheme.args = {
-	hideLabel: true,
-};
-
-// *****************************************************************************
-
-export const DefaultBrandTheme: StoryFn<typeof Legend> = Template.bind({});
-DefaultBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
-	},
-	theme: labelThemeBrand,
-};
-
-// *****************************************************************************
-
-export const WithSupportingTextBrandTheme: StoryFn<typeof Legend> =
-	Template.bind({});
-WithSupportingTextBrandTheme.args = {
-	supporting: 'text',
-};
-WithSupportingTextBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
-	},
-	theme: labelThemeBrand,
-};
-
-// *****************************************************************************
-
-export const WithSupportingComponentBrandTheme: StoryFn<typeof Legend> =
-	Template.bind({});
-WithSupportingComponentBrandTheme.args = {
-	supporting: 'component',
-};
-WithSupportingComponentBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
-	},
-	theme: labelThemeBrand,
-};
-
-// *****************************************************************************
-
-export const WithOptionalBrandTheme: StoryFn<typeof Legend> = Template.bind({});
-WithOptionalBrandTheme.args = {
-	optional: true,
-};
-WithOptionalBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
-	},
-	theme: labelThemeBrand,
-};
-
-// *****************************************************************************
-
-export const WithHiddenLabelBrandTheme: StoryFn<typeof Legend> = Template.bind(
-	{},
-);
-WithHiddenLabelBrandTheme.args = {
-	hideLabel: true,
-};
-WithHiddenLabelBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
-	},
-	theme: labelThemeBrand,
-};
-
-// *****************************************************************************
-
-export const DefaultCustomTheme: StoryFn<typeof Legend> = Template.bind({});
-DefaultCustomTheme.args = {
-	theme: {
-		textLabel: palette.neutral[86],
-	},
-};
-DefaultCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+export const DefaultDefaultTheme: Story = {
+	...LegendTemplate,
+	args: {
+		text: 'Email',
+		supporting: 'undefined',
+		optional: false,
+		hideLabel: false,
 	},
 };
 
-// *****************************************************************************
+export const WithSupportingTextDefaultTheme: Story = {
+	...LegendTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'text',
+	},
+};
+
+export const WithSupportingComponentDefaultTheme: Story = {
+	...LegendTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'component',
+	},
+};
+
+export const WithOptionalDefaultTheme: Story = {
+	...LegendTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		optional: true,
+	},
+};
+
+export const WithHiddenLabelDefaultTheme: Story = {
+	...LegendTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		hideLabel: true,
+	},
+};
+
+export const DefaultBrandTheme: Story = {
+	...LegendTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		theme: themeLabelBrand,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
+	},
+};
+
+export const WithSupportingTextBrandTheme: Story = {
+	...LegendTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		supporting: 'text',
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
+	},
+};
+
+export const WithSupportingComponentBrandTheme: Story = {
+	...LegendTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		supporting: 'component',
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
+	},
+};
+
+export const WithOptionalBrandTheme: Story = {
+	...LegendTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		optional: true,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
+	},
+};
+
+export const WithHiddenLabelBrandTheme: Story = {
+	...LegendTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		hideLabel: true,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
+	},
+};
+
+export const DefaultCustomTheme: Story = {
+	...LegendTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		theme: {
+			textLabel: palette.neutral[86],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
+	},
+};

--- a/libs/@guardian/source/src/react-components/label/Legend.stories.tsx
+++ b/libs/@guardian/source/src/react-components/label/Legend.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { Legend } from './Legend';
 import { themeLabelBrand } from './theme';

--- a/libs/@guardian/source/src/react-components/label/Legend.stories.tsx
+++ b/libs/@guardian/source/src/react-components/label/Legend.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<typeof Legend> = {
 export default meta;
 type Story = StoryObj<typeof Legend>;
 
-const LegendTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<fieldset>
 			<Legend {...args} />
@@ -35,7 +35,7 @@ const LegendTemplate: Story = {
 };
 
 export const DefaultDefaultTheme: Story = {
-	...LegendTemplate,
+	...Template,
 	args: {
 		text: 'Email',
 		supporting: 'undefined',
@@ -45,7 +45,7 @@ export const DefaultDefaultTheme: Story = {
 };
 
 export const WithSupportingTextDefaultTheme: Story = {
-	...LegendTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'text',
@@ -53,7 +53,7 @@ export const WithSupportingTextDefaultTheme: Story = {
 };
 
 export const WithSupportingComponentDefaultTheme: Story = {
-	...LegendTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'component',
@@ -61,7 +61,7 @@ export const WithSupportingComponentDefaultTheme: Story = {
 };
 
 export const WithOptionalDefaultTheme: Story = {
-	...LegendTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		optional: true,
@@ -69,7 +69,7 @@ export const WithOptionalDefaultTheme: Story = {
 };
 
 export const WithHiddenLabelDefaultTheme: Story = {
-	...LegendTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		hideLabel: true,
@@ -77,7 +77,7 @@ export const WithHiddenLabelDefaultTheme: Story = {
 };
 
 export const DefaultBrandTheme: Story = {
-	...LegendTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		theme: themeLabelBrand,
@@ -90,7 +90,7 @@ export const DefaultBrandTheme: Story = {
 };
 
 export const WithSupportingTextBrandTheme: Story = {
-	...LegendTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		supporting: 'text',
@@ -103,7 +103,7 @@ export const WithSupportingTextBrandTheme: Story = {
 };
 
 export const WithSupportingComponentBrandTheme: Story = {
-	...LegendTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		supporting: 'component',
@@ -116,7 +116,7 @@ export const WithSupportingComponentBrandTheme: Story = {
 };
 
 export const WithOptionalBrandTheme: Story = {
-	...LegendTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		optional: true,
@@ -129,7 +129,7 @@ export const WithOptionalBrandTheme: Story = {
 };
 
 export const WithHiddenLabelBrandTheme: Story = {
-	...LegendTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		hideLabel: true,
@@ -142,7 +142,7 @@ export const WithHiddenLabelBrandTheme: Story = {
 };
 
 export const DefaultCustomTheme: Story = {
-	...LegendTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		theme: {

--- a/libs/@guardian/source/src/react-components/link/ButtonLink.stories.tsx
+++ b/libs/@guardian/source/src/react-components/link/ButtonLink.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { SvgExternal } from '../__generated__/icons/SvgExternal';
 import { ButtonLink } from './ButtonLink';

--- a/libs/@guardian/source/src/react-components/link/ButtonLink.stories.tsx
+++ b/libs/@guardian/source/src/react-components/link/ButtonLink.stories.tsx
@@ -1,17 +1,11 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { palette } from '../../foundations';
 import { SvgExternal } from '../__generated__/icons/SvgExternal';
-import type { ButtonLinkProps } from './ButtonLink';
 import { ButtonLink } from './ButtonLink';
 
 const meta: Meta<typeof ButtonLink> = {
 	title: 'React Components/ButtonLink',
 	component: ButtonLink,
-	args: {
-		priority: 'primary',
-		icon: <SvgExternal />,
-		iconSide: 'left',
-	},
 	argTypes: {
 		icon: {
 			options: ['undefined', 'SvgExternal'],
@@ -25,59 +19,56 @@ const meta: Meta<typeof ButtonLink> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof ButtonLink>;
 
-const Template: StoryFn<typeof ButtonLink> = (args: ButtonLinkProps) => (
-	<ButtonLink {...args}>Return to home page</ButtonLink>
-);
-
-export const PrimaryButtonLinkDefaultTheme: StoryFn<typeof ButtonLink> =
-	Template.bind({});
-PrimaryButtonLinkDefaultTheme.args = {
-	icon: undefined,
-};
-
-// *****************************************************************************
-
-export const SecondaryButtonLinkDefaultTheme: StoryFn<typeof ButtonLink> =
-	Template.bind({});
-SecondaryButtonLinkDefaultTheme.args = {
-	priority: 'secondary',
-	icon: undefined,
-};
-
-// *****************************************************************************
-
-export const PrimaryIconButtonLinkDefaultTheme: StoryFn<typeof ButtonLink> =
-	Template.bind({});
-
-// *****************************************************************************
-
-export const SecondaryIconButtonLinkDefaultTheme: StoryFn<typeof ButtonLink> =
-	Template.bind({});
-SecondaryIconButtonLinkDefaultTheme.args = {
-	priority: 'secondary',
-};
-
-// *****************************************************************************
-
-export const RightIconButtonLinkDefaultTheme: StoryFn<typeof ButtonLink> =
-	Template.bind({});
-RightIconButtonLinkDefaultTheme.args = {
-	iconSide: 'right',
-};
-
-// *****************************************************************************
-
-export const PrimaryIconLinkCustomTheme: StoryFn<typeof ButtonLink> =
-	Template.bind({});
-PrimaryIconLinkCustomTheme.args = {
-	theme: {
-		textPrimary: palette.neutral[86],
-		textPrimaryHover: palette.brand[800],
+export const PrimaryButtonLinkDefaultTheme: Story = {
+	args: {
+		priority: 'primary',
+		icon: undefined,
+		iconSide: 'left',
+		children: 'Return to home page',
 	},
 };
-PrimaryIconLinkCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const SecondaryButtonLinkDefaultTheme: Story = {
+	args: {
+		...PrimaryButtonLinkDefaultTheme.args,
+		priority: 'secondary',
+	},
+};
+
+export const PrimaryIconButtonLinkDefaultTheme: Story = {
+	args: {
+		...PrimaryButtonLinkDefaultTheme.args,
+		icon: <SvgExternal />,
+	},
+};
+
+export const SecondaryIconButtonLinkDefaultTheme: Story = {
+	args: {
+		...PrimaryIconButtonLinkDefaultTheme.args,
+		priority: 'secondary',
+	},
+};
+
+export const RightIconButtonLinkDefaultTheme: Story = {
+	args: {
+		...PrimaryIconButtonLinkDefaultTheme.args,
+		iconSide: 'right',
+	},
+};
+
+export const PrimaryIconLinkCustomTheme: Story = {
+	args: {
+		...PrimaryIconButtonLinkDefaultTheme.args,
+		theme: {
+			textPrimary: palette.neutral[86],
+			textPrimaryHover: palette.brand[800],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/link/Link.stories.tsx
+++ b/libs/@guardian/source/src/react-components/link/Link.stories.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import {
 	headlineMedium14,
 	headlineMedium17,
@@ -21,18 +21,11 @@ import {
 } from '../../foundations';
 import { SvgExternal } from '../__generated__/icons/SvgExternal';
 import { Link } from './Link';
-import type { LinkProps } from './Link';
 import { themeLinkBrand, themeLinkBrandAlt } from './theme';
 
 const meta: Meta<typeof Link> = {
 	title: 'React Components/Link',
 	component: Link,
-	args: {
-		priority: 'primary',
-		icon: <SvgExternal />,
-		iconSide: 'left',
-		href: '#',
-	},
 	argTypes: {
 		icon: {
 			options: ['undefined', 'SvgExternal'],
@@ -46,6 +39,7 @@ const meta: Meta<typeof Link> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof Link>;
 
 const textSans = [
 	textSans34,
@@ -69,21 +63,16 @@ const headline = [
 	headlineMedium14,
 ];
 
-const Template: StoryFn<typeof Link> = (args: LinkProps) => (
-	<Link {...args}>Return to home page</Link>
-);
+const LinkTemplate: Story = {
+	render: (args) => <Link {...args}>Return to home page</Link>,
+};
 
-const UnderlineHoverHeadlineTemplate: StoryFn<typeof Link> = (
-	args: LinkProps,
-) => {
-	const headlineText = 'This is a guardian help link';
-
-	return (
+const UnderlineHoverHeadlineTemplate: Story = {
+	render: (args) => (
 		<div
 			css={css`
 				display: flex;
 				flex-direction: column;
-
 				a {
 					padding: 20px 0;
 				}
@@ -97,24 +86,19 @@ const UnderlineHoverHeadlineTemplate: StoryFn<typeof Link> = (
 						${preset}
 					`}
 				>
-					{headlineText}
+					This is a guardian help link
 				</Link>
 			))}
 		</div>
-	);
+	),
 };
 
-const UnderlineHoverTextSansTemplate: StoryFn<typeof Link> = (
-	args: LinkProps,
-) => {
-	const headlineText = 'link';
-
-	return (
+const UnderlineHoverTextSansTemplate: Story = {
+	render: (args) => (
 		<div
 			css={css`
 				display: flex;
 				flex-direction: column;
-
 				a {
 					padding: 20px 0;
 				}
@@ -135,110 +119,109 @@ const UnderlineHoverTextSansTemplate: StoryFn<typeof Link> = (
 							${preset}
 						`}
 					>
-						{headlineText}
+						link
 					</Link>{' '}
 					in the middle of it
 				</div>
 			))}
 		</div>
-	);
+	),
 };
 
-export const PrimaryLinkDefaultTheme: StoryFn<typeof Link> = Template.bind({});
-PrimaryLinkDefaultTheme.args = {
-	icon: undefined,
-};
-
-// *****************************************************************************
-
-export const PrimaryLinkBrandTheme: StoryFn<typeof Link> = Template.bind({});
-PrimaryLinkBrandTheme.args = {
-	icon: undefined,
-	theme: themeLinkBrand,
-};
-PrimaryLinkBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const PrimaryLinkDefaultTheme: Story = {
+	...LinkTemplate,
+	args: {
+		priority: 'primary',
+		icon: undefined,
+		iconSide: 'left',
+		href: '#',
 	},
 };
 
-// *****************************************************************************
-
-export const PrimaryLinkBrandAltTheme: StoryFn<typeof Link> = Template.bind({});
-PrimaryLinkBrandAltTheme.args = {
-	icon: undefined,
-	theme: themeLinkBrandAlt,
-};
-PrimaryLinkBrandAltTheme.parameters = {
-	backgrounds: {
-		default: 'brandAltBackground.primary',
+export const PrimaryLinkBrandTheme: Story = {
+	...LinkTemplate,
+	args: {
+		...PrimaryLinkDefaultTheme.args,
+		theme: themeLinkBrand,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
 	},
 };
 
-// *****************************************************************************
-
-export const SecondaryLinkDefaultTheme: StoryFn<typeof Link> = Template.bind(
-	{},
-);
-SecondaryLinkDefaultTheme.args = {
-	priority: 'secondary',
-	icon: undefined,
-};
-
-// *****************************************************************************
-
-export const PrimaryIconLinkDefaultTheme: StoryFn<typeof Link> = Template.bind(
-	{},
-);
-
-// *****************************************************************************
-
-export const SecondaryIconLinkDefaultTheme: StoryFn<typeof Link> =
-	Template.bind({});
-SecondaryIconLinkDefaultTheme.args = {
-	priority: 'secondary',
-};
-
-// *****************************************************************************
-
-export const RightIconLinkDefaultTheme: StoryFn<typeof Link> = Template.bind(
-	{},
-);
-RightIconLinkDefaultTheme.args = {
-	iconSide: 'right',
-};
-
-// *****************************************************************************
-
-export const UnderlineHoverHeadline: StoryFn<typeof Link> =
-	UnderlineHoverHeadlineTemplate.bind({});
-
-UnderlineHoverHeadline.args = {
-	icon: undefined,
-};
-
-// *****************************************************************************
-
-export const UnderlineHoverTextSans: StoryFn<typeof Link> =
-	UnderlineHoverTextSansTemplate.bind({});
-
-UnderlineHoverTextSans.args = {
-	icon: undefined,
-};
-
-// *****************************************************************************
-
-export const PrimaryIconLinkCustomTheme: StoryFn<typeof Link> = Template.bind(
-	{},
-);
-PrimaryIconLinkCustomTheme.args = {
-	theme: {
-		textPrimary: palette.neutral[86],
-		textPrimaryHover: palette.brand[800],
+export const PrimaryLinkBrandAltTheme: Story = {
+	...LinkTemplate,
+	args: {
+		...PrimaryLinkDefaultTheme.args,
+		theme: themeLinkBrandAlt,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandAltBackground.primary',
+		},
 	},
 };
-PrimaryIconLinkCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const SecondaryLinkDefaultTheme: Story = {
+	...LinkTemplate,
+	args: {
+		...PrimaryLinkDefaultTheme.args,
+		priority: 'secondary',
+	},
+};
+
+export const PrimaryIconLinkDefaultTheme: Story = {
+	...LinkTemplate,
+	args: {
+		...PrimaryLinkDefaultTheme.args,
+		icon: <SvgExternal />,
+	},
+};
+
+export const SecondaryIconLinkDefaultTheme: Story = {
+	...LinkTemplate,
+	args: {
+		...PrimaryIconLinkDefaultTheme.args,
+		priority: 'secondary',
+	},
+};
+
+export const RightIconLinkDefaultTheme: Story = {
+	...LinkTemplate,
+	args: {
+		...PrimaryIconLinkDefaultTheme.args,
+		iconSide: 'right',
+	},
+};
+
+export const UnderlineHoverHeadline: Story = {
+	...UnderlineHoverHeadlineTemplate,
+	args: {
+		...PrimaryLinkDefaultTheme.args,
+	},
+};
+
+export const UnderlineHoverTextSans: Story = {
+	...UnderlineHoverTextSansTemplate,
+	args: {
+		...PrimaryLinkDefaultTheme.args,
+	},
+};
+
+export const PrimaryIconLinkCustomTheme: Story = {
+	...LinkTemplate,
+	args: {
+		...PrimaryIconLinkDefaultTheme.args,
+		theme: {
+			textPrimary: palette.neutral[86],
+			textPrimaryHover: palette.brand[800],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/link/Link.stories.tsx
+++ b/libs/@guardian/source/src/react-components/link/Link.stories.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import {
 	headlineMedium14,
 	headlineMedium17,

--- a/libs/@guardian/source/src/react-components/link/Link.stories.tsx
+++ b/libs/@guardian/source/src/react-components/link/Link.stories.tsx
@@ -63,11 +63,84 @@ const headline = [
 	headlineMedium14,
 ];
 
-const LinkTemplate: Story = {
-	render: (args) => <Link {...args}>Return to home page</Link>,
+export const PrimaryLinkDefaultTheme: Story = {
+	args: {
+		priority: 'primary',
+		icon: undefined,
+		iconSide: 'left',
+		href: '#',
+		children: 'Return to home page',
+	},
 };
 
-const UnderlineHoverHeadlineTemplate: Story = {
+export const PrimaryLinkBrandTheme: Story = {
+	args: {
+		...PrimaryLinkDefaultTheme.args,
+		theme: themeLinkBrand,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
+	},
+};
+
+export const PrimaryLinkBrandAltTheme: Story = {
+	args: {
+		...PrimaryLinkDefaultTheme.args,
+		theme: themeLinkBrandAlt,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandAltBackground.primary',
+		},
+	},
+};
+
+export const SecondaryLinkDefaultTheme: Story = {
+	args: {
+		...PrimaryLinkDefaultTheme.args,
+		priority: 'secondary',
+	},
+};
+
+export const PrimaryIconLinkDefaultTheme: Story = {
+	args: {
+		...PrimaryLinkDefaultTheme.args,
+		icon: <SvgExternal />,
+	},
+};
+
+export const SecondaryIconLinkDefaultTheme: Story = {
+	args: {
+		...PrimaryIconLinkDefaultTheme.args,
+		priority: 'secondary',
+	},
+};
+
+export const RightIconLinkDefaultTheme: Story = {
+	args: {
+		...PrimaryIconLinkDefaultTheme.args,
+		iconSide: 'right',
+	},
+};
+
+export const PrimaryIconLinkCustomTheme: Story = {
+	args: {
+		...PrimaryIconLinkDefaultTheme.args,
+		theme: {
+			textPrimary: palette.neutral[86],
+			textPrimaryHover: palette.brand[800],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
+	},
+};
+
+export const UnderlineHoverHeadline: Story = {
 	render: (args) => (
 		<div
 			css={css`
@@ -91,17 +164,17 @@ const UnderlineHoverHeadlineTemplate: Story = {
 			))}
 		</div>
 	),
+	args: {
+		...PrimaryLinkDefaultTheme.args,
+	},
 };
 
-const UnderlineHoverTextSansTemplate: Story = {
+export const UnderlineHoverTextSans: Story = {
 	render: (args) => (
 		<div
 			css={css`
 				display: flex;
 				flex-direction: column;
-				a {
-					padding: 20px 0;
-				}
 			`}
 		>
 			{textSans.map((preset, i) => (
@@ -126,102 +199,7 @@ const UnderlineHoverTextSansTemplate: Story = {
 			))}
 		</div>
 	),
-};
-
-export const PrimaryLinkDefaultTheme: Story = {
-	...LinkTemplate,
-	args: {
-		priority: 'primary',
-		icon: undefined,
-		iconSide: 'left',
-		href: '#',
-	},
-};
-
-export const PrimaryLinkBrandTheme: Story = {
-	...LinkTemplate,
 	args: {
 		...PrimaryLinkDefaultTheme.args,
-		theme: themeLinkBrand,
-	},
-	parameters: {
-		backgrounds: {
-			default: 'brandBackground.primary',
-		},
-	},
-};
-
-export const PrimaryLinkBrandAltTheme: Story = {
-	...LinkTemplate,
-	args: {
-		...PrimaryLinkDefaultTheme.args,
-		theme: themeLinkBrandAlt,
-	},
-	parameters: {
-		backgrounds: {
-			default: 'brandAltBackground.primary',
-		},
-	},
-};
-
-export const SecondaryLinkDefaultTheme: Story = {
-	...LinkTemplate,
-	args: {
-		...PrimaryLinkDefaultTheme.args,
-		priority: 'secondary',
-	},
-};
-
-export const PrimaryIconLinkDefaultTheme: Story = {
-	...LinkTemplate,
-	args: {
-		...PrimaryLinkDefaultTheme.args,
-		icon: <SvgExternal />,
-	},
-};
-
-export const SecondaryIconLinkDefaultTheme: Story = {
-	...LinkTemplate,
-	args: {
-		...PrimaryIconLinkDefaultTheme.args,
-		priority: 'secondary',
-	},
-};
-
-export const RightIconLinkDefaultTheme: Story = {
-	...LinkTemplate,
-	args: {
-		...PrimaryIconLinkDefaultTheme.args,
-		iconSide: 'right',
-	},
-};
-
-export const UnderlineHoverHeadline: Story = {
-	...UnderlineHoverHeadlineTemplate,
-	args: {
-		...PrimaryLinkDefaultTheme.args,
-	},
-};
-
-export const UnderlineHoverTextSans: Story = {
-	...UnderlineHoverTextSansTemplate,
-	args: {
-		...PrimaryLinkDefaultTheme.args,
-	},
-};
-
-export const PrimaryIconLinkCustomTheme: Story = {
-	...LinkTemplate,
-	args: {
-		...PrimaryIconLinkDefaultTheme.args,
-		theme: {
-			textPrimary: palette.neutral[86],
-			textPrimaryHover: palette.brand[800],
-		},
-	},
-	parameters: {
-		backgrounds: {
-			default: 'background.inverse',
-		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/radio/Radio.stories.tsx
+++ b/libs/@guardian/source/src/react-components/radio/Radio.stories.tsx
@@ -1,7 +1,6 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { palette } from '../../foundations';
 import { Radio } from './Radio';
-import type { RadioProps } from './Radio';
 import { themeRadioBrand } from './theme';
 
 const meta: Meta<typeof Radio> = {
@@ -20,6 +19,12 @@ const meta: Meta<typeof Radio> = {
 		},
 		cssOverrides: { control: { disable: true } },
 	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Radio>;
+
+export const DefaultDefaultTheme: Story = {
 	args: {
 		label: 'Red',
 		value: 'red',
@@ -28,96 +33,76 @@ const meta: Meta<typeof Radio> = {
 	},
 };
 
-export default meta;
-
-const Template: StoryFn<typeof Radio> = (args: RadioProps) => (
-	<Radio {...args} />
-);
-
-export const DefaultDefaultTheme: StoryFn<typeof Radio> = Template.bind({});
-
-// *****************************************************************************
-
-export const DefaultBrandTheme: StoryFn<typeof Radio> = Template.bind({});
-DefaultBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const DefaultBrandTheme: Story = {
+	args: {
+		...DefaultDefaultTheme.args,
+		theme: themeRadioBrand,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
 	},
 };
-DefaultBrandTheme.args = {
-	theme: themeRadioBrand,
-};
 
-// *****************************************************************************
-
-export const SupportingTextDefaultTheme: StoryFn<typeof Radio> = Template.bind(
-	{},
-);
-SupportingTextDefaultTheme.args = {
-	supporting: 'Hex colour code: #ff0000',
-};
-
-// *****************************************************************************
-
-export const SupportingTextBrandTheme: StoryFn<typeof Radio> = Template.bind(
-	{},
-);
-SupportingTextBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const SupportingTextDefaultTheme: Story = {
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'Hex colour code: #ff0000',
 	},
 };
-SupportingTextBrandTheme.args = {
-	supporting: 'Hex colour code: #ff0000',
-	theme: themeRadioBrand,
-};
 
-// *****************************************************************************
-
-export const SupportingTextOnlyDefaultTheme: StoryFn<typeof Radio> =
-	Template.bind({});
-SupportingTextOnlyDefaultTheme.args = {
-	supporting: 'Hex colour code: #ff0000',
-	label: null,
-};
-
-// *****************************************************************************
-
-export const SupportingTextOnlyBrandTheme: StoryFn<typeof Radio> =
-	Template.bind({});
-SupportingTextOnlyBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const SupportingTextBrandTheme: Story = {
+	args: {
+		...DefaultBrandTheme.args,
+		supporting: 'Hex colour code: #ff0000',
+	},
+	parameters: {
+		...DefaultBrandTheme.parameters,
 	},
 };
-SupportingTextOnlyBrandTheme.args = {
-	supporting: 'Hex colour code: #ff0000',
-	label: null,
-	theme: themeRadioBrand,
-};
 
-// *****************************************************************************
-
-export const UnlabelledDefaultTheme: StoryFn<typeof Radio> = Template.bind({});
-UnlabelledDefaultTheme.args = {
-	label: undefined,
-};
-
-// *****************************************************************************
-
-export const DefaultCustomTheme: StoryFn<typeof Radio> = Template.bind({});
-DefaultCustomTheme.args = {
-	theme: {
-		fillSelected: palette.brand[800],
-		fillUnselected: palette.neutral[20],
-		borderSelected: palette.brand[800],
-		borderUnselected: palette.neutral[60],
-		borderHover: palette.brand[800],
-		textLabel: palette.neutral[86],
+export const SupportingTextOnlyDefaultTheme: Story = {
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'Hex colour code: #ff0000',
+		label: null,
 	},
 };
-DefaultCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const SupportingTextOnlyBrandTheme: Story = {
+	args: {
+		...DefaultBrandTheme.args,
+		supporting: 'Hex colour code: #ff0000',
+		label: null,
+	},
+	parameters: {
+		...DefaultBrandTheme.parameters,
+	},
+};
+
+export const UnlabelledDefaultTheme: Story = {
+	args: {
+		...DefaultDefaultTheme.args,
+		label: undefined,
+	},
+};
+
+export const DefaultCustomTheme: Story = {
+	args: {
+		...DefaultDefaultTheme.args,
+		theme: {
+			fillSelected: palette.brand[800],
+			fillUnselected: palette.neutral[20],
+			borderSelected: palette.brand[800],
+			borderUnselected: palette.neutral[60],
+			borderHover: palette.brand[800],
+			textLabel: palette.neutral[86],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/radio/Radio.stories.tsx
+++ b/libs/@guardian/source/src/react-components/radio/Radio.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { Radio } from './Radio';
 import { themeRadioBrand } from './theme';

--- a/libs/@guardian/source/src/react-components/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source/src/react-components/radio/RadioGroup.stories.tsx
@@ -1,7 +1,7 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { palette } from '../../foundations';
 import { Radio } from './Radio';
-import RadioStories from './Radio.stories';
+import { DefaultDefaultTheme as RadioDefault } from './Radio.stories';
 import { RadioGroup } from './RadioGroup';
 import type { ThemeRadio } from './theme';
 import { themeRadioBrand, themeRadioGroupBrand } from './theme';
@@ -9,14 +9,6 @@ import { themeRadioBrand, themeRadioGroupBrand } from './theme';
 const meta: Meta<typeof RadioGroup> = {
 	title: 'React Components/RadioGroup',
 	component: RadioGroup,
-	args: {
-		name: 'colours',
-		label: 'Select your preferred colour',
-		supporting: '',
-		hideLabel: false,
-		orientation: 'vertical',
-		error: '',
-	},
 	argTypes: {
 		// Override the control so that users can try entering a string in the Storybook canvas
 		supporting: {
@@ -31,6 +23,11 @@ const meta: Meta<typeof RadioGroup> = {
 };
 
 export default meta;
+type Story = StoryObj<
+	React.ComponentProps<typeof RadioGroup> & {
+		themeChild?: Partial<ThemeRadio>;
+	}
+>;
 
 const Image = () => (
 	<img
@@ -40,132 +37,129 @@ const Image = () => (
 	/>
 );
 
-type RadioGroupPropsAndChildTheme = React.ComponentProps<typeof RadioGroup> & {
-	themeChild?: Partial<ThemeRadio>;
+const RadioGroupTemplate: Story = {
+	render: (args) => (
+		<RadioGroup {...args}>
+			<Radio {...RadioDefault.args} theme={args.themeChild} key="radio-1" />
+			<Radio label="Blue" value="blue" theme={args.themeChild} key="radio-2" />
+		</RadioGroup>
+	),
 };
 
-const Template: StoryFn<RadioGroupPropsAndChildTheme> = (
-	args: RadioGroupPropsAndChildTheme,
-) => (
-	<RadioGroup {...args}>
-		<Radio {...RadioStories.args} theme={args.themeChild} key="radio-1" />
-		<Radio label="Blue" value="blue" theme={args.themeChild} key="radio-2" />
-	</RadioGroup>
-);
-
-export const DefaultDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
-	Template.bind({});
-
-// *****************************************************************************
-
-export const DefaultBrandTheme: StoryFn<RadioGroupPropsAndChildTheme> =
-	Template.bind({});
-DefaultBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
-	},
-};
-DefaultBrandTheme.args = {
-	theme: themeRadioGroupBrand,
-	themeChild: themeRadioBrand,
-};
-
-// *****************************************************************************
-
-export const HorizontalDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
-	Template.bind({});
-HorizontalDefaultTheme.args = {
-	orientation: 'horizontal',
-};
-
-// *****************************************************************************
-
-export const VisuallyHideLegendDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
-	Template.bind({});
-VisuallyHideLegendDefaultTheme.args = {
-	hideLabel: true,
-};
-
-// *****************************************************************************
-
-export const SupportingTextDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
-	Template.bind({});
-SupportingTextDefaultTheme.args = {
-	supporting: 'You can always change it later',
-};
-
-// *****************************************************************************
-
-export const SupportingTextBrandTheme: StoryFn<RadioGroupPropsAndChildTheme> =
-	Template.bind({});
-SupportingTextBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
-	},
-};
-SupportingTextBrandTheme.args = {
-	supporting: 'You can always change it later',
-	theme: themeRadioGroupBrand,
-	themeChild: themeRadioBrand,
-};
-
-// *****************************************************************************
-
-export const SupportingMediaDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
-	Template.bind({});
-SupportingMediaDefaultTheme.args = {
-	supporting: <Image />,
-};
-
-// *****************************************************************************
-
-export const ErrorDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
-	Template.bind({});
-ErrorDefaultTheme.args = {
-	error: 'The selected colour is out of stock',
-};
-
-// *****************************************************************************
-
-export const ErrorBrandTheme: StoryFn<RadioGroupPropsAndChildTheme> =
-	Template.bind({});
-ErrorBrandTheme.args = {
-	error: 'The selected colour is out of stock',
-	theme: themeRadioGroupBrand,
-	themeChild: themeRadioBrand,
-};
-ErrorBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const DefaultDefaultTheme: Story = {
+	...RadioGroupTemplate,
+	args: {
+		name: 'colours',
+		label: 'Select your preferred colour',
+		supporting: '',
+		hideLabel: false,
+		orientation: 'vertical',
+		error: '',
 	},
 };
 
-// *****************************************************************************
-
-export const SupportingMediaWithErrorDefaultTheme: StoryFn<RadioGroupPropsAndChildTheme> =
-	Template.bind({});
-SupportingMediaWithErrorDefaultTheme.args = {
-	error: 'Please select a colour',
-	supporting: <Image />,
-};
-
-// *****************************************************************************
-
-export const DefaultCustomTheme: StoryFn<RadioGroupPropsAndChildTheme> =
-	Template.bind({});
-DefaultCustomTheme.args = {
-	theme: { textLabel: palette.neutral[86] },
-	themeChild: {
-		fillSelected: palette.brand[800],
-		fillUnselected: palette.neutral[20],
-		borderSelected: palette.brand[800],
-		borderUnselected: palette.neutral[60],
-		borderHover: palette.brand[800],
-		textLabel: palette.neutral[86],
+export const DefaultBrandTheme: Story = {
+	...RadioGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		theme: themeRadioGroupBrand,
+		themeChild: themeRadioBrand,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
 	},
 };
-DefaultCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const HorizontalDefaultTheme: Story = {
+	...RadioGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		orientation: 'horizontal',
+	},
+};
+
+export const VisuallyHideLegendDefaultTheme: Story = {
+	...RadioGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		hideLabel: true,
+	},
+};
+
+export const SupportingTextDefaultTheme: Story = {
+	...RadioGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'You can always change it later',
+	},
+};
+
+export const SupportingTextBrandTheme: Story = {
+	...RadioGroupTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		supporting: 'You can always change it later',
+	},
+	parameters: {
+		...DefaultBrandTheme.parameters,
+	},
+};
+
+export const SupportingMediaDefaultTheme: Story = {
+	...RadioGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: <Image />,
+	},
+};
+
+export const ErrorDefaultTheme: Story = {
+	...RadioGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'The selected colour is out of stock',
+	},
+};
+
+export const ErrorBrandTheme: Story = {
+	...RadioGroupTemplate,
+	args: {
+		...DefaultBrandTheme.args,
+		error: 'The selected colour is out of stock',
+	},
+	parameters: {
+		...DefaultBrandTheme.parameters,
+	},
+};
+
+export const SupportingMediaWithErrorDefaultTheme: Story = {
+	...RadioGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'Please select a colour',
+		supporting: <Image />,
+	},
+};
+
+export const DefaultCustomTheme: Story = {
+	...RadioGroupTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		theme: { textLabel: palette.neutral[86] },
+		themeChild: {
+			fillSelected: palette.brand[800],
+			fillUnselected: palette.neutral[20],
+			borderSelected: palette.brand[800],
+			borderUnselected: palette.neutral[60],
+			borderHover: palette.brand[800],
+			textLabel: palette.neutral[86],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source/src/react-components/radio/RadioGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { Radio } from './Radio';
 import { DefaultDefaultTheme as RadioDefault } from './Radio.stories';

--- a/libs/@guardian/source/src/react-components/radio/RadioGroup.stories.tsx
+++ b/libs/@guardian/source/src/react-components/radio/RadioGroup.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { Radio } from './Radio';
-import { DefaultDefaultTheme as RadioDefault } from './Radio.stories';
+import * as RadioStories from './Radio.stories';
 import { RadioGroup } from './RadioGroup';
 import type { ThemeRadio } from './theme';
 import { themeRadioBrand, themeRadioGroupBrand } from './theme';
@@ -37,17 +37,21 @@ const Image = () => (
 	/>
 );
 
-const RadioGroupTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<RadioGroup {...args}>
-			<Radio {...RadioDefault.args} theme={args.themeChild} key="radio-1" />
+			<Radio
+				{...RadioStories.DefaultDefaultTheme.args}
+				theme={args.themeChild}
+				key="radio-1"
+			/>
 			<Radio label="Blue" value="blue" theme={args.themeChild} key="radio-2" />
 		</RadioGroup>
 	),
 };
 
 export const DefaultDefaultTheme: Story = {
-	...RadioGroupTemplate,
+	...Template,
 	args: {
 		name: 'colours',
 		label: 'Select your preferred colour',
@@ -59,7 +63,7 @@ export const DefaultDefaultTheme: Story = {
 };
 
 export const DefaultBrandTheme: Story = {
-	...RadioGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		theme: themeRadioGroupBrand,
@@ -73,7 +77,7 @@ export const DefaultBrandTheme: Story = {
 };
 
 export const HorizontalDefaultTheme: Story = {
-	...RadioGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		orientation: 'horizontal',
@@ -81,7 +85,7 @@ export const HorizontalDefaultTheme: Story = {
 };
 
 export const VisuallyHideLegendDefaultTheme: Story = {
-	...RadioGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		hideLabel: true,
@@ -89,7 +93,7 @@ export const VisuallyHideLegendDefaultTheme: Story = {
 };
 
 export const SupportingTextDefaultTheme: Story = {
-	...RadioGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'You can always change it later',
@@ -97,7 +101,7 @@ export const SupportingTextDefaultTheme: Story = {
 };
 
 export const SupportingTextBrandTheme: Story = {
-	...RadioGroupTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		supporting: 'You can always change it later',
@@ -108,7 +112,7 @@ export const SupportingTextBrandTheme: Story = {
 };
 
 export const SupportingMediaDefaultTheme: Story = {
-	...RadioGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: <Image />,
@@ -116,7 +120,7 @@ export const SupportingMediaDefaultTheme: Story = {
 };
 
 export const ErrorDefaultTheme: Story = {
-	...RadioGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'The selected colour is out of stock',
@@ -124,7 +128,7 @@ export const ErrorDefaultTheme: Story = {
 };
 
 export const ErrorBrandTheme: Story = {
-	...RadioGroupTemplate,
+	...Template,
 	args: {
 		...DefaultBrandTheme.args,
 		error: 'The selected colour is out of stock',
@@ -135,7 +139,7 @@ export const ErrorBrandTheme: Story = {
 };
 
 export const SupportingMediaWithErrorDefaultTheme: Story = {
-	...RadioGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'Please select a colour',
@@ -144,7 +148,7 @@ export const SupportingMediaWithErrorDefaultTheme: Story = {
 };
 
 export const DefaultCustomTheme: Story = {
-	...RadioGroupTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		theme: { textLabel: palette.neutral[86] },

--- a/libs/@guardian/source/src/react-components/select/Select.stories.tsx
+++ b/libs/@guardian/source/src/react-components/select/Select.stories.tsx
@@ -1,7 +1,6 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { palette } from '../../foundations';
 import { Option } from './Option';
-import type { SelectProps } from './Select';
 import { Select } from './Select';
 
 const meta: Meta<typeof Select> = {
@@ -26,6 +25,23 @@ const meta: Meta<typeof Select> = {
 			control: { type: 'radio' },
 		},
 	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+const SelectTemplate: Story = {
+	render: (args) => (
+		<Select {...args}>
+			<Option value="">Select a state</Option>
+			<Option value="al">Alabama</Option>
+			<Option value="ca">California</Option>
+		</Select>
+	),
+};
+
+export const DefaultDefaultTheme: Story = {
+	...SelectTemplate,
 	args: {
 		label: 'State',
 		optional: false,
@@ -36,118 +52,102 @@ const meta: Meta<typeof Select> = {
 	},
 };
 
-export default meta;
-
-const Template: StoryFn<typeof Select> = (args: SelectProps) => (
-	<Select {...args}>
-		<Option value="">Select a state</Option>
-		<Option value="al">Alabama</Option>
-		<Option value="ca">California</Option>
-	</Select>
-);
-
-// *****************************************************************************
-
-export const DefaultDefaultTheme: StoryFn<typeof Select> = Template.bind({});
-
-// *****************************************************************************
-
-export const VisuallyHideLabelDefaultTheme: StoryFn<typeof Select> =
-	Template.bind({});
-VisuallyHideLabelDefaultTheme.args = {
-	hideLabel: true,
-};
-
-// *****************************************************************************
-
-export const OptionalDefaultTheme: StoryFn<typeof Select> = Template.bind({});
-OptionalDefaultTheme.args = {
-	optional: true,
-};
-
-// *****************************************************************************
-
-export const ErrorWithMessageDefaultTheme: StoryFn<typeof Select> =
-	Template.bind({});
-ErrorWithMessageDefaultTheme.args = {
-	error: 'error',
-};
-
-// *****************************************************************************
-
-export const SuccessWithMessageDefaultTheme: StoryFn<typeof Select> =
-	Template.bind({});
-SuccessWithMessageDefaultTheme.args = {
-	success: 'success',
-};
-
-// *****************************************************************************
-
-export const SupportingTextDefaultTheme: StoryFn<typeof Select> = Template.bind(
-	{},
-);
-SupportingTextDefaultTheme.args = {
-	supporting: 'Leave blank if you are not within the US',
-};
-
-// *****************************************************************************
-
-export const SupportingSuccessTextDefaultTheme: StoryFn<typeof Select> =
-	Template.bind({});
-SupportingSuccessTextDefaultTheme.args = {
-	supporting: 'Leave blank if you are not within the US',
-
-	success: 'success',
-};
-
-// *****************************************************************************
-
-export const SupportingErrorTextDefaultTheme: StoryFn<typeof Select> =
-	Template.bind({});
-SupportingErrorTextDefaultTheme.args = {
-	supporting: 'Leave blank if you are not within the US',
-	error:
-		'Please select your home state. This service is unavailable outside of the US.',
-};
-
-// *****************************************************************************
-
-export const SupportingTextCustomTheme: StoryFn<typeof Select> = Template.bind(
-	{},
-);
-SupportingTextCustomTheme.args = {
-	supporting: 'Leave blank if you are not within the US',
-	theme: {
-		textLabel: palette.neutral[86],
-		textSupporting: palette.neutral[60],
-		textUserInput: palette.neutral[86],
-		iconFill: palette.neutral[86],
-		border: palette.neutral[60],
-		backgroundInput: palette.neutral[20],
-	},
-};
-SupportingTextCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+export const VisuallyHideLabelDefaultTheme: Story = {
+	...SelectTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		hideLabel: true,
 	},
 };
 
-// *****************************************************************************
-
-export const ErrorWithMessageCustomTheme: StoryFn<typeof Select> =
-	Template.bind({});
-ErrorWithMessageCustomTheme.args = {
-	error: 'error',
-	theme: {
-		textLabel: palette.neutral[86],
-		textError: palette.error[500],
-		iconFill: palette.error[500],
-		borderError: palette.error[500],
-		backgroundInput: palette.neutral[20],
+export const OptionalDefaultTheme: Story = {
+	...SelectTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		optional: true,
 	},
 };
-ErrorWithMessageCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const ErrorWithMessageDefaultTheme: Story = {
+	...SelectTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'error',
+	},
+};
+
+export const SuccessWithMessageDefaultTheme: Story = {
+	...SelectTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		success: 'success',
+	},
+};
+
+export const SupportingTextDefaultTheme: Story = {
+	...SelectTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'Leave blank if you are not within the US',
+	},
+};
+
+export const SupportingSuccessTextDefaultTheme: Story = {
+	...SelectTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'Leave blank if you are not within the US',
+		success: 'success',
+	},
+};
+
+export const SupportingErrorTextDefaultTheme: Story = {
+	...SelectTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'Leave blank if you are not within the US',
+		error:
+			'Please select your home state. This service is unavailable outside of the US.',
+	},
+};
+
+export const SupportingTextCustomTheme: Story = {
+	...SelectTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'Leave blank if you are not within the US',
+		theme: {
+			textLabel: palette.neutral[86],
+			textSupporting: palette.neutral[60],
+			textUserInput: palette.neutral[86],
+			iconFill: palette.neutral[86],
+			border: palette.neutral[60],
+			backgroundInput: palette.neutral[20],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
+	},
+};
+
+export const ErrorWithMessageCustomTheme: Story = {
+	...SelectTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'error',
+		theme: {
+			textLabel: palette.neutral[86],
+			textError: palette.error[500],
+			iconFill: palette.error[500],
+			borderError: palette.error[500],
+			backgroundInput: palette.neutral[20],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/select/Select.stories.tsx
+++ b/libs/@guardian/source/src/react-components/select/Select.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof Select> = {
 export default meta;
 type Story = StoryObj<typeof Select>;
 
-const SelectTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<Select {...args}>
 			<Option value="">Select a state</Option>
@@ -41,7 +41,7 @@ const SelectTemplate: Story = {
 };
 
 export const DefaultDefaultTheme: Story = {
-	...SelectTemplate,
+	...Template,
 	args: {
 		label: 'State',
 		optional: false,
@@ -53,7 +53,7 @@ export const DefaultDefaultTheme: Story = {
 };
 
 export const VisuallyHideLabelDefaultTheme: Story = {
-	...SelectTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		hideLabel: true,
@@ -61,7 +61,7 @@ export const VisuallyHideLabelDefaultTheme: Story = {
 };
 
 export const OptionalDefaultTheme: Story = {
-	...SelectTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		optional: true,
@@ -69,7 +69,7 @@ export const OptionalDefaultTheme: Story = {
 };
 
 export const ErrorWithMessageDefaultTheme: Story = {
-	...SelectTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'error',
@@ -77,7 +77,7 @@ export const ErrorWithMessageDefaultTheme: Story = {
 };
 
 export const SuccessWithMessageDefaultTheme: Story = {
-	...SelectTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		success: 'success',
@@ -85,7 +85,7 @@ export const SuccessWithMessageDefaultTheme: Story = {
 };
 
 export const SupportingTextDefaultTheme: Story = {
-	...SelectTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'Leave blank if you are not within the US',
@@ -93,7 +93,7 @@ export const SupportingTextDefaultTheme: Story = {
 };
 
 export const SupportingSuccessTextDefaultTheme: Story = {
-	...SelectTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'Leave blank if you are not within the US',
@@ -102,7 +102,7 @@ export const SupportingSuccessTextDefaultTheme: Story = {
 };
 
 export const SupportingErrorTextDefaultTheme: Story = {
-	...SelectTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'Leave blank if you are not within the US',
@@ -112,7 +112,7 @@ export const SupportingErrorTextDefaultTheme: Story = {
 };
 
 export const SupportingTextCustomTheme: Story = {
-	...SelectTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'Leave blank if you are not within the US',
@@ -133,7 +133,7 @@ export const SupportingTextCustomTheme: Story = {
 };
 
 export const ErrorWithMessageCustomTheme: Story = {
-	...SelectTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'error',

--- a/libs/@guardian/source/src/react-components/select/Select.stories.tsx
+++ b/libs/@guardian/source/src/react-components/select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { Option } from './Option';
 import { Select } from './Select';

--- a/libs/@guardian/source/src/react-components/spinner/Spinner.stories.tsx
+++ b/libs/@guardian/source/src/react-components/spinner/Spinner.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { Spinner } from './Spinner';
 

--- a/libs/@guardian/source/src/react-components/spinner/Spinner.stories.tsx
+++ b/libs/@guardian/source/src/react-components/spinner/Spinner.stories.tsx
@@ -1,6 +1,5 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { palette } from '../../foundations';
-import type { SpinnerProps } from './Spinner';
 import { Spinner } from './Spinner';
 
 const meta: Meta<typeof Spinner> = {
@@ -15,51 +14,37 @@ const meta: Meta<typeof Spinner> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof Spinner>;
 
-const Template: StoryFn<typeof Spinner> = (args: SpinnerProps) => (
-	<Spinner {...args} />
-);
-
-// *****************************************************************************
-
-export const XSmallSizeDefaultTheme: StoryFn<typeof Spinner> = Template.bind(
-	{},
-);
-XSmallSizeDefaultTheme.args = {
-	size: 'xsmall',
+export const XSmallSizeDefaultTheme: Story = {
+	args: {
+		size: 'xsmall',
+	},
 };
 
-// *****************************************************************************
-
-export const SmallSizeDefaultTheme: StoryFn<typeof Spinner> = Template.bind({});
-SmallSizeDefaultTheme.args = {
-	size: 'small',
+export const SmallSizeDefaultTheme: Story = {
+	args: {
+		size: 'small',
+	},
 };
 
-// *****************************************************************************
-
-export const MediumSizeDefaultTheme: StoryFn<typeof Spinner> = Template.bind(
-	{},
-);
-MediumSizeDefaultTheme.args = {
-	size: 'medium',
+export const MediumSizeDefaultTheme: Story = {
+	args: {
+		size: 'medium',
+	},
 };
 
-// *****************************************************************************
-
-export const CustomSizeDefaultTheme: StoryFn<typeof Spinner> = Template.bind(
-	{},
-);
-CustomSizeDefaultTheme.args = {
-	size: 40,
+export const CustomSizeDefaultTheme: Story = {
+	args: {
+		size: 40,
+	},
 };
 
-// *****************************************************************************
-
-export const CustomTheme: StoryFn<typeof Spinner> = Template.bind({});
-CustomTheme.args = {
-	theme: {
-		background: 'transparent',
-		color: palette.neutral[7],
+export const CustomTheme: Story = {
+	args: {
+		theme: {
+			background: 'transparent',
+			color: palette.neutral[7],
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/stack/Stack.stories.tsx
+++ b/libs/@guardian/source/src/react-components/stack/Stack.stories.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { palette, space } from '../../foundations';
-import type { StackProps } from './Stack';
 import { Stack } from './Stack';
 
 const meta: Meta<typeof Stack> = {
@@ -10,6 +9,7 @@ const meta: Meta<typeof Stack> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof Stack>;
 
 const wrapper = css`
 	outline: 1px dashed ${palette.neutral[46]};
@@ -22,119 +22,123 @@ const box = css`
 	background: ${palette.news[600]};
 `;
 
-const Template: StoryFn<typeof Stack> = (args: StackProps) => (
-	<div css={wrapper}>
-		<Stack {...args}>
-			<div css={box}>1</div>
-			<div css={box}>2</div>
-			<div css={box}>3</div>
-		</Stack>
-	</div>
-);
-
-export const Default: StoryFn<typeof Stack> = Template.bind({});
-
-// *****************************************************************************
-
-export const Space0: StoryFn<typeof Stack> = Template.bind({});
-Space0.args = {
-	space: 0,
+const StackTemplate: Story = {
+	render: (args) => (
+		<div css={wrapper}>
+			<Stack {...args}>
+				<div css={box}>1</div>
+				<div css={box}>2</div>
+				<div css={box}>3</div>
+			</Stack>
+		</div>
+	),
 };
 
-// *****************************************************************************
-
-export const Space1: StoryFn<typeof Stack> = Template.bind({});
-Space1.args = {
-	space: 1,
+export const Default: Story = {
+	...StackTemplate,
 };
 
-// *****************************************************************************
-
-export const Space2: StoryFn<typeof Stack> = Template.bind({});
-Space2.args = {
-	space: 2,
+export const Space0: Story = {
+	...StackTemplate,
+	args: {
+		space: 0,
+	},
 };
 
-// *****************************************************************************
-
-export const Space3: StoryFn<typeof Stack> = Template.bind({});
-Space3.args = {
-	space: 3,
+export const Space1: Story = {
+	...StackTemplate,
+	args: {
+		space: 1,
+	},
 };
 
-// *****************************************************************************
-
-export const Space4: StoryFn<typeof Stack> = Template.bind({});
-Space4.args = {
-	space: 4,
+export const Space2: Story = {
+	...StackTemplate,
+	args: {
+		space: 2,
+	},
 };
 
-// *****************************************************************************
-
-export const Space5: StoryFn<typeof Stack> = Template.bind({});
-Space5.args = {
-	space: 5,
+export const Space3: Story = {
+	...StackTemplate,
+	args: {
+		space: 3,
+	},
 };
 
-// *****************************************************************************
-
-export const Space6: StoryFn<typeof Stack> = Template.bind({});
-Space6.args = {
-	space: 6,
+export const Space4: Story = {
+	...StackTemplate,
+	args: {
+		space: 4,
+	},
 };
 
-// *****************************************************************************
-
-export const Space8: StoryFn<typeof Stack> = Template.bind({});
-Space8.args = {
-	space: 8,
+export const Space5: Story = {
+	...StackTemplate,
+	args: {
+		space: 5,
+	},
 };
 
-// *****************************************************************************
-
-export const Space9: StoryFn<typeof Stack> = Template.bind({});
-Space9.args = {
-	space: 9,
+export const Space6: Story = {
+	...StackTemplate,
+	args: {
+		space: 6,
+	},
 };
 
-// *****************************************************************************
-
-export const Space10: StoryFn<typeof Stack> = Template.bind({});
-Space10.args = {
-	space: 10,
+export const Space8: Story = {
+	...StackTemplate,
+	args: {
+		space: 8,
+	},
 };
 
-// *****************************************************************************
-
-export const Space12: StoryFn<typeof Stack> = Template.bind({});
-Space12.args = {
-	space: 12,
+export const Space9: Story = {
+	...StackTemplate,
+	args: {
+		space: 9,
+	},
 };
 
-// *****************************************************************************
-
-export const Space14: StoryFn<typeof Stack> = Template.bind({});
-Space14.args = {
-	space: 14,
+export const Space10: Story = {
+	...StackTemplate,
+	args: {
+		space: 10,
+	},
 };
 
-// *****************************************************************************
-
-export const Space16: StoryFn<typeof Stack> = Template.bind({});
-Space16.args = {
-	space: 16,
+export const Space12: Story = {
+	...StackTemplate,
+	args: {
+		space: 12,
+	},
 };
 
-// *****************************************************************************
-
-export const Space18: StoryFn<typeof Stack> = Template.bind({});
-Space18.args = {
-	space: 18,
+export const Space14: Story = {
+	...StackTemplate,
+	args: {
+		space: 14,
+	},
 };
 
-// *****************************************************************************
+export const Space16: Story = {
+	...StackTemplate,
+	args: {
+		space: 16,
+	},
+};
 
-export const Space24: StoryFn<typeof Stack> = Template.bind({});
-Space24.args = {
-	space: 24,
+export const Space18: Story = {
+	...StackTemplate,
+	args: {
+		space: 18,
+	},
+};
+
+export const Space24: Story = {
+	...StackTemplate,
+	args: {
+		space: 24,
+	},
 };

--- a/libs/@guardian/source/src/react-components/stack/Stack.stories.tsx
+++ b/libs/@guardian/source/src/react-components/stack/Stack.stories.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette, space } from '../../foundations';
 import { Stack } from './Stack';
 

--- a/libs/@guardian/source/src/react-components/stack/Stack.stories.tsx
+++ b/libs/@guardian/source/src/react-components/stack/Stack.stories.tsx
@@ -22,7 +22,7 @@ const box = css`
 	background: ${palette.news[600]};
 `;
 
-const StackTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<div css={wrapper}>
 			<Stack {...args}>
@@ -35,109 +35,109 @@ const StackTemplate: Story = {
 };
 
 export const Default: Story = {
-	...StackTemplate,
+	...Template,
 };
 
 export const Space0: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 0,
 	},
 };
 
 export const Space1: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 1,
 	},
 };
 
 export const Space2: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 2,
 	},
 };
 
 export const Space3: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 3,
 	},
 };
 
 export const Space4: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 4,
 	},
 };
 
 export const Space5: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 5,
 	},
 };
 
 export const Space6: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 6,
 	},
 };
 
 export const Space8: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 8,
 	},
 };
 
 export const Space9: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 9,
 	},
 };
 
 export const Space10: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 10,
 	},
 };
 
 export const Space12: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 12,
 	},
 };
 
 export const Space14: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 14,
 	},
 };
 
 export const Space16: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 16,
 	},
 };
 
 export const Space18: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 18,
 	},
 };
 
 export const Space24: Story = {
-	...StackTemplate,
+	...Template,
 	args: {
 		space: 24,
 	},

--- a/libs/@guardian/source/src/react-components/text-area/TextArea.stories.tsx
+++ b/libs/@guardian/source/src/react-components/text-area/TextArea.stories.tsx
@@ -1,7 +1,6 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { useState } from 'react';
 import { palette } from '../../foundations';
-import type { TextAreaProps } from './TextArea';
 import { TextArea } from './TextArea';
 
 const meta: Meta<typeof TextArea> = {
@@ -25,6 +24,23 @@ const meta: Meta<typeof TextArea> = {
 			control: { type: 'radio' },
 		},
 	},
+};
+
+export default meta;
+type Story = StoryObj<typeof TextArea>;
+
+const TextAreaTemplate: Story = {
+	render: (args) => {
+		const [value, setValue] = useState(args.value);
+		const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
+			setValue(e.target.value);
+
+		return <TextArea {...args} onChange={onChange} value={value} />;
+	},
+};
+
+export const DefaultDefaultTheme: Story = {
+	...TextAreaTemplate,
 	args: {
 		label: 'Comments',
 		optional: false,
@@ -36,185 +52,170 @@ const meta: Meta<typeof TextArea> = {
 	},
 };
 
-export default meta;
-
-const Template: StoryFn<typeof TextArea> = (args: TextAreaProps) => {
-	const [value, setValue] = useState(args.value);
-
-	const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
-		setValue(e.target.value);
-
-	return <TextArea {...args} onChange={onChange} value={value} />;
-};
-
-// *****************************************************************************
-
-export const DefaultDefaultTheme: StoryFn<typeof TextArea> = Template.bind({});
-
-// *****************************************************************************
-
-export const WithRowsDefaultTheme: StoryFn<typeof TextArea> = Template.bind({});
-WithRowsDefaultTheme.args = {
-	rows: 10,
-};
-
-// *****************************************************************************
-
-export const OptionalDefaultTheme: StoryFn<typeof TextArea> = Template.bind({});
-OptionalDefaultTheme.args = {
-	optional: true,
-};
-
-// *****************************************************************************
-
-export const VisuallyHideLabelDefaultTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-VisuallyHideLabelDefaultTheme.args = {
-	hideLabel: true,
-};
-
-// *****************************************************************************
-
-export const SupportingTextDefaultTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-SupportingTextDefaultTheme.args = {
-	supporting:
-		'Please keep comments respectful and abide by the community guidelines.',
-};
-
-// *****************************************************************************
-
-export const ErrorWithMessageDefaultTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-ErrorWithMessageDefaultTheme.args = {
-	error: 'error',
-};
-
-// *****************************************************************************
-
-export const SuccessWithMessageDefaultTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-SuccessWithMessageDefaultTheme.args = {
-	success: 'success',
-};
-
-// *****************************************************************************
-
-export const WithMaxLengthDefaultTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-WithMaxLengthDefaultTheme.args = {
-	maxLength: 10,
-};
-
-// *****************************************************************************
-
-export const WithDefaultValue: StoryFn<typeof TextArea> = Template.bind({});
-WithDefaultValue.args = {
-	value: 'This is a value passed in as a prop',
-};
-
-// *****************************************************************************
-
-export const DefaultSmallDefaultTheme: StoryFn<typeof TextArea> = Template.bind(
-	{},
-);
-DefaultSmallDefaultTheme.args = {
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const WithRowsSmallDefaultTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-WithRowsSmallDefaultTheme.args = {
-	rows: 10,
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const OptionalSmallDefaultTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-OptionalSmallDefaultTheme.args = {
-	optional: true,
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const VisuallyHideLabelSmallDefaultTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-VisuallyHideLabelSmallDefaultTheme.args = {
-	hideLabel: true,
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const SupportingTextSmallDefaultTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-SupportingTextSmallDefaultTheme.args = {
-	supporting:
-		'Please keep comments respectful and abide by the community guidelines.',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const ErrorWithMessageSmallDefaultTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-ErrorWithMessageSmallDefaultTheme.args = {
-	error: 'error',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const SuccessWithMessageSmallDefaultTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-SuccessWithMessageSmallDefaultTheme.args = {
-	success: 'success',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const SupportingTextCustomTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-SupportingTextCustomTheme.args = {
-	supporting:
-		'Please keep comments respectful and abide by the community guidelines.',
-	theme: {
-		textUserInput: palette.neutral[86],
-		textLabel: palette.neutral[86],
-		textSupporting: palette.neutral[60],
-		border: palette.neutral[60],
-		backgroundInput: palette.neutral[20],
-	},
-};
-SupportingTextCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+export const WithRowsDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		rows: 10,
 	},
 };
 
-// *****************************************************************************
-
-export const ErrorWithMessageCustomTheme: StoryFn<typeof TextArea> =
-	Template.bind({});
-ErrorWithMessageCustomTheme.args = {
-	error: 'error',
-	theme: {
-		textLabel: palette.neutral[86],
-		textError: palette.error[500],
-		borderError: palette.error[500],
-		backgroundInput: palette.neutral[20],
-	},
-};
-ErrorWithMessageCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+export const OptionalDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		optional: true,
 	},
 };
 
-// *****************************************************************************
+export const VisuallyHideLabelDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		hideLabel: true,
+	},
+};
+
+export const SupportingTextDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting:
+			'Please keep comments respectful and abide by the community guidelines.',
+	},
+};
+
+export const ErrorWithMessageDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'error',
+	},
+};
+
+export const SuccessWithMessageDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		success: 'success',
+	},
+};
+
+export const WithMaxLengthDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		maxLength: 10,
+	},
+};
+
+export const WithDefaultValue: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		value: 'This is a value passed in as a prop',
+	},
+};
+
+export const DefaultSmallDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		size: 'small',
+	},
+};
+
+export const WithRowsSmallDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		rows: 10,
+		size: 'small',
+	},
+};
+
+export const OptionalSmallDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		optional: true,
+		size: 'small',
+	},
+};
+
+export const VisuallyHideLabelSmallDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		hideLabel: true,
+		size: 'small',
+	},
+};
+
+export const SupportingTextSmallDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting:
+			'Please keep comments respectful and abide by the community guidelines.',
+		size: 'small',
+	},
+};
+
+export const ErrorWithMessageSmallDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'error',
+		size: 'small',
+	},
+};
+
+export const SuccessWithMessageSmallDefaultTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		success: 'success',
+		size: 'small',
+	},
+};
+
+export const SupportingTextCustomTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting:
+			'Please keep comments respectful and abide by the community guidelines.',
+		theme: {
+			textUserInput: palette.neutral[86],
+			textLabel: palette.neutral[86],
+			textSupporting: palette.neutral[60],
+			border: palette.neutral[60],
+			backgroundInput: palette.neutral[20],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
+	},
+};
+
+export const ErrorWithMessageCustomTheme: Story = {
+	...TextAreaTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'error',
+		theme: {
+			textLabel: palette.neutral[86],
+			textError: palette.error[500],
+			borderError: palette.error[500],
+			backgroundInput: palette.neutral[20],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
+	},
+};

--- a/libs/@guardian/source/src/react-components/text-area/TextArea.stories.tsx
+++ b/libs/@guardian/source/src/react-components/text-area/TextArea.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { palette } from '../../foundations';
 import { TextArea } from './TextArea';

--- a/libs/@guardian/source/src/react-components/text-area/TextArea.stories.tsx
+++ b/libs/@guardian/source/src/react-components/text-area/TextArea.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta<typeof TextArea> = {
 export default meta;
 type Story = StoryObj<typeof TextArea>;
 
-const TextAreaTemplate: Story = {
+const Template: Story = {
 	render: (args) => {
 		const [value, setValue] = useState(args.value);
 		const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
@@ -40,7 +40,7 @@ const TextAreaTemplate: Story = {
 };
 
 export const DefaultDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		label: 'Comments',
 		optional: false,
@@ -53,7 +53,7 @@ export const DefaultDefaultTheme: Story = {
 };
 
 export const WithRowsDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		rows: 10,
@@ -61,7 +61,7 @@ export const WithRowsDefaultTheme: Story = {
 };
 
 export const OptionalDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		optional: true,
@@ -69,7 +69,7 @@ export const OptionalDefaultTheme: Story = {
 };
 
 export const VisuallyHideLabelDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		hideLabel: true,
@@ -77,7 +77,7 @@ export const VisuallyHideLabelDefaultTheme: Story = {
 };
 
 export const SupportingTextDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting:
@@ -86,7 +86,7 @@ export const SupportingTextDefaultTheme: Story = {
 };
 
 export const ErrorWithMessageDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'error',
@@ -94,7 +94,7 @@ export const ErrorWithMessageDefaultTheme: Story = {
 };
 
 export const SuccessWithMessageDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		success: 'success',
@@ -102,7 +102,7 @@ export const SuccessWithMessageDefaultTheme: Story = {
 };
 
 export const WithMaxLengthDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		maxLength: 10,
@@ -110,7 +110,7 @@ export const WithMaxLengthDefaultTheme: Story = {
 };
 
 export const WithDefaultValue: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		value: 'This is a value passed in as a prop',
@@ -118,7 +118,7 @@ export const WithDefaultValue: Story = {
 };
 
 export const DefaultSmallDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		size: 'small',
@@ -126,7 +126,7 @@ export const DefaultSmallDefaultTheme: Story = {
 };
 
 export const WithRowsSmallDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		rows: 10,
@@ -135,7 +135,7 @@ export const WithRowsSmallDefaultTheme: Story = {
 };
 
 export const OptionalSmallDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		optional: true,
@@ -144,7 +144,7 @@ export const OptionalSmallDefaultTheme: Story = {
 };
 
 export const VisuallyHideLabelSmallDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		hideLabel: true,
@@ -153,7 +153,7 @@ export const VisuallyHideLabelSmallDefaultTheme: Story = {
 };
 
 export const SupportingTextSmallDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting:
@@ -163,7 +163,7 @@ export const SupportingTextSmallDefaultTheme: Story = {
 };
 
 export const ErrorWithMessageSmallDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'error',
@@ -172,7 +172,7 @@ export const ErrorWithMessageSmallDefaultTheme: Story = {
 };
 
 export const SuccessWithMessageSmallDefaultTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		success: 'success',
@@ -181,7 +181,7 @@ export const SuccessWithMessageSmallDefaultTheme: Story = {
 };
 
 export const SupportingTextCustomTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting:
@@ -202,7 +202,7 @@ export const SupportingTextCustomTheme: Story = {
 };
 
 export const ErrorWithMessageCustomTheme: Story = {
-	...TextAreaTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'error',

--- a/libs/@guardian/source/src/react-components/text-input/TextInput.stories.tsx
+++ b/libs/@guardian/source/src/react-components/text-input/TextInput.stories.tsx
@@ -1,21 +1,11 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { useState } from 'react';
 import { palette } from '../../foundations';
 import { TextInput } from './TextInput';
-import type { TextInputProps } from './TextInput';
 
 const meta: Meta<typeof TextInput> = {
 	title: 'React Components/TextInput',
 	component: TextInput,
-	args: {
-		label: 'Email',
-		optional: false,
-		hideLabel: false,
-		supporting: '',
-		size: 'medium',
-		error: 'undefined',
-		success: 'undefined',
-	},
 	argTypes: {
 		error: {
 			options: ['undefined', 'error'],
@@ -38,231 +28,242 @@ const meta: Meta<typeof TextInput> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof TextInput>;
 
-const Template: StoryFn<typeof TextInput> = (args: TextInputProps) => {
-	const [state, setState] = useState('');
-	return (
-		<TextInput
-			{...args}
-			value={state}
-			onChange={(event) => setState(event.target.value)}
-		/>
-	);
-};
-
-export const DefaultDefaultTheme: StoryFn<typeof TextInput> = Template.bind({});
-
-// *****************************************************************************
-
-export const OptionalDefaultTheme: StoryFn<typeof TextInput> = Template.bind(
-	{},
-);
-OptionalDefaultTheme.args = {
-	optional: true,
-};
-
-// *****************************************************************************
-
-export const HideLabelDefaultTheme: StoryFn<typeof TextInput> = Template.bind(
-	{},
-);
-HideLabelDefaultTheme.args = {
-	hideLabel: true,
-};
-
-// *****************************************************************************
-
-export const SupportingTextDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-SupportingTextDefaultTheme.args = {
-	supporting: 'alex@example.com',
-};
-
-// *****************************************************************************
-
-export const Width30DefaultTheme: StoryFn<typeof TextInput> = Template.bind({});
-Width30DefaultTheme.args = {
-	width: 30,
-	label: 'First name',
-};
-
-// *****************************************************************************
-
-export const Width10DefaultTheme: StoryFn<typeof TextInput> = Template.bind({});
-Width10DefaultTheme.args = {
-	width: 10,
-	label: 'Postcode',
-};
-
-// *****************************************************************************
-
-export const Width4DefaultTheme: StoryFn<typeof TextInput> = Template.bind({});
-Width4DefaultTheme.args = {
-	width: 4,
-	label: 'Year of birth',
-};
-
-// *****************************************************************************
-
-export const ErrorWithMessageDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-ErrorWithMessageDefaultTheme.args = {
-	error: 'error',
-};
-
-// *****************************************************************************
-
-export const SuccessWithMessageDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-SuccessWithMessageDefaultTheme.args = {
-	success: 'success',
-};
-
-// *****************************************************************************
-
-export const ConstraintDefaultTheme: StoryFn<typeof TextInput> = Template.bind(
-	{},
-);
-ConstraintDefaultTheme.args = {
-	label: 'Phone number',
-	pattern: '[0-9]{1,11}',
-	title: 'React Components/11 digit phone number',
-	type: 'tel',
-};
-
-// *****************************************************************************
-
-export const DefaultSmallDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-DefaultSmallDefaultTheme.args = {
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const OptionalSmallDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-OptionalSmallDefaultTheme.args = {
-	optional: true,
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const HideLabelSmallDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-HideLabelSmallDefaultTheme.args = {
-	hideLabel: true,
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const SupportingTextSmallDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-SupportingTextSmallDefaultTheme.args = {
-	supporting: 'alex@example.com',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const Width30SmallDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-Width30SmallDefaultTheme.args = {
-	width: 30,
-	label: 'First name',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const Width10SmallDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-Width10SmallDefaultTheme.args = {
-	width: 10,
-	label: 'Postcode',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const Width4SmallDefaultTheme: StoryFn<typeof TextInput> = Template.bind(
-	{},
-);
-Width4SmallDefaultTheme.args = {
-	width: 4,
-	label: 'Year of birth',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const ErrorWithMessageSmallDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-ErrorWithMessageSmallDefaultTheme.args = {
-	error: 'error',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const SuccessWithMessageSmallDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-SuccessWithMessageSmallDefaultTheme.args = {
-	success: 'success',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const ConstraintSmallDefaultTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-ConstraintSmallDefaultTheme.args = {
-	label: 'Phone number',
-	pattern: '[0-9]{1,11}',
-	title: 'React Components/11 digit phone number',
-	type: 'tel',
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const SupportingTextCustomTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-SupportingTextCustomTheme.args = {
-	supporting: 'alex@example.com',
-	theme: {
-		textUserInput: palette.neutral[86],
-		textLabel: palette.neutral[86],
-		textSupporting: palette.neutral[60],
-		border: palette.neutral[60],
-		backgroundInput: palette.neutral[20],
-	},
-};
-SupportingTextCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+const TextInputTemplate: Story = {
+	render: (args) => {
+		const [state, setState] = useState('');
+		return (
+			<TextInput
+				{...args}
+				value={state}
+				onChange={(event) => setState(event.target.value)}
+			/>
+		);
 	},
 };
 
-// *****************************************************************************
-
-export const ErrorWithMessageCustomTheme: StoryFn<typeof TextInput> =
-	Template.bind({});
-ErrorWithMessageCustomTheme.args = {
-	error: 'error',
-	theme: {
-		textLabel: palette.neutral[86],
-		textError: palette.error[500],
-		borderError: palette.error[500],
-		backgroundInput: palette.neutral[20],
-	},
-};
-ErrorWithMessageCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+export const DefaultDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		label: 'Email',
+		optional: false,
+		hideLabel: false,
+		supporting: '',
+		size: 'medium',
+		error: 'undefined',
+		success: 'undefined',
 	},
 };
 
-// *****************************************************************************
+export const OptionalDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		optional: true,
+	},
+};
+
+export const HideLabelDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		hideLabel: true,
+	},
+};
+
+export const SupportingTextDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'alex@example.com',
+	},
+};
+
+export const Width30DefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		width: 30,
+		label: 'First name',
+	},
+};
+
+export const Width10DefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		width: 10,
+		label: 'Postcode',
+	},
+};
+
+export const Width4DefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		width: 4,
+		label: 'Year of birth',
+	},
+};
+
+export const ErrorWithMessageDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'error',
+	},
+};
+
+export const SuccessWithMessageDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		success: 'success',
+	},
+};
+
+export const ConstraintDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		label: 'Phone number',
+		pattern: '[0-9]{1,11}',
+		title: 'React Components/11 digit phone number',
+		type: 'tel',
+	},
+};
+
+export const DefaultSmallDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		size: 'small',
+	},
+};
+
+export const OptionalSmallDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		optional: true,
+		size: 'small',
+	},
+};
+
+export const HideLabelSmallDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		hideLabel: true,
+		size: 'small',
+	},
+};
+
+export const SupportingTextSmallDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'alex@example.com',
+		size: 'small',
+	},
+};
+
+export const Width30SmallDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		width: 30,
+		label: 'First name',
+		size: 'small',
+	},
+};
+
+export const Width10SmallDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		width: 10,
+		label: 'Postcode',
+		size: 'small',
+	},
+};
+
+export const Width4SmallDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		width: 4,
+		label: 'Year of birth',
+		size: 'small',
+	},
+};
+
+export const ErrorWithMessageSmallDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'error',
+		size: 'small',
+	},
+};
+
+export const SuccessWithMessageSmallDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		success: 'success',
+		size: 'small',
+	},
+};
+
+export const ConstraintSmallDefaultTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		label: 'Phone number',
+		pattern: '[0-9]{1,11}',
+		title: 'React Components/11 digit phone number',
+		type: 'tel',
+		size: 'small',
+	},
+};
+
+export const SupportingTextCustomTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		supporting: 'alex@example.com',
+		theme: {
+			textUserInput: palette.neutral[86],
+			textLabel: palette.neutral[86],
+			textSupporting: palette.neutral[60],
+			border: palette.neutral[60],
+			backgroundInput: palette.neutral[20],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
+	},
+};
+
+export const ErrorWithMessageCustomTheme: Story = {
+	...TextInputTemplate,
+	args: {
+		...DefaultDefaultTheme.args,
+		error: 'error',
+		theme: {
+			textLabel: palette.neutral[86],
+			textError: palette.error[500],
+			borderError: palette.error[500],
+			backgroundInput: palette.neutral[20],
+		},
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
+	},
+};

--- a/libs/@guardian/source/src/react-components/text-input/TextInput.stories.tsx
+++ b/libs/@guardian/source/src/react-components/text-input/TextInput.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof TextInput> = {
 export default meta;
 type Story = StoryObj<typeof TextInput>;
 
-const TextInputTemplate: Story = {
+const Template: Story = {
 	render: (args) => {
 		const [state, setState] = useState('');
 		return (
@@ -44,7 +44,7 @@ const TextInputTemplate: Story = {
 };
 
 export const DefaultDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		label: 'Email',
 		optional: false,
@@ -57,7 +57,7 @@ export const DefaultDefaultTheme: Story = {
 };
 
 export const OptionalDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		optional: true,
@@ -65,7 +65,7 @@ export const OptionalDefaultTheme: Story = {
 };
 
 export const HideLabelDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		hideLabel: true,
@@ -73,7 +73,7 @@ export const HideLabelDefaultTheme: Story = {
 };
 
 export const SupportingTextDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'alex@example.com',
@@ -81,7 +81,7 @@ export const SupportingTextDefaultTheme: Story = {
 };
 
 export const Width30DefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		width: 30,
@@ -90,7 +90,7 @@ export const Width30DefaultTheme: Story = {
 };
 
 export const Width10DefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		width: 10,
@@ -99,7 +99,7 @@ export const Width10DefaultTheme: Story = {
 };
 
 export const Width4DefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		width: 4,
@@ -108,7 +108,7 @@ export const Width4DefaultTheme: Story = {
 };
 
 export const ErrorWithMessageDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'error',
@@ -116,7 +116,7 @@ export const ErrorWithMessageDefaultTheme: Story = {
 };
 
 export const SuccessWithMessageDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		success: 'success',
@@ -124,7 +124,7 @@ export const SuccessWithMessageDefaultTheme: Story = {
 };
 
 export const ConstraintDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		label: 'Phone number',
@@ -135,7 +135,7 @@ export const ConstraintDefaultTheme: Story = {
 };
 
 export const DefaultSmallDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		size: 'small',
@@ -143,7 +143,7 @@ export const DefaultSmallDefaultTheme: Story = {
 };
 
 export const OptionalSmallDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		optional: true,
@@ -152,7 +152,7 @@ export const OptionalSmallDefaultTheme: Story = {
 };
 
 export const HideLabelSmallDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		hideLabel: true,
@@ -161,7 +161,7 @@ export const HideLabelSmallDefaultTheme: Story = {
 };
 
 export const SupportingTextSmallDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'alex@example.com',
@@ -170,7 +170,7 @@ export const SupportingTextSmallDefaultTheme: Story = {
 };
 
 export const Width30SmallDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		width: 30,
@@ -180,7 +180,7 @@ export const Width30SmallDefaultTheme: Story = {
 };
 
 export const Width10SmallDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		width: 10,
@@ -190,7 +190,7 @@ export const Width10SmallDefaultTheme: Story = {
 };
 
 export const Width4SmallDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		width: 4,
@@ -200,7 +200,7 @@ export const Width4SmallDefaultTheme: Story = {
 };
 
 export const ErrorWithMessageSmallDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'error',
@@ -209,7 +209,7 @@ export const ErrorWithMessageSmallDefaultTheme: Story = {
 };
 
 export const SuccessWithMessageSmallDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		success: 'success',
@@ -218,7 +218,7 @@ export const SuccessWithMessageSmallDefaultTheme: Story = {
 };
 
 export const ConstraintSmallDefaultTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		label: 'Phone number',
@@ -230,7 +230,7 @@ export const ConstraintSmallDefaultTheme: Story = {
 };
 
 export const SupportingTextCustomTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		supporting: 'alex@example.com',
@@ -250,7 +250,7 @@ export const SupportingTextCustomTheme: Story = {
 };
 
 export const ErrorWithMessageCustomTheme: Story = {
-	...TextInputTemplate,
+	...Template,
 	args: {
 		...DefaultDefaultTheme.args,
 		error: 'error',

--- a/libs/@guardian/source/src/react-components/text-input/TextInput.stories.tsx
+++ b/libs/@guardian/source/src/react-components/text-input/TextInput.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { palette } from '../../foundations';
 import { TextInput } from './TextInput';

--- a/libs/@guardian/source/src/react-components/tiles/Tiles.stories.tsx
+++ b/libs/@guardian/source/src/react-components/tiles/Tiles.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { breakpoints } from '../../foundations';
 import { Tiles } from './Tiles';
 

--- a/libs/@guardian/source/src/react-components/tiles/Tiles.stories.tsx
+++ b/libs/@guardian/source/src/react-components/tiles/Tiles.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Tiles> = {
 export default meta;
 type Story = StoryObj<typeof Tiles>;
 
-const TilesTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<Tiles {...args}>
 			<div>
@@ -47,35 +47,35 @@ const TilesTemplate: Story = {
 };
 
 export const Columns2: Story = {
-	...TilesTemplate,
+	...Template,
 	args: {
 		columns: 2,
 	},
 };
 
 export const Columns3: Story = {
-	...TilesTemplate,
+	...Template,
 	args: {
 		columns: 3,
 	},
 };
 
 export const Columns4: Story = {
-	...TilesTemplate,
+	...Template,
 	args: {
 		columns: 4,
 	},
 };
 
 export const Columns5: Story = {
-	...TilesTemplate,
+	...Template,
 	args: {
 		columns: 5,
 	},
 };
 
 export const Columns5CollapseUntilTabletAtMobile: Story = {
-	...TilesTemplate,
+	...Template,
 	args: {
 		columns: 5,
 		collapseUntil: 'tablet',
@@ -89,7 +89,7 @@ export const Columns5CollapseUntilTabletAtMobile: Story = {
 };
 
 export const Columns5CollapseUntilTabletAtTablet: Story = {
-	...TilesTemplate,
+	...Template,
 	args: {
 		columns: 5,
 		collapseUntil: 'tablet',

--- a/libs/@guardian/source/src/react-components/tiles/Tiles.stories.tsx
+++ b/libs/@guardian/source/src/react-components/tiles/Tiles.stories.tsx
@@ -1,102 +1,103 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { breakpoints } from '../../foundations';
-import type { TilesProps } from './Tiles';
 import { Tiles } from './Tiles';
 
 const meta: Meta<typeof Tiles> = {
 	title: 'React Components/Tiles',
 	component: Tiles,
+};
+
+export default meta;
+type Story = StoryObj<typeof Tiles>;
+
+const TilesTemplate: Story = {
+	render: (args) => (
+		<Tiles {...args}>
+			<div>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut faucibus
+				nibh erat, eget rutrum ligula vehicula sit amet. Etiam scelerisque
+				dapibus pulvinar. Integer non accumsan justo. Duis et vehicula risus.
+				Nulla ligula eros, consequat sodales lectus eget, eleifend venenatis
+				neque.
+			</div>
+			<div>
+				Interdum et malesuada fames ac ante ipsum primis in faucibus. Nulla
+				facilisi. Phasellus id aliquam odio. Aliquam tempus eu enim in
+				fermentum. Donec ut velit vel purus rutrum vulputate ut scelerisque
+				lacus.
+			</div>
+			<div>
+				Pellentesque id ornare turpis. Aliquam laoreet aliquet pharetra. Donec
+				nec erat ac libero interdum sollicitudin. Nullam imperdiet ut dolor non
+				cursus. Integer et ante fringilla, luctus magna nec, consequat est.
+			</div>
+			<div>
+				Nunc nec dapibus quam. Praesent nec neque vel velit mollis tempor.
+				Suspendisse justo eros, pharetra et elit sit amet, hendrerit laoreet
+				dui. Curabitur ut libero nibh. Duis finibus sollicitudin tortor, ac
+				viverra urna commodo et.
+			</div>
+			<div>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Non igitur
+				potestis voluptate omnia dirigentes aut tueri aut retinere virtutem. Hoc
+				Hieronymus summum bonum esse dixit.
+			</div>
+		</Tiles>
+	),
+};
+
+export const Columns2: Story = {
+	...TilesTemplate,
 	args: {
 		columns: 2,
 	},
 };
 
-export default meta;
-
-const Template: StoryFn<typeof Tiles> = (args: TilesProps) => (
-	<Tiles {...args}>
-		<div>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut faucibus nibh
-			erat, eget rutrum ligula vehicula sit amet. Etiam scelerisque dapibus
-			pulvinar. Integer non accumsan justo. Duis et vehicula risus. Nulla ligula
-			eros, consequat sodales lectus eget, eleifend venenatis neque.
-		</div>
-		<div>
-			Interdum et malesuada fames ac ante ipsum primis in faucibus. Nulla
-			facilisi. Phasellus id aliquam odio. Aliquam tempus eu enim in fermentum.
-			Donec ut velit vel purus rutrum vulputate ut scelerisque lacus.
-		</div>
-		<div>
-			Pellentesque id ornare turpis. Aliquam laoreet aliquet pharetra. Donec nec
-			erat ac libero interdum sollicitudin. Nullam imperdiet ut dolor non
-			cursus. Integer et ante fringilla, luctus magna nec, consequat est.
-		</div>
-		<div>
-			Nunc nec dapibus quam. Praesent nec neque vel velit mollis tempor.
-			Suspendisse justo eros, pharetra et elit sit amet, hendrerit laoreet dui.
-			Curabitur ut libero nibh. Duis finibus sollicitudin tortor, ac viverra
-			urna commodo et.
-		</div>
-		<div>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Non igitur
-			potestis voluptate omnia dirigentes aut tueri aut retinere virtutem. Hoc
-			Hieronymus summum bonum esse dixit.
-		</div>
-	</Tiles>
-);
-
-export const Columns2: StoryFn<typeof Tiles> = Template.bind({});
-Columns2.args = {
-	columns: 2,
-};
-
-// *****************************************************************************
-
-export const Columns3: StoryFn<typeof Tiles> = Template.bind({});
-Columns3.args = {
-	columns: 3,
-};
-
-// *****************************************************************************
-
-export const Columns4: StoryFn<typeof Tiles> = Template.bind({});
-Columns4.args = {
-	columns: 4,
-};
-
-// *****************************************************************************
-
-export const Columns5: StoryFn<typeof Tiles> = Template.bind({});
-Columns5.args = {
-	columns: 5,
-};
-
-// *****************************************************************************
-
-export const Columns5CollapseUntilTabletAtMobile: StoryFn<typeof Tiles> =
-	Template.bind({});
-Columns5CollapseUntilTabletAtMobile.args = {
-	columns: 5,
-	collapseUntil: 'tablet',
-};
-Columns5CollapseUntilTabletAtMobile.parameters = {
-	viewport: { defaultViewport: 'mobile' },
-	chromatic: {
-		viewports: [breakpoints.mobile],
+export const Columns3: Story = {
+	...TilesTemplate,
+	args: {
+		columns: 3,
 	},
 };
 
-// *****************************************************************************
-
-export const Columns5CollapseUntilTabletAtTablet: StoryFn<typeof Tiles> =
-	Template.bind({});
-Columns5CollapseUntilTabletAtTablet.args = {
-	columns: 5,
-	collapseUntil: 'tablet',
+export const Columns4: Story = {
+	...TilesTemplate,
+	args: {
+		columns: 4,
+	},
 };
-Columns5CollapseUntilTabletAtTablet.parameters = {
-	viewport: { defaultViewport: 'tablet' },
-	chromatic: {
-		viewports: [breakpoints.tablet],
+
+export const Columns5: Story = {
+	...TilesTemplate,
+	args: {
+		columns: 5,
+	},
+};
+
+export const Columns5CollapseUntilTabletAtMobile: Story = {
+	...TilesTemplate,
+	args: {
+		columns: 5,
+		collapseUntil: 'tablet',
+	},
+	parameters: {
+		viewport: { defaultViewport: 'mobile' },
+		chromatic: {
+			viewports: [breakpoints.mobile],
+		},
+	},
+};
+
+export const Columns5CollapseUntilTabletAtTablet: Story = {
+	...TilesTemplate,
+	args: {
+		columns: 5,
+		collapseUntil: 'tablet',
+	},
+	parameters: {
+		viewport: { defaultViewport: 'tablet' },
+		chromatic: {
+			viewports: [breakpoints.tablet],
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/user-feedback/InlineError.stories.tsx
+++ b/libs/@guardian/source/src/react-components/user-feedback/InlineError.stories.tsx
@@ -1,8 +1,7 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { breakpoints, palette } from '../../foundations';
-import type { UserFeedbackProps } from './@types/UserFeedbackProps';
 import { InlineError } from './InlineError';
-import { userFeedbackThemeBrand } from './theme';
+import { themeUserFeedbackBrand } from './theme';
 
 const meta: Meta<typeof InlineError> = {
 	title: 'React Components/InlineError',
@@ -13,74 +12,73 @@ const meta: Meta<typeof InlineError> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof InlineError>;
 
-const Template: StoryFn<typeof InlineError> = ({
-	children,
-	...args
-}: UserFeedbackProps) => (
-	<InlineError {...args}>{children ?? 'Please enter your name'}</InlineError>
-);
-
-export const InlineErrorDefaultTheme: StoryFn<typeof InlineError> =
-	Template.bind({});
-
-// *****************************************************************************
-
-export const InlineErrorBrandTheme: StoryFn<typeof InlineError> = Template.bind(
-	{},
-);
-InlineErrorBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
-	},
-	theme: userFeedbackThemeBrand,
+const InlineErrorTemplate: Story = {
+	render: (args) => (
+		<InlineError {...args}>
+			{args.children ?? 'Please enter your name'}
+		</InlineError>
+	),
 };
 
-// *****************************************************************************
+export const InlineErrorDefaultTheme: Story = {
+	...InlineErrorTemplate,
+};
 
-export const LongInlineErrorDefaultThemeMobile: StoryFn<typeof InlineError> =
-	Template.bind({});
-LongInlineErrorDefaultThemeMobile.parameters = {
-	viewport: { defaultViewport: 'mobileMedium' },
-	chromatic: {
-		viewports: [breakpoints.mobileMedium],
+export const InlineErrorBrandTheme: Story = {
+	...InlineErrorTemplate,
+	args: {
+		theme: themeUserFeedbackBrand,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
 	},
 };
-LongInlineErrorDefaultThemeMobile.args = {
-	children: 'Please pick a date in the future, but not a leap year',
-};
 
-// *****************************************************************************
-
-export const InlineErrorSmallDefaultTheme: StoryFn<typeof InlineError> =
-	Template.bind({});
-InlineErrorSmallDefaultTheme.args = {
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const InlineErrorSmallBrandTheme: StoryFn<typeof InlineError> =
-	Template.bind({});
-InlineErrorSmallBrandTheme.args = {
-	size: 'small',
-};
-InlineErrorSmallBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const LongInlineErrorDefaultThemeMobile: Story = {
+	...InlineErrorTemplate,
+	args: {
+		children: 'Please pick a date in the future, but not a leap year',
 	},
-	theme: userFeedbackThemeBrand,
+	parameters: {
+		viewport: { defaultViewport: 'mobileMedium' },
+		chromatic: {
+			viewports: [breakpoints.mobileMedium],
+		},
+	},
 };
 
-// *****************************************************************************
-
-export const InlineErrorCustomTheme: StoryFn<typeof InlineError> =
-	Template.bind({});
-InlineErrorCustomTheme.args = {
-	theme: { textError: palette.error[500] },
+export const InlineErrorSmallDefaultTheme: Story = {
+	...InlineErrorTemplate,
+	args: {
+		size: 'small',
+	},
 };
-InlineErrorCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const InlineErrorSmallBrandTheme: Story = {
+	...InlineErrorTemplate,
+	args: {
+		size: 'small',
+		theme: themeUserFeedbackBrand,
+	},
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
+	},
+};
+
+export const InlineErrorCustomTheme: Story = {
+	...InlineErrorTemplate,
+	args: {
+		theme: { textError: palette.error[500] },
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/user-feedback/InlineError.stories.tsx
+++ b/libs/@guardian/source/src/react-components/user-feedback/InlineError.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof InlineError> = {
 export default meta;
 type Story = StoryObj<typeof InlineError>;
 
-const InlineErrorTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<InlineError {...args}>
 			{args.children ?? 'Please enter your name'}
@@ -23,11 +23,11 @@ const InlineErrorTemplate: Story = {
 };
 
 export const InlineErrorDefaultTheme: Story = {
-	...InlineErrorTemplate,
+	...Template,
 };
 
 export const InlineErrorBrandTheme: Story = {
-	...InlineErrorTemplate,
+	...Template,
 	args: {
 		theme: themeUserFeedbackBrand,
 	},
@@ -39,7 +39,7 @@ export const InlineErrorBrandTheme: Story = {
 };
 
 export const LongInlineErrorDefaultThemeMobile: Story = {
-	...InlineErrorTemplate,
+	...Template,
 	args: {
 		children: 'Please pick a date in the future, but not a leap year',
 	},
@@ -52,14 +52,14 @@ export const LongInlineErrorDefaultThemeMobile: Story = {
 };
 
 export const InlineErrorSmallDefaultTheme: Story = {
-	...InlineErrorTemplate,
+	...Template,
 	args: {
 		size: 'small',
 	},
 };
 
 export const InlineErrorSmallBrandTheme: Story = {
-	...InlineErrorTemplate,
+	...Template,
 	args: {
 		size: 'small',
 		theme: themeUserFeedbackBrand,
@@ -72,7 +72,7 @@ export const InlineErrorSmallBrandTheme: Story = {
 };
 
 export const InlineErrorCustomTheme: Story = {
-	...InlineErrorTemplate,
+	...Template,
 	args: {
 		theme: { textError: palette.error[500] },
 	},

--- a/libs/@guardian/source/src/react-components/user-feedback/InlineError.stories.tsx
+++ b/libs/@guardian/source/src/react-components/user-feedback/InlineError.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { breakpoints, palette } from '../../foundations';
 import { InlineError } from './InlineError';
 import { themeUserFeedbackBrand } from './theme';

--- a/libs/@guardian/source/src/react-components/user-feedback/InlineError.stories.tsx
+++ b/libs/@guardian/source/src/react-components/user-feedback/InlineError.stories.tsx
@@ -14,21 +14,15 @@ const meta: Meta<typeof InlineError> = {
 export default meta;
 type Story = StoryObj<typeof InlineError>;
 
-const Template: Story = {
-	render: (args) => (
-		<InlineError {...args}>
-			{args.children ?? 'Please enter your name'}
-		</InlineError>
-	),
-};
-
 export const InlineErrorDefaultTheme: Story = {
-	...Template,
+	args: {
+		children: 'Please enter your name',
+	},
 };
 
 export const InlineErrorBrandTheme: Story = {
-	...Template,
 	args: {
+		...InlineErrorDefaultTheme.args,
 		theme: themeUserFeedbackBrand,
 	},
 	parameters: {
@@ -39,8 +33,8 @@ export const InlineErrorBrandTheme: Story = {
 };
 
 export const LongInlineErrorDefaultThemeMobile: Story = {
-	...Template,
 	args: {
+		...InlineErrorDefaultTheme.args,
 		children: 'Please pick a date in the future, but not a leap year',
 	},
 	parameters: {
@@ -52,28 +46,25 @@ export const LongInlineErrorDefaultThemeMobile: Story = {
 };
 
 export const InlineErrorSmallDefaultTheme: Story = {
-	...Template,
 	args: {
+		...InlineErrorDefaultTheme.args,
 		size: 'small',
 	},
 };
 
 export const InlineErrorSmallBrandTheme: Story = {
-	...Template,
 	args: {
+		...InlineErrorBrandTheme.args,
 		size: 'small',
-		theme: themeUserFeedbackBrand,
 	},
 	parameters: {
-		backgrounds: {
-			default: 'brandBackground.primary',
-		},
+		...InlineErrorBrandTheme.parameters,
 	},
 };
 
 export const InlineErrorCustomTheme: Story = {
-	...Template,
 	args: {
+		...InlineErrorDefaultTheme.args,
 		theme: { textError: palette.error[500] },
 	},
 	parameters: {

--- a/libs/@guardian/source/src/react-components/user-feedback/InlineSuccess.stories.tsx
+++ b/libs/@guardian/source/src/react-components/user-feedback/InlineSuccess.stories.tsx
@@ -1,4 +1,4 @@
-import type { StoryObj, Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { palette } from '../../foundations';
 import { InlineSuccess } from './InlineSuccess';
 import { themeUserFeedbackBrand } from './theme';

--- a/libs/@guardian/source/src/react-components/user-feedback/InlineSuccess.stories.tsx
+++ b/libs/@guardian/source/src/react-components/user-feedback/InlineSuccess.stories.tsx
@@ -1,8 +1,7 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { palette } from '../../foundations';
-import type { UserFeedbackProps } from './@types/UserFeedbackProps';
 import { InlineSuccess } from './InlineSuccess';
-import { userFeedbackThemeBrand } from './theme';
+import { themeUserFeedbackBrand } from './theme';
 
 const meta: Meta<typeof InlineSuccess> = {
 	title: 'React Components/InlineSuccess',
@@ -13,56 +12,59 @@ const meta: Meta<typeof InlineSuccess> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof InlineSuccess>;
 
-const Template: StoryFn<typeof InlineSuccess> = (args: UserFeedbackProps) => (
-	<InlineSuccess {...args}>Your voucher code is valid</InlineSuccess>
-);
+const InlineSuccessTemplate: Story = {
+	render: (args) => (
+		<InlineSuccess {...args}>Your voucher code is valid</InlineSuccess>
+	),
+};
 
-export const InlineSuccessDefaultTheme: StoryFn<typeof InlineSuccess> =
-	Template.bind({});
+export const InlineSuccessDefaultTheme: Story = {
+	...InlineSuccessTemplate,
+};
 
-// *****************************************************************************
-
-export const InlineSuccessBrandTheme: StoryFn<typeof InlineSuccess> =
-	Template.bind({});
-InlineSuccessBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+export const InlineSuccessBrandTheme: Story = {
+	...InlineSuccessTemplate,
+	args: {
+		theme: themeUserFeedbackBrand,
 	},
-	theme: userFeedbackThemeBrand,
-};
-
-// *****************************************************************************
-
-export const InlineSuccessSmallDefaultTheme: StoryFn<typeof InlineSuccess> =
-	Template.bind({});
-InlineSuccessSmallDefaultTheme.args = {
-	size: 'small',
-};
-
-// *****************************************************************************
-
-export const InlineSuccessSmallBrandTheme: StoryFn<typeof InlineSuccess> =
-	Template.bind({});
-InlineSuccessSmallBrandTheme.args = {
-	size: 'small',
-};
-InlineSuccessSmallBrandTheme.parameters = {
-	backgrounds: {
-		default: 'brandBackground.primary',
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
 	},
-	theme: userFeedbackThemeBrand,
 };
 
-// *****************************************************************************
-
-export const InlineSuccessCustomTheme: StoryFn<typeof InlineSuccess> =
-	Template.bind({});
-InlineSuccessCustomTheme.args = {
-	theme: { textSuccess: palette.success[500] },
+export const InlineSuccessSmallDefaultTheme: Story = {
+	...InlineSuccessTemplate,
+	args: {
+		size: 'small',
+	},
 };
-InlineSuccessCustomTheme.parameters = {
-	backgrounds: {
-		default: 'background.inverse',
+
+export const InlineSuccessSmallBrandTheme: Story = {
+	...InlineSuccessTemplate,
+	args: {
+		size: 'small',
+		theme: themeUserFeedbackBrand,
+	},
+
+	parameters: {
+		backgrounds: {
+			default: 'brandBackground.primary',
+		},
+	},
+};
+
+export const InlineSuccessCustomTheme: Story = {
+	...InlineSuccessTemplate,
+	args: {
+		theme: { textSuccess: palette.success[500] },
+	},
+	parameters: {
+		backgrounds: {
+			default: 'background.inverse',
+		},
 	},
 };

--- a/libs/@guardian/source/src/react-components/user-feedback/InlineSuccess.stories.tsx
+++ b/libs/@guardian/source/src/react-components/user-feedback/InlineSuccess.stories.tsx
@@ -14,19 +14,15 @@ const meta: Meta<typeof InlineSuccess> = {
 export default meta;
 type Story = StoryObj<typeof InlineSuccess>;
 
-const Template: Story = {
-	render: (args) => (
-		<InlineSuccess {...args}>Your voucher code is valid</InlineSuccess>
-	),
-};
-
 export const InlineSuccessDefaultTheme: Story = {
-	...Template,
+	args: {
+		children: 'Your voucher code is valid',
+	},
 };
 
 export const InlineSuccessBrandTheme: Story = {
-	...Template,
 	args: {
+		...InlineSuccessDefaultTheme.args,
 		theme: themeUserFeedbackBrand,
 	},
 	parameters: {
@@ -37,29 +33,26 @@ export const InlineSuccessBrandTheme: Story = {
 };
 
 export const InlineSuccessSmallDefaultTheme: Story = {
-	...Template,
 	args: {
+		...InlineSuccessDefaultTheme.args,
 		size: 'small',
 	},
 };
 
 export const InlineSuccessSmallBrandTheme: Story = {
-	...Template,
 	args: {
+		...InlineSuccessBrandTheme.args,
 		size: 'small',
-		theme: themeUserFeedbackBrand,
 	},
 
 	parameters: {
-		backgrounds: {
-			default: 'brandBackground.primary',
-		},
+		...InlineSuccessBrandTheme.parameters,
 	},
 };
 
 export const InlineSuccessCustomTheme: Story = {
-	...Template,
 	args: {
+		...InlineSuccessDefaultTheme.args,
 		theme: { textSuccess: palette.success[500] },
 	},
 	parameters: {

--- a/libs/@guardian/source/src/react-components/user-feedback/InlineSuccess.stories.tsx
+++ b/libs/@guardian/source/src/react-components/user-feedback/InlineSuccess.stories.tsx
@@ -14,18 +14,18 @@ const meta: Meta<typeof InlineSuccess> = {
 export default meta;
 type Story = StoryObj<typeof InlineSuccess>;
 
-const InlineSuccessTemplate: Story = {
+const Template: Story = {
 	render: (args) => (
 		<InlineSuccess {...args}>Your voucher code is valid</InlineSuccess>
 	),
 };
 
 export const InlineSuccessDefaultTheme: Story = {
-	...InlineSuccessTemplate,
+	...Template,
 };
 
 export const InlineSuccessBrandTheme: Story = {
-	...InlineSuccessTemplate,
+	...Template,
 	args: {
 		theme: themeUserFeedbackBrand,
 	},
@@ -37,14 +37,14 @@ export const InlineSuccessBrandTheme: Story = {
 };
 
 export const InlineSuccessSmallDefaultTheme: Story = {
-	...InlineSuccessTemplate,
+	...Template,
 	args: {
 		size: 'small',
 	},
 };
 
 export const InlineSuccessSmallBrandTheme: Story = {
-	...InlineSuccessTemplate,
+	...Template,
 	args: {
 		size: 'small',
 		theme: themeUserFeedbackBrand,
@@ -58,7 +58,7 @@ export const InlineSuccessSmallBrandTheme: Story = {
 };
 
 export const InlineSuccessCustomTheme: Story = {
-	...InlineSuccessTemplate,
+	...Template,
 	args: {
 		theme: { textSuccess: palette.success[500] },
 	},


### PR DESCRIPTION
## What are you changing?

- Converts Source React Components stories to [Component Story Format](https://storybook.js.org/docs/api/csf)
- This _does not_ include icon stories as this has been done in #1562

## Why?

- This is the recommended way to write stories and should make upgrading to newer releases of Storybook simpler
- It's an [open format](https://github.com/ComponentDriven/csf) that can be used outside of Storybook
- It's simpler and removes boilerplate code. (For single component stories there's no need to explicitly render the component and pass args—this happens automatically.)
