### PR TITLE
Banner padding tweaks

### DIFF
--- a/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
@@ -38,7 +38,8 @@ const tickerContainerStyles = css`
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	padding: ${space[2]}px ${space[4]}px ${space[2]}px ${space[5]}px;
+	padding-bottom: ${space[5]}px;
+	padding-top: ${space[1]}px;
 `;
 
 //styles for headline text (which is optional)


### PR DESCRIPTION
## What are you changing?

Banner was added to the development source kitchen as part of [this PR.](https://github.com/guardian/csnx/pull/1653) However it's been noticed in further testing that the padding is quite off. This PR is to update the default padding of the Ticker.
