### PR TITLE
Set internal devDep versions of `libs` to bottom of peerDep range

### DIFF
--- a/libs/@guardian/core-web-vitals/package.json
+++ b/libs/@guardian/core-web-vitals/package.json
@@ -25,7 +25,7 @@
 		"verify-dist": "wireit"
 	},
 	"devDependencies": {
-		"@guardian/libs": "18.0.2",
+		"@guardian/libs": "18.0.0",
 		"@types/jest": "29.5.8",
 		"jest": "29.7.0",
 		"jest-environment-jsdom": "29.7.0",

--- a/libs/@guardian/identity-auth-frontend/package.json
+++ b/libs/@guardian/identity-auth-frontend/package.json
@@ -27,7 +27,7 @@
 	},
 	"devDependencies": {
 		"@guardian/identity-auth": "3.0.1",
-		"@guardian/libs": "18.0.2",
+		"@guardian/libs": "18.0.0",
 		"@types/jest": "29.5.8",
 		"jest": "29.7.0",
 		"jest-environment-jsdom": "29.7.0",

--- a/libs/@guardian/source-development-kitchen/package.json
+++ b/libs/@guardian/source-development-kitchen/package.json
@@ -27,7 +27,7 @@
 	},
 	"devDependencies": {
 		"@emotion/react": "11.11.3",
-		"@guardian/libs": "18.0.2",
+		"@guardian/libs": "18.0.0",
 		"@guardian/source": "8.0.0",
 		"@storybook/addon-a11y": "8.2.9",
 		"@storybook/addon-essentials": "8.2.9",

--- a/libs/@guardian/source/package.json
+++ b/libs/@guardian/source/package.json
@@ -32,8 +32,7 @@
 		"storybook": "storybook dev --port 4401",
 		"test": "wireit",
 		"tsc": "wireit",
-		"verify-dist": "wireit",
-		"wireit": "storybook build"
+		"verify-dist": "wireit"
 	},
 	"dependencies": {
 		"mini-svg-data-uri": "1.4.4"
@@ -46,7 +45,7 @@
 		"@cobalt-ui/plugin-js": "1.4.3",
 		"@cobalt-ui/utils": "1.2.2",
 		"@emotion/react": "11.11.3",
-		"@guardian/libs": "18.0.2",
+		"@guardian/libs": "workspace:*",
 		"@storybook/addon-a11y": "8.2.9",
 		"@storybook/addon-essentials": "8.2.9",
 		"@storybook/addon-interactions": "8.2.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,8 +258,8 @@ importers:
   libs/@guardian/core-web-vitals:
     devDependencies:
       '@guardian/libs':
-        specifier: 18.0.2
-        version: link:../libs
+        specifier: 18.0.0
+        version: 18.0.0(tslib@2.6.2)(typescript@5.5.2)
       '@types/jest':
         specifier: 29.5.8
         version: 29.5.8
@@ -376,8 +376,8 @@ importers:
         specifier: 3.0.1
         version: link:../identity-auth
       '@guardian/libs':
-        specifier: 18.0.2
-        version: link:../libs
+        specifier: 18.0.0
+        version: 18.0.0(tslib@2.6.2)(typescript@5.5.2)
       '@types/jest':
         specifier: 29.5.8
         version: 29.5.8
@@ -506,7 +506,7 @@ importers:
         specifier: 11.11.3
         version: 11.11.3(@types/react@18.2.79)(react@18.2.0)
       '@guardian/libs':
-        specifier: 18.0.2
+        specifier: workspace:*
         version: link:../libs
       '@storybook/addon-a11y':
         specifier: 8.2.9
@@ -599,8 +599,8 @@ importers:
         specifier: 11.11.3
         version: 11.11.3(@types/react@18.2.79)(react@18.2.0)
       '@guardian/libs':
-        specifier: 18.0.2
-        version: link:../libs
+        specifier: 18.0.0
+        version: 18.0.0(tslib@2.6.2)(typescript@5.5.2)
       '@guardian/source':
         specifier: 8.0.0
         version: link:../source
@@ -3222,6 +3222,19 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: true
+
+  /@guardian/libs@18.0.0(tslib@2.6.2)(typescript@5.5.2):
+    resolution: {integrity: sha512-V/aVeCg3yEDBiw6ykAIRux3HCpORKPAzTReDogg2ZHf8BV0v7P2ysc/etO5TW4+8FVd6X8SpX3GmTP3YePx8FQ==}
+    peerDependencies:
+      tslib: ^2.6.2
+      typescript: ~5.5.2
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      tslib: 2.6.2
+      typescript: 5.5.2
     dev: true
 
   /@humanwhocodes/config-array@0.11.14:


### PR DESCRIPTION
## What are you changing?

- some devDep versions had drifted from the peerDep min version (e.g. #1692), this restores them
- sets the devDep version of `libs` in `source` to workspace version, because it doesn't have a peerDep 

## Why?

- ensures we develop against the lowest version of peerDeps we declare compatibility with
