### PR TITLE
Remove the offset text underline styles for `Link`

### DIFF
--- a/libs/@guardian/source/src/react-components/link/styles.ts
+++ b/libs/@guardian/source/src/react-components/link/styles.ts
@@ -13,8 +13,6 @@ export const link = css`
 	${textSans17};
 	cursor: pointer;
 	text-decoration: underline;
-	text-underline-position: under;
-	text-underline-offset: 5%;
 
 	display: inline;
 	align-items: center;


### PR DESCRIPTION
## What are you changing?

- Removes the styles that offset the underline on `Link` components

## Why?

- Better alignment between all platforms, and agreed by the Design Systems team
