### PR TITLE
Temporarily disable `@stylistic` plugin in `eslint-config`

### DIFF
--- a/libs/@guardian/eslint-config/CHANGELOG.md
+++ b/libs/@guardian/eslint-config/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @guardian/eslint-config
 
+## 10.0.0-beta.1
+
+### Changes
+
+Temporarily removes `@stylistic/member-delimiter-style`, as installing it alongside `@eslint/compat` creates a types
+clash in `node_modules`. This will be re-added in a future release.
+
+https://github.com/eslint/rewrite/issues/104
+
 ## 10.0.0-beta.0
 
 ### Major Changes
@@ -14,7 +23,8 @@ It also includes configs for `jest`, `storybook` and `react`.
 
 See the [README](README.md) for full details.
 
-> ESLint 9 contains a lot of breaking changes, including a new config format. See their [migration guide](https://eslint.org/docs/latest/use/migrate-to-9.0.0) for more details.
+> ESLint 9 contains a lot of breaking changes, including a new config format. See
+> their [migration guide](https://eslint.org/docs/latest/use/migrate-to-9.0.0) for more details.
 >
 > Note that [ESLint 8 is EOL 2024-10-05](https://eslint.org/version-support/).
 
@@ -33,7 +43,9 @@ See the [README](README.md) for full details.
 
 ### Patch Changes
 
-- 0382052: 1. All packages are now ES modules, although they should be compatible with CommonJS environments. 2. Adds entry points for projects that can consume [`package.json#exports`](https://nodejs.org/api/packages.html#exports), alongside `main`.
+- 0382052: 1. All packages are now ES modules, although they should be compatible with CommonJS environments. 2. Adds
+  entry points for projects that can consume [`package.json#exports`](https://nodejs.org/api/packages.html#exports),
+  alongside `main`.
 
 ## 8.0.0
 
@@ -41,9 +53,11 @@ See the [README](README.md) for full details.
 
 - cc7aa7d: Requires curly braces in all circumstances.
 
-  This should help reduce noise in diffs, and remove ambiguity about when you should use curly braces (and possibly when a block starts and ends), especially for people unfamiliar with the language.
+  This should help reduce noise in diffs, and remove ambiguity about when you should use curly braces (and possibly when
+  a block starts and ends), especially for people unfamiliar with the language.
 
-  _Note that this rule is fixable, so running eslint with the `--fix` flag will automatically update your code to comply with the new setting._
+  _Note that this rule is fixable, so running eslint with the `--fix` flag will automatically update your code to comply
+  with the new setting._
 
 ## 7.0.1
 
@@ -64,7 +78,8 @@ See the [README](README.md) for full details.
 
 ### Major Changes
 
-- 9e0cb43: `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` dependencies upgraded to next major version (6).
+- 9e0cb43: `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` dependencies upgraded to next major
+  version (6).
 
 ## 5.0.0
 
@@ -122,14 +137,17 @@ See the [README](README.md) for full details.
 
   We extended `plugin:prettier/recommended` which
 
-  1. used `eslint-config-prettier` to disable any white-space formatting rules that would conflict with our prettier config
-  2. used `eslint-plugin-prettier` to lint for formatting errors that did not match our prettier config
+  1.  used `eslint-config-prettier` to disable any white-space formatting rules that would conflict with our prettier
+      config
+  2.  used `eslint-plugin-prettier` to lint for formatting errors that did not match our prettier config
 
-  This is quite expensive, and although it means you could use `--fix` to apply prettier, it's not as fast as using prettier directly.
+  This is quite expensive, and although it means you could use `--fix` to apply prettier, it's not as fast as using
+  prettier directly.
 
   ### After
 
-  We still use `eslint-config-prettier` to avoid conflicts with our `prettier` config, but we no longer lint for errors (and therefore also don't fix them).
+  We still use `eslint-config-prettier` to avoid conflicts with our `prettier` config, but we no longer lint for
+  errors (and therefore also don't fix them).
 
   ### Recommendations
 
@@ -138,7 +156,8 @@ See the [README](README.md) for full details.
   - via [editor integration](https://prettier.io/docs/en/editors.html)
   - via a [pre-commit hook](https://prettier.io/docs/en/precommit.html)
 
-  If you prefer the way this used to work (applying `prettier` formatting as part of linting), add the [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier) manually to your ESLint config.
+  If you prefer the way this used to work (applying `prettier` formatting as part of linting), add
+  the [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier) manually to your ESLint config.
 
 ## 1.0.2
 

--- a/libs/@guardian/eslint-config/configs/javascript.base.js
+++ b/libs/@guardian/eslint-config/configs/javascript.base.js
@@ -1,10 +1,12 @@
 import js from '@eslint/js';
-import stylistic from '@stylistic/eslint-plugin';
+// import stylistic from '@stylistic/eslint-plugin';
 
 export default {
 	name: '@guardian/javascript',
 	plugins: {
-		'@stylistic': stylistic,
+		// this currently creates a types clash in node_modules so disable this for now
+		// https://github.com/eslint/rewrite/issues/104
+		// '@stylistic': stylistic,
 	},
 	rules: {
 		...js.configs.recommended.rules,
@@ -14,18 +16,18 @@ export default {
 
 		// delimit members with semi-colons and require
 		// one at the end to keep diffs simpler
-		'@stylistic/member-delimiter-style': [
-			2,
-			{
-				multiline: {
-					delimiter: 'semi',
-					requireLast: true,
-				},
-				singleline: {
-					delimiter: 'semi',
-					requireLast: false,
-				},
-			},
-		],
+		// '@stylistic/member-delimiter-style': [
+		// 	2,
+		// 	{
+		// 		multiline: {
+		// 			delimiter: 'semi',
+		// 			requireLast: true,
+		// 		},
+		// 		singleline: {
+		// 			delimiter: 'semi',
+		// 			requireLast: false,
+		// 		},
+		// 	},
+		// ],
 	},
 };

--- a/libs/@guardian/eslint-config/package.json
+++ b/libs/@guardian/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/eslint-config",
-	"version": "10.0.0-beta.0",
+	"version": "10.0.0-beta.1",
 	"description": "ESLint config for Guardian JavaScript projects",
 	"type": "module",
 	"main": "index.js",
@@ -11,7 +11,6 @@
 	"dependencies": {
 		"@eslint/compat": "1.1.1",
 		"@eslint/js": "9.9.1",
-		"@stylistic/eslint-plugin": "2.6.4",
 		"eslint-config-prettier": "9.1.0",
 		"eslint-import-resolver-typescript": "3.6.3",
 		"eslint-plugin-eslint-comments": "3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,9 +332,6 @@ importers:
       '@eslint/js':
         specifier: 9.9.1
         version: 9.9.1
-      '@stylistic/eslint-plugin':
-        specifier: 2.6.4
-        version: 2.6.4(eslint@9.9.0)(typescript@5.5.2)
       eslint-config-prettier:
         specifier: 9.1.0
         version: 9.1.0(eslint@9.9.0)
@@ -4442,22 +4439,6 @@ packages:
       espree: 10.1.0
     dev: true
 
-  /@stylistic/eslint-plugin-js@2.6.4(eslint@9.9.0):
-    resolution: {integrity: sha512-kx1hS3xTvzxZLdr/DCU/dLBE++vcP97sHeEFX2QXhk1Ipa4K1rzPOLw1HCbf4mU3s+7kHP5eYpDe+QteEOFLug==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: '>=8.40.0'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-    dependencies:
-      '@types/eslint': 9.6.0
-      acorn: 8.12.1
-      eslint: 9.9.0
-      eslint-visitor-keys: 4.0.0
-      espree: 10.1.0
-    dev: false
-
   /@stylistic/eslint-plugin-jsx@2.6.2(eslint@8.57.0):
     resolution: {integrity: sha512-dSXK/fSPA938J1fBi10QmhzLKtZ/2TuyVNHQMk8jUhWfKJDleAogaSqcWNAbN8fwcoe9UWmt/3StiIf2oYC1aQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4474,24 +4455,6 @@ packages:
       picomatch: 4.0.2
     dev: true
 
-  /@stylistic/eslint-plugin-jsx@2.6.4(eslint@9.9.0):
-    resolution: {integrity: sha512-bIvVhdtjmyu3S10V7QRIuawtCZSq9gRmzAX23ucjCOdSFzEwlq+di0IM0riBAvvQerrJL4SM6G3xgyPs8BSXIA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: '>=8.40.0'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-    dependencies:
-      '@stylistic/eslint-plugin-js': 2.6.4(eslint@9.9.0)
-      '@types/eslint': 9.6.0
-      eslint: 9.9.0
-      eslint-visitor-keys: 4.0.0
-      espree: 10.1.0
-      estraverse: 5.3.0
-      picomatch: 4.0.2
-    dev: false
-
   /@stylistic/eslint-plugin-plus@2.6.2(eslint@8.57.0)(typescript@5.5.2):
     resolution: {integrity: sha512-cANcPASfRvq3VTbbQCrSIXq+2AI0IW68PNYaZoXXS0ENlp7HDB8dmrsJnOgWCcoEvdCB8z/eWcG/eq/v5Qcl+Q==}
     peerDependencies:
@@ -4507,18 +4470,6 @@ packages:
       - supports-color
       - typescript
     dev: true
-
-  /@stylistic/eslint-plugin-plus@2.6.4(eslint@9.9.0):
-    resolution: {integrity: sha512-EuRvtxhf7Hv8OoMIePulP/6rBJIgPTu1l5GAm1780WcF1Cl8bOZXIn84Pdac5pNv6lVlzCOFm8MD3VE+2YROuA==}
-    peerDependencies:
-      eslint: '*'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-    dependencies:
-      '@types/eslint': 9.6.0
-      eslint: 9.9.0
-    dev: false
 
   /@stylistic/eslint-plugin-ts@2.6.2(eslint@8.57.0)(typescript@5.5.2):
     resolution: {integrity: sha512-6OEN3VtUNxjgOvWPavnC10MByr1H4zsgwNND3rQXr5lDFv93MLUnTsH+/SH15OkuqdyJgrQILI6b9lYecb1vIg==}
@@ -4537,24 +4488,6 @@ packages:
       - supports-color
       - typescript
     dev: true
-
-  /@stylistic/eslint-plugin-ts@2.6.4(eslint@9.9.0)(typescript@5.5.2):
-    resolution: {integrity: sha512-yxL8Hj6WkObw1jfiLpBzKy5yfxY6vwlwO4miq34ySErUjUecPV5jxfVbOe4q1QDPKemQGPq93v7sAQS5PzM8lA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: '>=8.40.0'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-    dependencies:
-      '@stylistic/eslint-plugin-js': 2.6.4(eslint@9.9.0)
-      '@types/eslint': 9.6.0
-      '@typescript-eslint/utils': 8.1.0(eslint@9.9.0)(typescript@5.5.2)
-      eslint: 9.9.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: false
 
   /@stylistic/eslint-plugin@2.6.2(eslint@8.57.0)(typescript@5.5.2):
     resolution: {integrity: sha512-Ic5oFNM/25iuagob6LiIBkSI/A2y45TsyKtDtODXHRZDy52WfPfeexI6r+OH5+aWN9QGob2Bw+4JRM9/4areWw==}
@@ -4575,26 +4508,6 @@ packages:
       - supports-color
       - typescript
     dev: true
-
-  /@stylistic/eslint-plugin@2.6.4(eslint@9.9.0)(typescript@5.5.2):
-    resolution: {integrity: sha512-euUGnjzH8EOqEYTGk9dB2OBINp0FX1nuO7/k4fO82zNRBIKZgJoDwTLM4Ce+Om6W1Qmh1PrZjCr4jh4tMEXGPQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: '>=8.40.0'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-    dependencies:
-      '@stylistic/eslint-plugin-js': 2.6.4(eslint@9.9.0)
-      '@stylistic/eslint-plugin-jsx': 2.6.4(eslint@9.9.0)
-      '@stylistic/eslint-plugin-plus': 2.6.4(eslint@9.9.0)
-      '@stylistic/eslint-plugin-ts': 2.6.4(eslint@9.9.0)(typescript@5.5.2)
-      '@types/eslint': 9.6.0
-      eslint: 9.9.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: false
 
   /@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1)(svelte@4.2.19)(vite@5.4.2):
     resolution: {integrity: sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==}
@@ -4899,6 +4812,7 @@ packages:
     dependencies:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
+    dev: true
 
   /@types/estree@0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
@@ -5460,25 +5374,6 @@ packages:
       - supports-color
       - typescript
     dev: true
-
-  /@typescript-eslint/utils@8.1.0(eslint@9.9.0)(typescript@5.5.2):
-    resolution: {integrity: sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.0)
-      '@typescript-eslint/scope-manager': 8.1.0
-      '@typescript-eslint/types': 8.1.0
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.5.2)
-      eslint: 9.9.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: false
 
   /@typescript-eslint/utils@8.2.0(eslint@9.9.0)(typescript@5.5.2):
     resolution: {integrity: sha512-O46eaYKDlV3TvAVDNcoDzd5N550ckSe8G4phko++OCSC1dYIb9LTc3HDGYdWqWIAT5qDUKphO6sd9RrpIJJPfg==}
@@ -11843,6 +11738,7 @@ packages:
   /picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
+    dev: true
 
   /pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}


### PR DESCRIPTION
## What are you changing?

Temporarily disabling `@stylistic` plugin in `@guardian/eslint-config`

## Why?

Installing it alongside `@eslint/compat` [creates a types clash in `node_modules`](https://github.com/eslint/rewrite/issues/104).

This unblocks #1668. It will be re-added in a future release.

