### PR TITLE
Configurable ticker size

### DIFF
--- a/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.stories.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.stories.tsx
@@ -24,9 +24,7 @@ const Template: StoryFn<typeof Ticker> = (args: TickerSettings) => (
 export const HalfwayContributed: StoryFn<typeof Ticker> = Template.bind({});
 HalfwayContributed.args = {
 	currencySymbol: '£',
-	copy: {
-		countLabel: '',
-	},
+	copy: {},
 	tickerData: {
 		total: 50000,
 		goal: 100000,
@@ -38,7 +36,7 @@ export const SmallDonationsSoFar: StoryFn<typeof Ticker> = Template.bind({});
 SmallDonationsSoFar.args = {
 	currencySymbol: '£',
 	copy: {
-		countLabel: 'Help us reach our end-of-year goal',
+		headline: 'Help us reach our end-of-year goal',
 	},
 	tickerData: {
 		total: 99,
@@ -51,7 +49,7 @@ export const ContributionGoalMet: StoryFn<typeof Ticker> = Template.bind({});
 ContributionGoalMet.args = {
 	currencySymbol: '£',
 	copy: {
-		countLabel: 'Help us reach our end-of-year goal',
+		headline: 'Help us reach our end-of-year goal',
 	},
 	tickerData: {
 		total: 10000000,

--- a/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.stories.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.stories.tsx
@@ -30,6 +30,7 @@ HalfwayContributed.args = {
 		goal: 100000,
 	},
 	tickerStylingSettings,
+	size: 'small',
 };
 
 export const SmallDonationsSoFar: StoryFn<typeof Ticker> = Template.bind({});
@@ -43,6 +44,7 @@ SmallDonationsSoFar.args = {
 		goal: 100000,
 	},
 	tickerStylingSettings,
+	size: 'small',
 };
 
 export const ContributionGoalMet: StoryFn<typeof Ticker> = Template.bind({});
@@ -56,4 +58,19 @@ ContributionGoalMet.args = {
 		goal: 1000000,
 	},
 	tickerStylingSettings,
+	size: 'small',
+};
+
+export const HalfwayContributedLarge: StoryFn<typeof Ticker> = Template.bind(
+	{},
+);
+HalfwayContributedLarge.args = {
+	currencySymbol: '£',
+	copy: {},
+	tickerData: {
+		total: 50000,
+		goal: 100000,
+	},
+	tickerStylingSettings,
+	size: 'large',
 };

--- a/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
@@ -49,15 +49,15 @@ const headlineStyles = (headlineColour: string) => css`
 	padding-bottom: ${space[1]}px;
 `;
 
-//styles for the numerical count (total raised so far) and the goal text
-const goalLabelStyles = (goalContributionsColour: string) => css`
+//styles for the total and the goal text
+const goalLabelStyles = (goalColour: string) => css`
 	${textSans15};
-	color: ${goalContributionsColour};
+	color: ${goalColour};
 `;
 
-const countLabelStyles = (countColour: string) => css`
+const totalLabelStyles = (totalColour: string) => css`
 	${textSansBold17};
-	color: ${countColour};
+	color: ${totalColour};
 `;
 
 const labelContainerStyles = css`
@@ -163,7 +163,7 @@ export const Ticker = ({
 					</div>
 					<div css={labelContainerStyles}>
 						<div css={goalLabelStyles(goalColour)}>
-							<span css={countLabelStyles(totalColour)}>
+							<span css={totalLabelStyles(totalColour)}>
 								{currencySymbol}
 								{runningTotal.toLocaleString()}
 							</span>{' '}

--- a/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
@@ -10,7 +10,7 @@ import { useIsInView } from './useIsInView';
 import { useTicker } from './useTicker';
 
 interface TickerCopy {
-	countLabel: string;
+	headline?: string;
 }
 
 export interface TickerData {
@@ -147,7 +147,9 @@ export const Ticker = ({
 		<div ref={setNode}>
 			<div>
 				<div css={tickerContainerStyles}>
-					<div css={headlineStyles(headlineColour)}>{copy.countLabel}</div>
+					{copy.headline && (
+						<div css={headlineStyles(headlineColour)}>{copy.headline}</div>
+					)}
 					<div css={progressBarBackgroundStyles(progressBarBackgroundColour)}>
 						<div css={progressBarStyles}>
 							<div

--- a/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
@@ -4,6 +4,8 @@ import {
 	space,
 	textSans15,
 	textSansBold17,
+	textSansBold20,
+	textSansBold24,
 } from '@guardian/source/foundations';
 import { useEffect, useState } from 'react';
 import { useIsInView } from './useIsInView';
@@ -26,12 +28,30 @@ export interface TickerStylingSettings {
 	progressBarBackgroundColour: string;
 }
 
+type TickerSize = 'small' | 'medium' | 'large';
+
 export interface TickerSettings {
 	currencySymbol: string;
 	copy: TickerCopy;
 	tickerData: TickerData;
 	tickerStylingSettings: TickerStylingSettings;
+	size: TickerSize;
 }
+
+const tickerSizeSettings = {
+	small: {
+		barHeight: 10,
+		totalFont: textSansBold17,
+	},
+	medium: {
+		barHeight: 14,
+		totalFont: textSansBold20,
+	},
+	large: {
+		barHeight: 16,
+		totalFont: textSansBold24,
+	},
+};
 
 //styles for the container that holds the ticker
 const tickerContainerStyles = css`
@@ -55,8 +75,8 @@ const goalLabelStyles = (goalColour: string) => css`
 	color: ${goalColour};
 `;
 
-const totalLabelStyles = (totalColour: string) => css`
-	${textSansBold17};
+const totalLabelStyles = (totalColour: string, totalFont: string) => css`
+	${totalFont};
 	color: ${totalColour};
 `;
 
@@ -67,8 +87,9 @@ const labelContainerStyles = css`
 //styles for the progress bar background
 const progressBarBackgroundStyles = (
 	progressBarBackgroundColour: string,
+	barHeight: number,
 ) => css`
-	height: 10px;
+	height: ${barHeight}px;
 	align-self: stretch;
 	align-items: center;
 	display: flex;
@@ -77,15 +98,6 @@ const progressBarBackgroundStyles = (
 	overflow-x: hidden;
 	width: 100%;
 	position: relative;
-`;
-
-//styles for the moving part of the progress bar
-const progressBarStyles = css`
-	overflow: hidden;
-	width: 100%;
-	height: 10px;
-	position: absolute;
-	border-radius: 8px;
 `;
 
 const progressBarTransform = (goal: number, runningTotal: number): string => {
@@ -103,6 +115,7 @@ const filledProgressStyles = (
 	goal: number,
 	runningTotal: number,
 	progressBarColour: string,
+	barHeight: number,
 ): SerializedStyles => css`
 	position: absolute;
 	top: 0;
@@ -112,7 +125,7 @@ const filledProgressStyles = (
 	transform: ${progressBarTransform(goal, runningTotal)};
 	transition: transform 3s cubic-bezier(0.25, 0.55, 0.2, 0.85);
 	background-color: ${progressBarColour};
-	height: 10px;
+	height: ${barHeight}px;
 `;
 
 export const Ticker = ({
@@ -120,6 +133,7 @@ export const Ticker = ({
 	currencySymbol,
 	copy,
 	tickerStylingSettings,
+	size,
 }: TickerSettings) => {
 	//state to track if the component is ready to animate
 	const [readyToAnimate, setReadyToAnimate] = useState(false);
@@ -143,6 +157,8 @@ export const Ticker = ({
 		goalColour,
 	} = tickerStylingSettings;
 
+	const { barHeight, totalFont } = tickerSizeSettings[size];
+
 	return (
 		<div ref={setNode}>
 			<div>
@@ -150,20 +166,24 @@ export const Ticker = ({
 					{copy.headline && (
 						<div css={headlineStyles(headlineColour)}>{copy.headline}</div>
 					)}
-					<div css={progressBarBackgroundStyles(progressBarBackgroundColour)}>
-						<div css={progressBarStyles}>
-							<div
-								css={filledProgressStyles(
-									tickerData.goal,
-									runningTotal,
-									filledProgressColour,
-								)}
-							/>
-						</div>
+					<div
+						css={progressBarBackgroundStyles(
+							progressBarBackgroundColour,
+							barHeight,
+						)}
+					>
+						<div
+							css={filledProgressStyles(
+								tickerData.goal,
+								runningTotal,
+								filledProgressColour,
+								barHeight,
+							)}
+						/>
 					</div>
 					<div css={labelContainerStyles}>
 						<div css={goalLabelStyles(goalColour)}>
-							<span css={totalLabelStyles(totalColour)}>
+							<span css={totalLabelStyles(totalColour, totalFont)}>
 								{currencySymbol}
 								{runningTotal.toLocaleString()}
 							</span>{' '}


### PR DESCRIPTION
Adds a new `size` prop to the ticker component. The style/font changes depending on this value.

I've also done some renaming:
1. The `countLabel` field is now called `headline`, and is optional.
2. previously "count" and "total" were used interchangeably, now it's only "total"