### PR TITLE
Revert "Remove `ArticleDesign.PrintShop`"

### DIFF
--- a/.changeset/small-bats-help.md
+++ b/.changeset/small-bats-help.md
@@ -2,4 +2,4 @@
 '@guardian/libs': minor
 ---
 
-Revert "Remove `ArticleDesign.PrintShop`". To be re-implemented at a later date.
+Restores `ArticleDesign.PrintShop`. To be re-removed at a later date.

--- a/.changeset/small-bats-help.md
+++ b/.changeset/small-bats-help.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": major
+"@fake-scope/fake-pkg": minor
 ---
 
 Revert "Remove `ArticleDesign.PrintShop`". To be re-implemented at a later date.

--- a/.changeset/small-bats-help.md
+++ b/.changeset/small-bats-help.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": minor
+'@fake-scope/fake-pkg': minor
 ---
 
 Revert "Remove `ArticleDesign.PrintShop`". To be re-implemented at a later date.

--- a/.changeset/small-bats-help.md
+++ b/.changeset/small-bats-help.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": major
+---
+
+Revert "Remove `ArticleDesign.PrintShop`". To be re-implemented at a later date.

--- a/.changeset/small-bats-help.md
+++ b/.changeset/small-bats-help.md
@@ -1,5 +1,5 @@
 ---
-'@fake-scope/fake-pkg': minor
+'@guardian/libs': minor
 ---
 
 Revert "Remove `ArticleDesign.PrintShop`". To be re-implemented at a later date.

--- a/libs/@guardian/libs/src/format/ArticleDesign.ts
+++ b/libs/@guardian/libs/src/format/ArticleDesign.ts
@@ -19,6 +19,7 @@ export enum ArticleDesign {
 	Quiz,
 	Interactive,
 	PhotoEssay,
+	PrintShop,
 	Obituary,
 	Correction,
 	FullPageInteractive,


### PR DESCRIPTION
Reverts guardian/csnx#1683

libs has 2 breaking changes at v19 that we'd like to decouple. The change that removes `ArticleDesign.PrintShop` and a change to the CMP (#1342)

To move quickly on the CMP release in DCR, we'd like to roll back the PrintShop changes and re-implement them at a later date.