### PR TITLE
focus and progress state in crossword component

### DIFF
--- a/libs/@guardian/react-crossword/package.json
+++ b/libs/@guardian/react-crossword/package.json
@@ -32,7 +32,7 @@
 	"devDependencies": {
 		"@emotion/react": "11.11.3",
 		"@guardian/eslint-config": "workspace:*",
-		"@guardian/libs": "workspace:*",
+		"@guardian/libs": "19.1.0",
 		"@guardian/source": "8.0.0",
 		"@storybook/addon-a11y": "8.4.1",
 		"@storybook/addon-essentials": "8.4.1",
@@ -57,6 +57,7 @@
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.11.3",
+		"@guardian/libs": "^19.1.0",
 		"@guardian/source": "^8.0.0",
 		"@types/react": "^18.2.79",
 		"react": "^18.2.0",

--- a/libs/@guardian/react-crossword/src/@types/crossword.ts
+++ b/libs/@guardian/react-crossword/src/@types/crossword.ts
@@ -39,6 +39,13 @@ export type Focus = {
 	entryId?: EntryID;
 };
 
+export type CurrentCell = {
+	x: number;
+	y: number;
+};
+
+export type CurrentEntryId = EntryID;
+
 export type Theme = {
 	background: string;
 	foreground: string;
@@ -46,6 +53,7 @@ export type Theme = {
 	gutter: number;
 	focus: string;
 	focusBorder: string;
+	cellSize: number;
 };
 
 export type Dimensions = {

--- a/libs/@guardian/react-crossword/src/components/Cell.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Cell.stories.tsx
@@ -10,18 +10,21 @@ const meta: Meta<typeof Cell> = {
 
 export default meta;
 
-const Template: StoryFn<typeof Cell> = (args: CellProps) => {
+const Template: StoryFn<typeof Cell> = ({
+	theme = defaultTheme,
+	...args
+}: CellProps) => {
 	return (
 		<svg
 			style={{
 				border: `5px solid green`,
-				width: args.cellSize,
-				height: args.cellSize,
-				backgroundColor: defaultTheme.background,
+				width: theme.cellSize,
+				height: theme.cellSize,
+				backgroundColor: theme.background,
 			}}
-			viewBox={`0 0 ${args.cellSize} ${args.cellSize}`}
+			viewBox={`0 0 ${theme.cellSize} ${theme.cellSize}`}
 		>
-			<Cell {...args} theme={defaultTheme} cellSize={args.cellSize} />
+			<Cell {...args} theme={theme} />
 		</svg>
 	);
 };
@@ -32,7 +35,6 @@ Default.args = {
 		x: 0,
 		y: 0,
 	},
-	cellSize: 16,
 };
 
 export const Empty: StoryFn<typeof Cell> = Template.bind({});
@@ -42,7 +44,6 @@ Empty.args = {
 		y: 0,
 		group: ['1-across'],
 	},
-	cellSize: 16,
 };
 
 export const WithNumber: StoryFn<typeof Cell> = Template.bind({});
@@ -53,7 +54,6 @@ WithNumber.args = {
 		number: 1,
 		group: ['1-across'],
 	},
-	cellSize: 16,
 };
 
 export const Guessed: StoryFn<typeof Cell> = Template.bind({});
@@ -64,7 +64,6 @@ Guessed.args = {
 		group: ['1-across'],
 	},
 	guess: 'A',
-	cellSize: 16,
 };
 
 export const GuessedWithNumber: StoryFn<typeof Cell> = Template.bind({});
@@ -76,7 +75,6 @@ GuessedWithNumber.args = {
 		group: ['1-across'],
 	},
 	guess: 'A',
-	cellSize: 16,
 };
 
 export const BigCellGuessedWithNumber: StoryFn<typeof Cell> = Template.bind({});
@@ -88,5 +86,8 @@ BigCellGuessedWithNumber.args = {
 		group: ['1-across'],
 	},
 	guess: 'A',
-	cellSize: 50,
+	theme: {
+		...defaultTheme,
+		cellSize: 50,
+	},
 };

--- a/libs/@guardian/react-crossword/src/components/Cell.tsx
+++ b/libs/@guardian/react-crossword/src/components/Cell.tsx
@@ -6,7 +6,6 @@ export type CellProps = {
 	data: CellType;
 	x: number;
 	y: number;
-	cellSize: number;
 	guess?: string;
 	theme: Theme;
 	isFocused?: boolean;
@@ -17,7 +16,6 @@ export const CellComponent = ({
 	data,
 	x,
 	y,
-	cellSize = 16,
 	guess = '',
 	theme,
 	isFocused,
@@ -40,12 +38,12 @@ export const CellComponent = ({
 			? theme.focus
 			: theme.foreground;
 	return (
-		<g>
+		<g data-x={data.x} data-y={data.y}>
 			<rect
 				x={x}
 				y={y}
-				width={cellSize}
-				height={cellSize}
+				width={theme.cellSize}
+				height={theme.cellSize}
 				fill={backgroundColor}
 				{...border}
 			/>
@@ -54,8 +52,8 @@ export const CellComponent = ({
 					x={x}
 					y={y}
 					dy={8}
-					height={cellSize}
-					width={cellSize}
+					height={theme.cellSize}
+					width={theme.cellSize}
 					fill={theme.text}
 					style={{ fontSize: 10 }}
 				>
@@ -65,11 +63,11 @@ export const CellComponent = ({
 			<text
 				x={x}
 				y={y}
-				dx={cellSize / 2}
-				dy={cellSize / 1.7}
+				dx={theme.cellSize / 2}
+				dy={theme.cellSize / 1.7}
 				textAnchor="middle"
 				dominantBaseline="middle"
-				style={{ fontSize: cellSize * 0.7 }}
+				style={{ fontSize: theme.cellSize * 0.7 }}
 			>
 				{guess}
 			</text>

--- a/libs/@guardian/react-crossword/src/components/Grid.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.stories.tsx
@@ -27,62 +27,53 @@ const Template: StoryFn<typeof Grid> = (args: GridProps) => {
 export const Cryptic: StoryFn<typeof Grid> = Template.bind({});
 Cryptic.args = {
 	cells: getCells(cryptic),
-	rows: cryptic.dimensions.rows,
-	cols: cryptic.dimensions.cols,
+	dimensions: cryptic.dimensions,
 };
 
 export const Everyman: StoryFn<typeof Grid> = Template.bind({});
 Everyman.args = {
 	cells: getCells(everyman),
-	rows: everyman.dimensions.rows,
-	cols: everyman.dimensions.cols,
+	dimensions: everyman.dimensions,
 };
 
 export const Prize: StoryFn<typeof Grid> = Template.bind({});
 Prize.args = {
 	cells: getCells(prize),
-	rows: prize.dimensions.rows,
-	cols: prize.dimensions.cols,
+	dimensions: prize.dimensions,
 };
 
 export const Quick: StoryFn<typeof Grid> = Template.bind({});
 Quick.args = {
 	cells: getCells(quick),
-	rows: quick.dimensions.rows,
-	cols: quick.dimensions.cols,
+	dimensions: quick.dimensions,
 };
 
 export const QuickCryptic: StoryFn<typeof Grid> = Template.bind({});
 QuickCryptic.args = {
 	cells: getCells(quickCryptic),
-	rows: quickCryptic.dimensions.rows,
-	cols: quickCryptic.dimensions.cols,
+	dimensions: quickCryptic.dimensions,
 };
 
 export const Quiptic: StoryFn<typeof Grid> = Template.bind({});
 Quiptic.args = {
 	cells: getCells(quiptic),
-	rows: quiptic.dimensions.rows,
-	cols: quiptic.dimensions.cols,
+	dimensions: quiptic.dimensions,
 };
 
 export const Special: StoryFn<typeof Grid> = Template.bind({});
 Special.args = {
 	cells: getCells(special),
-	rows: special.dimensions.rows,
-	cols: special.dimensions.cols,
+	dimensions: special.dimensions,
 };
 
 export const Speedy: StoryFn<typeof Grid> = Template.bind({});
 Speedy.args = {
 	cells: getCells(speedy),
-	rows: speedy.dimensions.rows,
-	cols: speedy.dimensions.cols,
+	dimensions: speedy.dimensions,
 };
 
 export const Weekend: StoryFn<typeof Grid> = Template.bind({});
 Weekend.args = {
 	cells: getCells(weekend),
-	rows: weekend.dimensions.rows,
-	cols: weekend.dimensions.cols,
+	dimensions: weekend.dimensions,
 };

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -1,62 +1,145 @@
+import { isUndefined } from '@guardian/libs';
 import type { MouseEventHandler } from 'react';
 import { useCallback, useRef } from 'react';
-import type { Cells, Focus, Progress, Theme } from '../@types/crossword';
+import type {
+	Cells,
+	CurrentCell,
+	CurrentEntryId,
+	Dimensions,
+	Progress,
+	Theme,
+} from '../@types/crossword';
+import type { Direction } from '../@types/Direction';
 import { Cell } from './Cell';
 
 export type GridProps = {
 	cells: Cells;
 	theme: Theme;
 	progress: Progress;
-	rows: number;
-	cols: number;
-	setFocus: (focus: Focus) => void;
-	focus?: Focus;
+	dimensions: Dimensions;
+	setCurrentCell: React.Dispatch<React.SetStateAction<CurrentCell | undefined>>;
+	setCurrentEntryId: React.Dispatch<
+		React.SetStateAction<CurrentEntryId | undefined>
+	>;
+	currentCell?: CurrentCell;
+	currentEntryId?: CurrentEntryId;
 };
 
 export const Grid = ({
 	cells,
 	theme,
 	progress,
-	rows,
-	cols,
-	focus,
-	setFocus = () => {},
+	dimensions,
+	currentCell,
+	currentEntryId,
+	setCurrentCell,
+	setCurrentEntryId,
 }: GridProps) => {
 	const gridRef = useRef<SVGSVGElement>(null);
-	const cellSize = 32;
-	const SVGHeight = cellSize * rows + theme.gutter * (rows + 1);
-	const SVGWidth = cellSize * cols + theme.gutter * (cols + 1);
+	const workingDirectionRef = useRef<Direction>('across');
 
-	const getClickRef: MouseEventHandler<SVGSVGElement> = useCallback(
+	const SVGHeight =
+		theme.cellSize * dimensions.rows + theme.gutter * (dimensions.rows + 1);
+	const SVGWidth =
+		theme.cellSize * dimensions.cols + theme.gutter * (dimensions.cols + 1);
+
+	const selectClickedCell: MouseEventHandler<SVGSVGElement> = useCallback(
 		(event) => {
-			if (gridRef.current) {
-				const clickX =
-					event.clientX - gridRef.current.getBoundingClientRect().left;
-				const clickY =
-					event.clientY - gridRef.current.getBoundingClientRect().top;
-				const cellX = Math.floor(clickX / (cellSize + theme.gutter));
-				const cellY = Math.floor(clickY / (cellSize + theme.gutter));
-				const entryIds = cells.get(`x${cellX}y${cellY}`)?.group;
-				let entryId;
-				if (entryIds?.length === 1) {
-					entryId = entryIds[0];
-				} else {
-					const newEntryId = entryIds?.find((id) => id !== focus?.entryId);
-					// if you are not already on an entry stay on it unless the new cell has a different entry or you haven't moved cell
-					if (
-						(cellX !== focus?.x || cellY !== focus.y) &&
-						focus?.entryId &&
-						entryIds?.includes(focus.entryId)
-					) {
-						entryId = focus.entryId;
-					} else {
-						entryId = newEntryId;
-					}
-				}
-				setFocus({ x: cellX, y: cellY, entryId });
+			// The 'g' elements in the grid SVG are the cells, and we have set
+			// data-x and data-y attributes on them to represent their position
+			// in the grid.
+			//
+			// _Note that this is not same as the x and y attributes of the SVG
+			// element itself, which are the position of the top left corner of
+			// the element._
+			//
+			// We can use the event target to find the closest 'g' element, and
+			// then get the data-x and data-y attributes to determine which cell
+			// was clicked.
+
+			const { target } = event;
+
+			if (!(target instanceof Element)) {
+				return;
 			}
+			const g = target.closest('[data-x][data-y]');
+
+			if (!g) {
+				return;
+			}
+
+			const clickedCellX = Number(g.getAttribute('data-x'));
+			const clickedCellY = Number(g.getAttribute('data-y'));
+
+			// We may need to update the current entry based on the cell that
+			// was clicked. We'll start by assuming that the current entry still
+			// applies:
+			let newEntryId = currentEntryId;
+
+			// Get the entry IDs that apply to the clicked cell:
+			const entryIdsForCell = cells.get(
+				`x${clickedCellX}y${clickedCellY}`,
+			)?.group;
+
+			// If there are no entries for this cell (i.e. it's a black one),
+			// set the selected entry to undefined
+			if (isUndefined(entryIdsForCell)) {
+				newEntryId = undefined;
+			}
+
+			// This is not a black cell, so we should check if we need to do
+			// anything about the currently selected entry...
+
+			// If there is only one entry for this cell, select it:
+			else if (entryIdsForCell.length === 1) {
+				newEntryId = entryIdsForCell[0];
+			}
+
+			// There are multiple entries for this cell, so we need to decide
+			// which one to select...
+
+			// If we clicked the cell we were already on, switch to the next
+			// entry for the this cell, if there is one (i.e. toggle between up
+			// and down entries):
+			else if (
+				currentCell?.x === clickedCellX &&
+				currentCell.y === clickedCellY
+			) {
+				const alternateEntryId = entryIdsForCell.find(
+					(id) => id !== currentEntryId,
+				);
+
+				if (alternateEntryId) {
+					newEntryId = alternateEntryId;
+				}
+			}
+
+			// We're in a new cell...
+
+			// If we don't have a current entry to worry about, or if the
+			// current entry does not apply to the new cell, get a new new
+			// entry. We'll try to keep the same direction, if possible:
+			else if (!currentEntryId || !entryIdsForCell.includes(currentEntryId)) {
+				const currentDirection = workingDirectionRef.current;
+				const newEntryIdOfCurrentDirection = entryIdsForCell.find((id) =>
+					id.endsWith(currentDirection),
+				);
+				newEntryId = newEntryIdOfCurrentDirection ?? entryIdsForCell[0];
+			}
+
+			// We're done.
+
+			// Save the direction of the final entry, if there is one:
+			const newEntryDirection = newEntryId?.split('-')[1];
+			if (newEntryDirection === 'across' || newEntryDirection === 'down') {
+				workingDirectionRef.current = newEntryDirection;
+			}
+
+			// Set the new current cell and entry:
+			setCurrentCell({ x: clickedCellX, y: clickedCellY });
+			setCurrentEntryId(newEntryId);
 		},
-		[cells, focus, setFocus, theme.gutter],
+		[cells, currentCell, currentEntryId, setCurrentCell, setCurrentEntryId],
 	);
 
 	return (
@@ -68,15 +151,15 @@ export const Grid = ({
 			}}
 			ref={gridRef}
 			viewBox={`0 0 ${SVGWidth} ${SVGHeight}`}
-			onClick={getClickRef}
+			onClick={selectClickedCell}
 		>
 			{Array.from(cells.values()).map((cell) => {
-				const x = cell.x * (cellSize + theme.gutter) + theme.gutter;
-				const y = cell.y * (cellSize + theme.gutter) + theme.gutter;
+				const x = cell.x * (theme.cellSize + theme.gutter) + theme.gutter;
+				const y = cell.y * (theme.cellSize + theme.gutter) + theme.gutter;
 				const guess = progress[cell.x]?.[cell.y];
-				const isFocused = focus?.x === cell.x && focus.y === cell.y;
-				const isHighlighted = focus?.entryId
-					? cell.group?.includes(focus.entryId)
+				const isFocused = currentCell?.x === cell.x && currentCell.y === cell.y;
+				const isHighlighted = currentEntryId
+					? cell.group?.includes(currentEntryId)
 					: false;
 				return (
 					<Cell
@@ -84,7 +167,6 @@ export const Grid = ({
 						data={cell}
 						x={x}
 						y={y}
-						cellSize={cellSize}
 						theme={theme}
 						guess={guess}
 						isFocused={isFocused}

--- a/libs/@guardian/react-crossword/src/theme.ts
+++ b/libs/@guardian/react-crossword/src/theme.ts
@@ -8,4 +8,5 @@ export const defaultTheme: Theme = {
 	gutter: 1,
 	focus: 'lightpink',
 	focusBorder: 'hotpink',
+	cellSize: 32,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,7 +515,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config
       '@guardian/libs':
-        specifier: workspace:*
+        specifier: 19.1.0
         version: link:../libs
       '@guardian/source':
         specifier: 8.0.0


### PR DESCRIPTION
## What are you changing?

some proposed refactors that i found helped me to understand the code. see what you think.

- added `cellSize` to `theme`
- broke up `focus` state into `currentEntryId` and `currentCell`
- added col/row id to the svg cells, so we don't have to calculate cells coords from click location
- the rest is mainly variable names or code order i think, without changing how it works

## Why?

`currentEntryId` or `currentCell` could change without the other needing to, but anything that relied on `focus` would have to re-render e.g. the highlighted clue in the clue list
