### PR TITLE
Remove the unused format prop from ToggleSwitch

### DIFF
--- a/.changeset/tame-geese-bathe.md
+++ b/.changeset/tame-geese-bathe.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-development-kitchen': major
+---
+
+Remove format prop from Toggle Switch component

--- a/.changeset/tame-geese-bathe.md
+++ b/.changeset/tame-geese-bathe.md
@@ -2,4 +2,6 @@
 '@guardian/source-development-kitchen': major
 ---
 
-Remove format prop from Toggle Switch component
+Remove `format` prop from `ToggleSwitch` component.
+
+It was not being used anyway.

--- a/libs/@guardian/source-development-kitchen/src/react-components/toggle-switch/ToggleSwitch.stories.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/toggle-switch/ToggleSwitch.stories.tsx
@@ -1,63 +1,8 @@
 import { css } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
-import {
-	ArticleDesign,
-	ArticleDisplay,
-	ArticlePillar,
-	ArticleSpecial,
-} from '@guardian/libs';
-import {
-	culture,
-	labs,
-	lifestyle,
-	news,
-	opinion,
-	specialReport,
-	sport,
-} from '@guardian/source/foundations';
 import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import { ToggleSwitch } from './ToggleSwitch';
 import type { ToggleSwitchProps } from './ToggleSwitch';
-
-const decideBackgroundColor = (format?: ArticleFormat) => {
-	if (format) {
-		switch (format.theme) {
-			case ArticlePillar.News:
-				return news[200];
-			case ArticlePillar.Culture:
-				return culture[200];
-			case ArticlePillar.Lifestyle:
-				return lifestyle[300];
-			case ArticlePillar.Sport:
-				return sport[100];
-			case ArticlePillar.Opinion:
-				return opinion[200];
-			case ArticleSpecial.Labs:
-				return labs[200];
-			case ArticleSpecial.SpecialReport:
-				return specialReport[200];
-			default:
-				return news[200];
-		}
-	}
-	return null;
-};
-
-const defaultFormat = {
-	display: ArticleDisplay.Standard,
-	design: ArticleDesign.Standard,
-};
-
-const pillars = [
-	ArticlePillar.News,
-	ArticlePillar.Sport,
-	ArticlePillar.Culture,
-	ArticlePillar.Lifestyle,
-	ArticlePillar.Opinion,
-	ArticleSpecial.SpecialReport,
-	ArticleSpecial.Labs,
-];
 
 const meta: Meta<typeof ToggleSwitch> = {
 	title: 'React Components/ToggleSwitch',
@@ -65,27 +10,6 @@ const meta: Meta<typeof ToggleSwitch> = {
 };
 
 export default meta;
-
-const PillarsTemplate: StoryFn<typeof ToggleSwitch> = (
-	args: ToggleSwitchProps,
-) => {
-	return (
-		<div
-			css={css`
-				display: flex;
-				flex-direction: column;
-			`}
-		>
-			{pillars.map((pillar) => (
-				<Template
-					key={pillar}
-					{...args}
-					format={{ ...defaultFormat, theme: pillar }}
-				/>
-			))}
-		</div>
-	);
-};
 
 const Template: StoryFn<typeof ToggleSwitch> = (args: ToggleSwitchProps) => {
 	const [checked, setChecked] = useState(args.checked);
@@ -95,7 +19,6 @@ const Template: StoryFn<typeof ToggleSwitch> = (args: ToggleSwitchProps) => {
 				padding: 10px;
 				margin: 10px 0;
 				width: 350px;
-				background-color: ${decideBackgroundColor(args.format)};
 			`}
 		>
 			<ToggleSwitch
@@ -132,15 +55,6 @@ export const WithBorder: StoryFn<typeof ToggleSwitch> = Template.bind({});
 WithBorder.args = {
 	label: 'Get alerts on this story',
 	labelBorder: true,
-};
-
-// *****************************************************************************
-
-export const WithFormat: StoryFn<typeof ToggleSwitch> = PillarsTemplate.bind(
-	{},
-);
-WithFormat.args = {
-	label: 'Get alerts on this story',
 };
 
 // *****************************************************************************

--- a/libs/@guardian/source-development-kitchen/src/react-components/toggle-switch/ToggleSwitch.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/toggle-switch/ToggleSwitch.tsx
@@ -1,4 +1,3 @@
-import type { ArticleFormat } from '@guardian/libs';
 import { descriptionId, generateSourceId } from '@guardian/source/foundations';
 import type { Props } from '@guardian/source/react-components';
 import { useEffect, useState } from 'react';
@@ -30,10 +29,6 @@ export interface ToggleSwitchProps extends Props {
 	 * use defaultChecked to indicate the whether the ToggleSwitch is checked initially.
 	 */
 	defaultChecked?: boolean;
-	/**
-	 * Optional Format prop, when provided this renders the toggle with a theme colored tick and light background track
-	 */
-	format?: ArticleFormat;
 	/**
 	 * Optional Id for the switch. Defaults to a generated indexed Source ID e.g. "src-component-XXX}"
 	 */
@@ -83,7 +78,6 @@ export const ToggleSwitch = ({
 	id,
 	fontWeight = 'regular',
 	fontSize = 'small',
-	format,
 	label,
 	labelBorder = false,
 	labelPosition = 'right',
@@ -117,8 +111,8 @@ export const ToggleSwitch = ({
 		<label
 			id={labelId}
 			css={[
-				labelStyles(fontSize, fontWeight, format),
-				labelBorder && labelBorderStyles(format),
+				labelStyles(fontSize, fontWeight),
+				labelBorder && labelBorderStyles,
 				cssOverrides,
 			]}
 			{...props}
@@ -126,11 +120,7 @@ export const ToggleSwitch = ({
 			{labelPosition === 'left' && label}
 			<button
 				id={buttonId}
-				css={[
-					buttonStyles,
-					buttonStylesMargin(labelPosition),
-					toggleStyles(format),
-				]}
+				css={[buttonStyles, buttonStylesMargin(labelPosition), toggleStyles]}
 				role="switch"
 				aria-checked={isChecked()}
 				aria-labelledby={labelId}

--- a/libs/@guardian/source-development-kitchen/src/react-components/toggle-switch/styles.ts
+++ b/libs/@guardian/source-development-kitchen/src/react-components/toggle-switch/styles.ts
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
-import type { ArticleFormat } from '@guardian/libs';
 import {
 	brand,
 	neutral,
@@ -16,16 +15,6 @@ import type {
 	ToggleSwitchFontSize,
 	ToggleSwitchFontWeight,
 } from './ToggleSwitch';
-
-const toggleBackground = 'rgba(255, 255, 255, 0.4)';
-const toggleBorder = 'rgba(255, 255, 255, 0.6)';
-
-/**
- * This colour represents Palette.success[400] with a 40% opacity white overlay.
- * As we're using it for a border we're unable to add an overlay so use a pre-calculated
- * hex value instead.
- */
-const toggleBorderGreen = '#A7CFB8';
 
 export const buttonStyles = css`
 	flex: none;
@@ -68,86 +57,83 @@ export const buttonStylesMargin = (
 	}
 };
 
-export const toggleStyles = (format?: ArticleFormat): SerializedStyles => {
-	return css`
-		width: 44px;
-		height: 22px;
-		border-radius: 16px;
-		box-sizing: unset;
+export const toggleStyles = css`
+	width: 44px;
+	height: 22px;
+	border-radius: 16px;
+	box-sizing: unset;
 
-		/* this will go away when resets have been standardised */
-		&:before,
-		&:after {
-			box-sizing: border-box;
-		}
+	/* this will go away when resets have been standardised */
+	&:before,
+	&:after {
+		box-sizing: border-box;
+	}
 
-		&:before {
-			content: '';
-			position: absolute;
-			top: 5px;
-			height: 11px;
-			width: 6px;
-			right: 8px;
-			opacity: 0;
-			border-bottom: 2px solid ${success[400]};
-			border-right: 2px solid ${success[400]};
-			transform: rotate(45deg);
-			transition-property: opacity;
-			transition-duration: 0.2s;
-		}
+	&:before {
+		content: '';
+		position: absolute;
+		top: 5px;
+		height: 11px;
+		width: 6px;
+		right: 8px;
+		opacity: 0;
+		border-bottom: 2px solid ${success[400]};
+		border-right: 2px solid ${success[400]};
+		transform: rotate(45deg);
+		transition-property: opacity;
+		transition-duration: 0.2s;
+	}
 
-		&:after {
-			height: 18px;
-			width: 18px;
-			top: 2px;
-			left: 2px;
-		}
+	&:after {
+		height: 18px;
+		width: 18px;
+		top: 2px;
+		left: 2px;
+	}
 
-		&[aria-checked='false'] {
-			background-color: ${format ? toggleBackground : neutral[46]};
-			border: 1px solid ${format ? toggleBorder : neutral[46]};
-		}
+	&[aria-checked='false'] {
+		background-color: ${neutral[46]};
+		border: 1px solid ${neutral[46]};
+	}
 
-		&[aria-checked='false']:before {
-			transition-delay: 0;
-		}
+	&[aria-checked='false']:before {
+		transition-delay: 0;
+	}
 
-		&[aria-checked='true'] {
-			background-color: ${success[400]};
-			border: 1px solid ${format ? toggleBorderGreen : success[400]};
-		}
+	&[aria-checked='true'] {
+		background-color: ${success[400]};
+		border: 1px solid ${success[400]};
+	}
 
-		&[aria-checked='true']:before {
-			opacity: 1;
-			z-index: 1;
-			transition-delay: 0.2s;
-		}
+	&[aria-checked='true']:before {
+		opacity: 1;
+		z-index: 1;
+		transition-delay: 0.2s;
+	}
 
-		&[aria-checked='true']:after {
-			left: 24px;
-			background: ${neutral[100]};
-		}
+	&[aria-checked='true']:after {
+		left: 24px;
+		background: ${neutral[100]};
+	}
 
-		&:focus {
-			outline: 0;
-			html:not(.src-focus-disabled) & {
-				outline: 5px solid ${format ? neutral[100] : brand[500]};
-				outline-offset: 3px;
-			}
+	&:focus {
+		outline: 0;
+		html:not(.src-focus-disabled) & {
+			outline: 5px solid ${brand[500]};
+			outline-offset: 3px;
 		}
-	`;
-};
+	}
+`;
 
 export const labelStyles = (
 	fontSize: ToggleSwitchFontSize,
 	fontWeight: ToggleSwitchFontWeight,
-	format?: ArticleFormat,
 ): SerializedStyles => css`
 	${fontSize === 'small' &&
 	(fontWeight === 'regular' ? textSans15 : textSansBold15)};
 	${fontSize === 'medium' &&
 	(fontWeight === 'regular' ? textSans17 : textSansBold17)};
-	color: ${format ? neutral[100] : neutral[7]};
+	color: ${neutral[7]};
 	display: inline-flex;
 	justify-content: space-between;
 	align-items: center;
@@ -156,10 +142,8 @@ export const labelStyles = (
 	position: relative;
 `;
 
-export const labelBorderStyles = (
-	format?: ArticleFormat,
-): SerializedStyles => css`
-	border-top: 1px solid ${format ? neutral[100] : neutral[46]};
+export const labelBorderStyles = css`
+	border-top: 1px solid ${neutral[46]};
 	padding-top: ${space[1]}px;
 	width: 100%;
 `;


### PR DESCRIPTION
## What are you changing?

- Remove the unused `format` prop from the `ToggleSwitch` component in `@guardian/source-development-kitchen`

## Why?

The optional format prop is never used anywhere in the Guardian organisation, implying it is redundant. 

The component doesn't really do a lot with the format. If a `format` is set, the element gets a slightly different colour palette, but we aren't checking the value of the prop `format`, just whether or not it exists. At best this is overly complex. 

**Without format:**

<img width="279" alt="Screenshot 2024-10-09 at 12 32 52" src="https://github.com/user-attachments/assets/5c8cf409-4619-485a-a006-0eff936cd16f">

**With format:** 

<img width="380" alt="Screenshot 2024-10-09 at 12 32 43" src="https://github.com/user-attachments/assets/3cd11261-ba5e-4e88-99c4-1509b2899295">

Note: background colour doesn't get applied automatically, this must be manually added to the containing element

If we decide we want to keep the alternative colours, we can do so using a flag rather than a `format` prop e.g. `altColourScheme: boolean`. But it should be noted that this alternative colour scheme [is not reflected in the Design System](https://www.figma.com/design/FnCwHWaXPUsyjE0luiI03e/%E2%97%89-Cheat-sheet?m=auto&node-id=2437-73573&t=YGnpuBQPWo6cJ8rR-1).