### PR TITLE
Add 15px variations for headline typography presets

### DIFF
--- a/.changeset/quiet-brooms-fail.md
+++ b/.changeset/quiet-brooms-fail.md
@@ -3,4 +3,4 @@
 '@guardian/source': minor
 ---
 
-Adds `headlineBold15`, `headlineLight15`, `headlineMedium15` and `headlineMediumItalic15` to the typography presets
+Adds `headlineBold15`, `headlineLight15`, `headlineLightItalic15`, `headlineMedium15` and `headlineMediumItalic15` to the typography presets

--- a/libs/@guardian/design-tokens/__generated__/tokens.d.ts
+++ b/libs/@guardian/design-tokens/__generated__/tokens.d.ts
@@ -845,6 +845,18 @@ export declare const typographyPresets: {
 		readonly fontWeight: 300;
 		readonly fontStyle: 'italic';
 	};
+	readonly headlineLightItalic15: {
+		readonly fontFamily: readonly [
+			'GH Guardian Headline',
+			'Guardian Egyptian Web',
+			'Georgia',
+			'serif',
+		];
+		readonly fontSize: '15px';
+		readonly lineHeight: 1.15;
+		readonly fontWeight: 300;
+		readonly fontStyle: 'italic';
+	};
 	readonly headlineLightItalic17: {
 		readonly fontFamily: readonly [
 			'GH Guardian Headline',

--- a/libs/@guardian/design-tokens/__generated__/tokens.js
+++ b/libs/@guardian/design-tokens/__generated__/tokens.js
@@ -829,6 +829,18 @@ export const typographyPresets = {
 		fontWeight: 300,
 		fontStyle: 'italic',
 	},
+	headlineLightItalic15: {
+		fontFamily: [
+			'GH Guardian Headline',
+			'Guardian Egyptian Web',
+			'Georgia',
+			'serif',
+		],
+		fontSize: '15px',
+		lineHeight: 1.15,
+		fontWeight: 300,
+		fontStyle: 'italic',
+	},
 	headlineLightItalic17: {
 		fontFamily: [
 			'GH Guardian Headline',

--- a/libs/@guardian/design-tokens/__generated__/variables.css
+++ b/libs/@guardian/design-tokens/__generated__/variables.css
@@ -797,6 +797,19 @@
 	--source-typographyPresets-headlineLightItalic14-line-height: var(
 		--source-typography-lineHeight-tight
 	);
+	--source-typographyPresets-headlineLightItalic15-font-family: var(
+		--source-typography-fontFamily-headline
+	);
+	--source-typographyPresets-headlineLightItalic15-font-size: var(
+		--source-typography-fontSize-15
+	);
+	--source-typographyPresets-headlineLightItalic15-font-style: italic;
+	--source-typographyPresets-headlineLightItalic15-font-weight: var(
+		--source-typography-fontWeight-light
+	);
+	--source-typographyPresets-headlineLightItalic15-line-height: var(
+		--source-typography-lineHeight-tight
+	);
 	--source-typographyPresets-headlineLightItalic17-font-family: var(
 		--source-typography-fontFamily-headline
 	);

--- a/libs/@guardian/design-tokens/src/tokens.json
+++ b/libs/@guardian/design-tokens/src/tokens.json
@@ -950,6 +950,15 @@
 				"fontStyle": "italic"
 			}
 		},
+		"headlineLightItalic15": {
+			"$value": {
+				"fontFamily": "{typography.fontFamily.headline}",
+				"fontSize": "{typography.fontSize.15}",
+				"lineHeight": "{typography.lineHeight.tight}",
+				"fontWeight": "{typography.fontWeight.light}",
+				"fontStyle": "italic"
+			}
+		},
 		"headlineLightItalic17": {
 			"$value": {
 				"fontFamily": "{typography.fontFamily.headline}",

--- a/libs/@guardian/source/src/foundations/__generated__/typography/css.ts
+++ b/libs/@guardian/source/src/foundations/__generated__/typography/css.ts
@@ -263,6 +263,15 @@ export const headlineLightItalic14 = `
 	--source-text-decoration-thickness: 2px;
 `;
 
+export const headlineLightItalic15 = `
+	font-family: "GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
+	font-size: 0.9375rem;
+	line-height: 1.15;
+	font-weight: 300;
+	font-style: italic;
+	--source-text-decoration-thickness: 2px;
+`;
+
 export const headlineLightItalic17 = `
 	font-family: "GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif;
 	font-size: 1.0625rem;

--- a/libs/@guardian/source/src/foundations/__generated__/typography/objects.ts
+++ b/libs/@guardian/source/src/foundations/__generated__/typography/objects.ts
@@ -242,6 +242,14 @@ export const headlineLightItalic14Object = {
 	fontStyle: 'italic',
 } as const;
 
+export const headlineLightItalic15Object = {
+	fontFamily: '"GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif',
+	fontSize: '0.9375rem',
+	lineHeight: 1.15,
+	fontWeight: 300,
+	fontStyle: 'italic',
+} as const;
+
 export const headlineLightItalic17Object = {
 	fontFamily: '"GH Guardian Headline", "Guardian Egyptian Web", Georgia, serif',
 	fontSize: '1.0625rem',

--- a/libs/@guardian/source/src/foundations/index.test.ts
+++ b/libs/@guardian/source/src/foundations/index.test.ts
@@ -113,6 +113,8 @@ it('Should have exactly these exports', () => {
 		'headlineLight64Object',
 		'headlineLightItalic14',
 		'headlineLightItalic14Object',
+		'headlineLightItalic15',
+		'headlineLightItalic15Object',
 		'headlineLightItalic17',
 		'headlineLightItalic17Object',
 		'headlineLightItalic20',


### PR DESCRIPTION
## What are you changing?

Adds the following to the typography presets:
 - `headlineBold15`
 - `headlineLight15`
 - `headlineLightItalic15`
 - `headlineMedium15`
 - `headlineMediumItalic15`

## Why?

- These styles already exist in the [design system](https://theguardian.design/2a1e5182b/p/01555f-typography-presets) and are required for some upcoming changes to DCR
