### PR TITLE
Fix sourcepoint integration tests in libs node22

### DIFF
--- a/libs/@guardian/libs/package.json
+++ b/libs/@guardian/libs/package.json
@@ -119,7 +119,7 @@
 			"output": []
 		},
 		"sourcepoint-integration-test": {
-			"command": "node --test sourcepoint-integration-tests/*.test.js",
+			"command": "node --test sourcepoint-integration-tests/*.test.{js,mjs,cjs}",
 			"dependencies": [
 				"build"
 			]

--- a/libs/@guardian/libs/package.json
+++ b/libs/@guardian/libs/package.json
@@ -119,7 +119,7 @@
 			"output": []
 		},
 		"sourcepoint-integration-test": {
-			"command": "node --test sourcepoint-integration-tests",
+			"command": "node --test sourcepoint-integration-tests/*.test.js",
 			"dependencies": [
 				"build"
 			]


### PR DESCRIPTION
## What are you changing?

- Update the way the `sourcepoint-integration-test` runs as the way tests are run changed in node v22 
https://nodejs.org/docs/latest-v22.x/api/test.html#running-tests-from-the-command-line
https://nodejs.org/docs/latest-v20.x/api/test.html#running-tests-from-the-command-line

## Why?

- The tests were not running


### Before
<img width="1279" alt="Screenshot 2024-10-29 at 14 37 59" src="https://github.com/user-attachments/assets/d0da3056-b08f-4881-9cbb-7c51bd95a26f">

### After
<img width="1074" alt="Screenshot 2024-10-29 at 14 38 40" src="https://github.com/user-attachments/assets/d8fd793a-97e9-455b-a41c-dd283f560d71">
