### PR TITLE
Remove `ArticleDesign.PrintShop`

### DIFF
--- a/.changeset/nine-doors-sing.md
+++ b/.changeset/nine-doors-sing.md
@@ -1,0 +1,33 @@
+---
+'@guardian/libs': major
+---
+
+Removes `ArticleDesign.PrintShop`, as we no longer intend to handle this as a separate `ArticleDesign`.
+
+This is a breaking change because it removes this member from the `enum`. Therefore any code the depends on this member will need to be updated.
+
+For example, in a `switch` the `case` will need to be removed:
+
+```
+switch (design) {
+    case ArticleDesign.Standard:
+      // Other code
+    case ArticleDesign.PrintShop:
+      // This case will need to be removed
+}
+```
+
+Any code that stores the enum members directly, such as a fixture, will also need to be updated:
+
+```
+{
+    ...
+    format: {
+        // With PrintShop removed, 20 will now refer to Obituary
+        design: 20,
+        ...
+    }
+}
+```
+
+Consideration will need to be given to what `ArticleDesign` will now be used for articles that were previously `PrintShop`. This is handled in the CAPI client for frontend/DCAR, and in AR itself for AR.

--- a/libs/@guardian/libs/src/format/ArticleDesign.ts
+++ b/libs/@guardian/libs/src/format/ArticleDesign.ts
@@ -19,7 +19,6 @@ export enum ArticleDesign {
 	Quiz,
 	Interactive,
 	PhotoEssay,
-	PrintShop,
 	Obituary,
 	Correction,
 	FullPageInteractive,


### PR DESCRIPTION
We no longer intend to handle this as a separate `ArticleDesign`. Anything that was previously `PrintShop` will now be one of the other `ArticleDesign`s. This change will require updates in DCAR and AR.

This is a breaking change because it removes this member from the `enum`. Therefore any code the depends on this member will need to be updated.

For example, in a `switch` the `case` will need to be removed:

```ts
switch (design) {
    case ArticleDesign.Standard:
      // Other code
    case ArticleDesign.PrintShop:
      // This case will need to be removed
}
```

Any code that stores the enum members directly, such as a fixture, will also need to be updated:

```
{
    ...
    format: {
        // With PrintShop removed, 20 will now refer to Obituary
        design: 20,
        ...
    }
}
```

Consideration will need to be given to what `ArticleDesign` will now be used for articles that were previously `PrintShop`. This is handled in the CAPI client for frontend/DCAR, and in AR itself for AR.
