### PR TITLE
Fix missing types in `@guardian/eslint-config`

### DIFF
--- a/libs/@guardian/eslint-config/CHANGELOG.md
+++ b/libs/@guardian/eslint-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/eslint-config
 
+## 10.0.0-beta.4
+
+### Patch Changes
+
+- Fix missing types issue.
+
 ## 10.0.0-beta.3
 
 ### Minor Changes

--- a/libs/@guardian/eslint-config/package.json
+++ b/libs/@guardian/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/eslint-config",
-	"version": "10.0.0-beta.3",
+	"version": "10.0.0-beta.4",
 	"description": "ESLint config for Guardian JavaScript projects",
 	"type": "module",
 	"main": "index.js",
@@ -24,11 +24,11 @@
 		"typescript-eslint": "8.11.0"
 	},
 	"devDependencies": {
-		"eslint": "9.9.0",
+		"eslint": "9.13.0",
 		"wireit": "0.14.8"
 	},
 	"peerDependencies": {
-		"eslint": "^9.9.0"
+		"eslint": "^9.13.0"
 	},
 	"wireit": {
 		"lint": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,34 +286,34 @@ importers:
     dependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.4.1
-        version: 4.4.1(eslint@9.9.0)
+        version: 4.4.1(eslint@9.13.0)
       '@eslint/js':
         specifier: 9.13.0
         version: 9.13.0
       '@stylistic/eslint-plugin':
         specifier: 2.9.0
-        version: 2.9.0(eslint@9.9.0)(typescript@5.5.2)
+        version: 2.9.0(eslint@9.13.0)(typescript@5.5.2)
       eslint-config-prettier:
         specifier: 9.1.0
-        version: 9.1.0(eslint@9.9.0)
+        version: 9.1.0(eslint@9.13.0)
       eslint-import-resolver-typescript:
         specifier: 3.6.3
-        version: 3.6.3(@typescript-eslint/parser@8.11.0)(eslint-plugin-import-x@4.3.1)(eslint@9.9.0)
+        version: 3.6.3(@typescript-eslint/parser@8.11.0)(eslint-plugin-import-x@4.3.1)(eslint@9.13.0)
       eslint-plugin-import-x:
         specifier: 4.3.1
-        version: 4.3.1(eslint@9.9.0)(typescript@5.5.2)
+        version: 4.3.1(eslint@9.13.0)(typescript@5.5.2)
       eslint-plugin-jsx-a11y:
         specifier: 6.10.2
-        version: 6.10.2(eslint@9.9.0)
+        version: 6.10.2(eslint@9.13.0)
       eslint-plugin-react:
         specifier: 7.37.2
-        version: 7.37.2(eslint@9.9.0)
+        version: 7.37.2(eslint@9.13.0)
       eslint-plugin-react-hooks:
         specifier: 5.0.0
-        version: 5.0.0(eslint@9.9.0)
+        version: 5.0.0(eslint@9.13.0)
       eslint-plugin-storybook:
         specifier: 0.10.1
-        version: 0.10.1(eslint@9.9.0)(typescript@5.5.2)
+        version: 0.10.1(eslint@9.13.0)(typescript@5.5.2)
       globals:
         specifier: 15.11.0
         version: 15.11.0
@@ -322,11 +322,11 @@ importers:
         version: 11.0.0
       typescript-eslint:
         specifier: 8.11.0
-        version: 8.11.0(eslint@9.9.0)(typescript@5.5.2)
+        version: 8.11.0(eslint@9.13.0)(typescript@5.5.2)
     devDependencies:
       eslint:
-        specifier: 9.9.0
-        version: 9.9.0
+        specifier: 9.13.0
+        version: 9.13.0
       wireit:
         specifier: 0.14.8
         version: 0.14.8
@@ -2234,7 +2234,7 @@ packages:
     dev: true
     optional: true
 
-  /@eslint-community/eslint-plugin-eslint-comments@4.4.1(eslint@9.9.0):
+  /@eslint-community/eslint-plugin-eslint-comments@4.4.1(eslint@9.13.0):
     resolution: {integrity: sha512-lb/Z/MzbTf7CaVYM9WCFNQZ4L1yi3ev2fsFPF99h31ljhSEyUoyEsKsNWiU+qD1glbYTDJdqgyaLKtyTkkqtuQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2244,9 +2244,21 @@ packages:
         optional: true
     dependencies:
       escape-string-regexp: 4.0.0
-      eslint: 9.9.0
+      eslint: 9.13.0
       ignore: 5.3.2
     dev: false
+
+  /@eslint-community/eslint-utils@4.4.0(eslint@9.13.0):
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+    dependencies:
+      eslint: 9.13.0
+      eslint-visitor-keys: 3.4.3
 
   /@eslint-community/eslint-utils@4.4.0(eslint@9.9.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -2259,6 +2271,7 @@ packages:
     dependencies:
       eslint: 9.9.0
       eslint-visitor-keys: 3.4.3
+    dev: true
 
   /@eslint-community/regexpp@4.11.0:
     resolution: {integrity: sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==}
@@ -2273,6 +2286,21 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@eslint/config-array@0.18.0:
+    resolution: {integrity: sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      '@eslint/object-schema': 2.1.4
+      debug: 4.3.7
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  /@eslint/core@0.7.0:
+    resolution: {integrity: sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   /@eslint/eslintrc@3.1.0:
     resolution: {integrity: sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==}
@@ -2293,15 +2321,21 @@ packages:
   /@eslint/js@9.13.0:
     resolution: {integrity: sha512-IFLyoY4d72Z5y/6o/BazFBezupzI/taV8sGumxTAVw3lXG9A6md1Dc34T9s1FoD/an9pJH8RHbAxsaEbBed9lA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: false
 
   /@eslint/js@9.9.0:
     resolution: {integrity: sha512-hhetes6ZHP3BlXLxmd8K2SNgkhNSi+UcecbnwWKwpP7kyi/uC75DJ1lOOBO3xrC4jyojtGE3YxKZPHfk4yrgug==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dev: true
 
   /@eslint/object-schema@2.1.4:
     resolution: {integrity: sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  /@eslint/plugin-kit@0.2.1:
+    resolution: {integrity: sha512-HFZ4Mp26nbWk9d/BpvP0YNL6W4UoZF0VFcTw/aPPA8RpOxeFQgK+ClABGgAUXs9Y/RGX/l1vOmrqz1MQt9MNuw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      levn: 0.4.1
 
   /@guardian/libs@19.0.0(tslib@2.6.2)(typescript@5.5.2):
     resolution: {integrity: sha512-UEcVsjSAjkZzbHRrEtkPW/5ngOCNzVk/BtJBkAdX3enYjHLYLxNfuGZW/Z5W5K9Plf/7xH2Jtcker5tQq9R6sQ==}
@@ -2317,12 +2351,28 @@ packages:
       typescript: 5.5.2
     dev: true
 
+  /@humanfs/core@0.19.1:
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  /@humanfs/node@0.16.6:
+    resolution: {integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==}
+    engines: {node: '>=18.18.0'}
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.3.1
+
   /@humanwhocodes/module-importer@1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
 
   /@humanwhocodes/retry@0.3.0:
     resolution: {integrity: sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==}
+    engines: {node: '>=18.18'}
+    dev: true
+
+  /@humanwhocodes/retry@0.3.1:
+    resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
     engines: {node: '>=18.18'}
 
   /@img/sharp-darwin-arm64@0.33.5:
@@ -3557,7 +3607,7 @@ packages:
       storybook: 8.3.5
     dev: true
 
-  /@stylistic/eslint-plugin@2.9.0(eslint@9.9.0)(typescript@5.5.2):
+  /@stylistic/eslint-plugin@2.9.0(eslint@9.13.0)(typescript@5.5.2):
     resolution: {integrity: sha512-OrDyFAYjBT61122MIY1a3SfEgy3YCMgt2vL4eoPmvTwDBwyQhAXurxNQznlRD/jESNfYWfID8Ej+31LljvF7Xg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -3566,8 +3616,8 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 8.11.0(eslint@9.9.0)(typescript@5.5.2)
-      eslint: 9.9.0
+      '@typescript-eslint/utils': 8.11.0(eslint@9.13.0)(typescript@5.5.2)
+      eslint: 9.13.0
       eslint-visitor-keys: 4.1.0
       espree: 10.2.0
       estraverse: 5.3.0
@@ -3911,7 +3961,6 @@ packages:
 
   /@types/estree@1.0.6:
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-    dev: true
 
   /@types/express-serve-static-core@4.17.43:
     resolution: {integrity: sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==}
@@ -3984,6 +4033,9 @@ packages:
       '@types/tough-cookie': 4.0.2
       parse5: 7.1.2
     dev: true
+
+  /@types/json-schema@7.0.15:
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   /@types/lodash@4.17.0:
     resolution: {integrity: sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==}
@@ -4136,7 +4188,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  /@typescript-eslint/eslint-plugin@8.11.0(@typescript-eslint/parser@8.11.0)(eslint@9.9.0)(typescript@5.5.2):
+  /@typescript-eslint/eslint-plugin@8.11.0(@typescript-eslint/parser@8.11.0)(eslint@9.13.0)(typescript@5.5.2):
     resolution: {integrity: sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -4150,12 +4202,12 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 8.11.0(eslint@9.9.0)(typescript@5.5.2)
+      '@typescript-eslint/parser': 8.11.0(eslint@9.13.0)(typescript@5.5.2)
       '@typescript-eslint/scope-manager': 8.11.0
-      '@typescript-eslint/type-utils': 8.11.0(eslint@9.9.0)(typescript@5.5.2)
-      '@typescript-eslint/utils': 8.11.0(eslint@9.9.0)(typescript@5.5.2)
+      '@typescript-eslint/type-utils': 8.11.0(eslint@9.13.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 8.11.0(eslint@9.13.0)(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 8.11.0
-      eslint: 9.9.0
+      eslint: 9.13.0
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -4165,7 +4217,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@8.11.0(eslint@9.9.0)(typescript@5.5.2):
+  /@typescript-eslint/parser@8.11.0(eslint@9.13.0)(typescript@5.5.2):
     resolution: {integrity: sha512-lmt73NeHdy1Q/2ul295Qy3uninSqi6wQI18XwSpm8w0ZbQXUpjCAWP1Vlv/obudoBiIjJVjlztjQ+d/Md98Yxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -4182,7 +4234,7 @@ packages:
       '@typescript-eslint/typescript-estree': 8.11.0(typescript@5.5.2)
       '@typescript-eslint/visitor-keys': 8.11.0
       debug: 4.3.7
-      eslint: 9.9.0
+      eslint: 9.13.0
       typescript: 5.5.2
     transitivePeerDependencies:
       - supports-color
@@ -4204,7 +4256,7 @@ packages:
       '@typescript-eslint/visitor-keys': 8.4.0
     dev: false
 
-  /@typescript-eslint/type-utils@8.11.0(eslint@9.9.0)(typescript@5.5.2):
+  /@typescript-eslint/type-utils@8.11.0(eslint@9.13.0)(typescript@5.5.2):
     resolution: {integrity: sha512-ItiMfJS6pQU0NIKAaybBKkuVzo6IdnAhPFZA/2Mba/uBjuPQPet/8+zh5GtLHwmuFRShZx+8lhIs7/QeDHflOg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -4214,7 +4266,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 8.11.0(typescript@5.5.2)
-      '@typescript-eslint/utils': 8.11.0(eslint@9.9.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 8.11.0(eslint@9.13.0)(typescript@5.5.2)
       debug: 4.3.7
       ts-api-utils: 1.3.0(typescript@5.5.2)
       typescript: 5.5.2
@@ -4277,7 +4329,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@8.11.0(eslint@9.9.0)(typescript@5.5.2):
+  /@typescript-eslint/utils@8.11.0(eslint@9.13.0)(typescript@5.5.2):
     resolution: {integrity: sha512-CYiX6WZcbXNJV7UNB4PLDIBtSdRmRI/nb0FMyqHPTQD1rMjA0foPLaPUV39C/MxkTd/QKSeX+Gb34PPsDVC35g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -4286,17 +4338,17 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
       '@typescript-eslint/scope-manager': 8.11.0
       '@typescript-eslint/types': 8.11.0
       '@typescript-eslint/typescript-estree': 8.11.0(typescript@5.5.2)
-      eslint: 9.9.0
+      eslint: 9.13.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/utils@8.4.0(eslint@9.9.0)(typescript@5.5.2):
+  /@typescript-eslint/utils@8.4.0(eslint@9.13.0)(typescript@5.5.2):
     resolution: {integrity: sha512-swULW8n1IKLjRAgciCkTCafyTHHfwVQFt8DovmaF69sKbOxTSFMmIZaSHjqO9i/RV0wIblaawhzvtva8Nmm7lQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -4305,11 +4357,11 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.9.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
       '@typescript-eslint/scope-manager': 8.4.0
       '@typescript-eslint/types': 8.4.0
       '@typescript-eslint/typescript-estree': 8.4.0(typescript@5.5.2)
-      eslint: 9.9.0
+      eslint: 9.13.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6294,7 +6346,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-prettier@9.1.0(eslint@9.9.0):
+  /eslint-config-prettier@9.1.0(eslint@9.13.0):
     resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
     hasBin: true
     peerDependencies:
@@ -6303,7 +6355,7 @@ packages:
       eslint:
         optional: true
     dependencies:
-      eslint: 9.9.0
+      eslint: 9.13.0
     dev: false
 
   /eslint-import-resolver-node@0.3.9:
@@ -6316,7 +6368,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0)(eslint-plugin-import-x@4.3.1)(eslint@9.9.0):
+  /eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0)(eslint-plugin-import-x@4.3.1)(eslint@9.13.0):
     resolution: {integrity: sha512-ud9aw4szY9cCT1EWWdGv1L1XR6hh2PaRWif0j2QjQ0pgTY/69iw+W0Z4qZv5wHahOl8isEr+k/JnyAqNQkLkIA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -6334,9 +6386,9 @@ packages:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.6
       enhanced-resolve: 5.17.1
-      eslint: 9.9.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.11.0)(eslint-import-resolver-typescript@3.6.3)(eslint@9.9.0)
-      eslint-plugin-import-x: 4.3.1(eslint@9.9.0)(typescript@5.5.2)
+      eslint: 9.13.0
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.11.0)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0)
+      eslint-plugin-import-x: 4.3.1(eslint@9.13.0)(typescript@5.5.2)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-bun-module: 1.1.0
@@ -6348,7 +6400,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils@2.8.1(@typescript-eslint/parser@8.11.0)(eslint-import-resolver-typescript@3.6.3)(eslint@9.9.0):
+  /eslint-module-utils@2.8.1(@typescript-eslint/parser@8.11.0)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0):
     resolution: {integrity: sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -6369,15 +6421,15 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 8.11.0(eslint@9.9.0)(typescript@5.5.2)
+      '@typescript-eslint/parser': 8.11.0(eslint@9.13.0)(typescript@5.5.2)
       debug: 3.2.7
-      eslint: 9.9.0
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.11.0)(eslint-plugin-import-x@4.3.1)(eslint@9.9.0)
+      eslint: 9.13.0
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.11.0)(eslint-plugin-import-x@4.3.1)(eslint@9.13.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-plugin-import-x@4.3.1(eslint@9.9.0)(typescript@5.5.2):
+  /eslint-plugin-import-x@4.3.1(eslint@9.13.0)(typescript@5.5.2):
     resolution: {integrity: sha512-5TriWkXulDl486XnYYRgsL+VQoS/7mhN/2ci02iLCuL7gdhbiWxnsuL/NTcaKY9fpMgsMFjWZBtIGW7pb+RX0g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -6386,10 +6438,10 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 8.4.0(eslint@9.9.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 8.4.0(eslint@9.13.0)(typescript@5.5.2)
       debug: 4.3.7
       doctrine: 3.0.0
-      eslint: 9.9.0
+      eslint: 9.13.0
       eslint-import-resolver-node: 0.3.9
       get-tsconfig: 4.7.5
       is-glob: 4.0.3
@@ -6402,7 +6454,7 @@ packages:
       - typescript
     dev: false
 
-  /eslint-plugin-jsx-a11y@6.10.2(eslint@9.9.0):
+  /eslint-plugin-jsx-a11y@6.10.2(eslint@9.13.0):
     resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -6419,7 +6471,7 @@ packages:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.9.0
+      eslint: 9.13.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -6429,7 +6481,7 @@ packages:
       string.prototype.includes: 2.0.1
     dev: false
 
-  /eslint-plugin-react-hooks@5.0.0(eslint@9.9.0):
+  /eslint-plugin-react-hooks@5.0.0(eslint@9.13.0):
     resolution: {integrity: sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -6438,10 +6490,10 @@ packages:
       eslint:
         optional: true
     dependencies:
-      eslint: 9.9.0
+      eslint: 9.13.0
     dev: false
 
-  /eslint-plugin-react@7.37.2(eslint@9.9.0):
+  /eslint-plugin-react@7.37.2(eslint@9.13.0):
     resolution: {integrity: sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -6456,7 +6508,7 @@ packages:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.1.0
-      eslint: 9.9.0
+      eslint: 9.13.0
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -6471,7 +6523,7 @@ packages:
       string.prototype.repeat: 1.0.0
     dev: false
 
-  /eslint-plugin-storybook@0.10.1(eslint@9.9.0)(typescript@5.5.2):
+  /eslint-plugin-storybook@0.10.1(eslint@9.13.0)(typescript@5.5.2):
     resolution: {integrity: sha512-YpxkdqyiKpMIrRquuvBaCinsqmZJ86JvXRX/gtRa4Qctpk0ipFt2cWqEjkB1HHWWG0DVRXlUBKHjRogC2Ig1fg==}
     engines: {node: '>= 18'}
     peerDependencies:
@@ -6481,8 +6533,8 @@ packages:
         optional: true
     dependencies:
       '@storybook/csf': 0.1.11
-      '@typescript-eslint/utils': 8.11.0(eslint@9.9.0)(typescript@5.5.2)
-      eslint: 9.9.0
+      '@typescript-eslint/utils': 8.11.0(eslint@9.13.0)(typescript@5.5.2)
+      eslint: 9.13.0
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -6491,6 +6543,14 @@ packages:
 
   /eslint-scope@8.0.2:
     resolution: {integrity: sha512-6E4xmrTw5wtxnLA5wYL3WDfhZ/1bUBGOXV0zQvVRDOtrR8D0p6W7fs3JweNYhwRYeGvd/1CKX2se0/2s7Q/nJA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+    dev: true
+
+  /eslint-scope@8.1.0:
+    resolution: {integrity: sha512-14dSvlhaVhKKsa9Fx1l8A17s7ah7Ef7wCakJ10LYk6+GYmP9yDti2oq2SEwcyndt6knfcZyhyxwY3i9yL78EQw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       esrecurse: 4.3.0
@@ -6507,7 +6567,54 @@ packages:
   /eslint-visitor-keys@4.1.0:
     resolution: {integrity: sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    dev: false
+
+  /eslint@9.13.0:
+    resolution: {integrity: sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0)
+      '@eslint-community/regexpp': 4.11.0
+      '@eslint/config-array': 0.18.0
+      '@eslint/core': 0.7.0
+      '@eslint/eslintrc': 3.1.0
+      '@eslint/js': 9.13.0
+      '@eslint/plugin-kit': 0.2.1
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.3.1
+      '@types/estree': 1.0.6
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.7
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.1.0
+      eslint-visitor-keys: 4.1.0
+      espree: 10.2.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
 
   /eslint@9.9.0:
     resolution: {integrity: sha512-JfiKJrbx0506OEerjK2Y1QlldtBxkAlLxT5OEcRF8uaQ86noDe2k31Vw9rnSWv+MXZHj7OOUV/dA0AhdLFcyvA==}
@@ -6555,6 +6662,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
@@ -6576,7 +6684,6 @@ packages:
       acorn: 8.12.1
       acorn-jsx: 5.3.2(acorn@8.12.1)
       eslint-visitor-keys: 4.1.0
-    dev: false
 
   /esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -7667,6 +7774,7 @@ packages:
   /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
@@ -11602,7 +11710,7 @@ packages:
       semver: 7.6.3
     dev: true
 
-  /typescript-eslint@8.11.0(eslint@9.9.0)(typescript@5.5.2):
+  /typescript-eslint@8.11.0(eslint@9.13.0)(typescript@5.5.2):
     resolution: {integrity: sha512-cBRGnW3FSlxaYwU8KfAewxFK5uzeOAp0l2KebIlPDOT5olVi65KDG/yjBooPBG0kGW/HLkoz1c/iuBFehcS3IA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -11611,9 +11719,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.11.0(@typescript-eslint/parser@8.11.0)(eslint@9.9.0)(typescript@5.5.2)
-      '@typescript-eslint/parser': 8.11.0(eslint@9.9.0)(typescript@5.5.2)
-      '@typescript-eslint/utils': 8.11.0(eslint@9.9.0)(typescript@5.5.2)
+      '@typescript-eslint/eslint-plugin': 8.11.0(@typescript-eslint/parser@8.11.0)(eslint@9.13.0)(typescript@5.5.2)
+      '@typescript-eslint/parser': 8.11.0(eslint@9.13.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 8.11.0(eslint@9.13.0)(typescript@5.5.2)
       typescript: 5.5.2
     transitivePeerDependencies:
       - eslint


### PR DESCRIPTION
## What are you changing?

bumping eslint version needed for our config

## Why?

Fix missing types in `@guardian/eslint-config`
