### PR TITLE
Revert "Make Select show error styling only if user has interacted"

### DIFF
--- a/.changeset/rotten-bobcats-prove.md
+++ b/.changeset/rotten-bobcats-prove.md
@@ -1,5 +1,0 @@
----
-'@guardian/source': major
----
-
-Changed Select to only show error styling once user has interacted

--- a/libs/@guardian/source/src/react-components/select/styles.ts
+++ b/libs/@guardian/source/src/react-components/select/styles.ts
@@ -81,7 +81,7 @@ export const select = (select: ThemeSelect): SerializedStyles => css`
 		${focusHalo};
 	}
 
-	&:user-invalid {
+	&:invalid {
 		${errorInput(select)};
 	}
 `;


### PR DESCRIPTION
Reverts guardian/csnx#1733

The original change is a definite improvement for most users, but it introduces a potential regression in UAs that do not support `:user-invalid` (around 13%).

We can't look into how to handle that without blocking all releases from the repo, so this is temporary revert while we address support. 

Once we have a solution for that, we'll recreate the original change.

sorry!