### PR TITLE
Update `react-crossword` stories

### DIFF
--- a/libs/@guardian/react-crossword/.storybook/main.ts
+++ b/libs/@guardian/react-crossword/.storybook/main.ts
@@ -3,7 +3,8 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
 	stories: [
-		resolve('..', process.cwd(), 'src/**/*.mdx'),
+		resolve('..', process.cwd(), 'stories/*.@(mdx)'),
+		resolve('..', process.cwd(), 'stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'),
 		resolve('..', process.cwd(), 'src/**/*.stories.@(js|jsx|mjs|ts|tsx)'),
 	],
 	addons: [

--- a/libs/@guardian/react-crossword/.storybook/preview.tsx
+++ b/libs/@guardian/react-crossword/.storybook/preview.tsx
@@ -1,11 +1,4 @@
 import { FocusStyleManager, palette } from '@guardian/source/foundations';
-import {
-	Controls,
-	Description,
-	Primary,
-	Subtitle,
-	Title,
-} from '@storybook/blocks';
 import type { Decorator, Preview } from '@storybook/react';
 import { useEffect } from 'react';
 import { viewport } from './preview/viewport';
@@ -23,6 +16,7 @@ const preview: Preview = {
 		options: {
 			storySort: {
 				method: 'alphabetical-by-kind',
+				order: ['README'], // display these stories first
 			},
 		},
 		controls: {
@@ -30,18 +24,6 @@ const preview: Preview = {
 				color: /(background|color)$/i,
 				date: /Date$/i,
 			},
-		},
-		docs: {
-			page: () => (
-				<>
-					<Title />
-					<Subtitle />
-					<Description />
-					<Primary />
-					<Controls />
-				</>
-			),
-			toc: true,
 		},
 		backgrounds: {
 			default: 'palette.neutral[100]',
@@ -70,7 +52,6 @@ const preview: Preview = {
 		},
 		viewport,
 	},
-	tags: ['autodocs'],
 };
 
 export const decorators = [FocusManagerDecorator];

--- a/libs/@guardian/react-crossword/src/components/Cell.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Cell.stories.tsx
@@ -1,93 +1,98 @@
-import type { Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { defaultTheme } from '../theme';
-import type { CellProps } from './Cell';
 import { Cell } from './Cell';
 
 const meta: Meta<typeof Cell> = {
 	component: Cell,
-	title: 'Cell',
+	title: 'Components/Cell',
+	args: {
+		theme: defaultTheme,
+	},
+	decorators: [
+		(Story, { args }) => (
+			<svg
+				style={{
+					border: `5px solid green`,
+					width: args.theme.cellSize,
+					height: args.theme.cellSize,
+					backgroundColor: args.theme.background,
+				}}
+				viewBox={`0 0 ${args.theme.cellSize} ${args.theme.cellSize}`}
+			>
+				<Story />
+			</svg>
+		),
+	],
 };
 
 export default meta;
+type Story = StoryObj<typeof Cell>;
 
-const Template: StoryFn<typeof Cell> = ({
-	theme = defaultTheme,
-	...args
-}: CellProps) => {
-	return (
-		<svg
-			style={{
-				border: `5px solid green`,
-				width: theme.cellSize,
-				height: theme.cellSize,
-				backgroundColor: theme.background,
-			}}
-			viewBox={`0 0 ${theme.cellSize} ${theme.cellSize}`}
-		>
-			<Cell {...args} theme={theme} />
-		</svg>
-	);
-};
-
-export const Default: StoryFn<typeof Cell> = Template.bind({});
-Default.args = {
-	data: {
-		x: 0,
-		y: 0,
+export const Default: Story = {
+	args: {
+		data: {
+			x: 0,
+			y: 0,
+		},
 	},
 };
 
-export const Empty: StoryFn<typeof Cell> = Template.bind({});
-Empty.args = {
-	data: {
-		x: 0,
-		y: 0,
-		group: ['1-across'],
+export const Empty: Story = {
+	args: {
+		data: {
+			x: 0,
+			y: 0,
+			group: ['1-across'],
+		},
 	},
 };
 
-export const WithNumber: StoryFn<typeof Cell> = Template.bind({});
-WithNumber.args = {
-	data: {
-		x: 0,
-		y: 0,
-		number: 1,
-		group: ['1-across'],
+export const WithNumber: Story = {
+	args: {
+		data: {
+			x: 0,
+			y: 0,
+			number: 1,
+			group: ['1-across'],
+		},
 	},
 };
 
-export const Guessed: StoryFn<typeof Cell> = Template.bind({});
-Guessed.args = {
-	data: {
-		x: 0,
-		y: 0,
-		group: ['1-across'],
+export const Guessed: Story = {
+	args: {
+		data: {
+			x: 0,
+			y: 0,
+			group: ['1-across'],
+		},
+		guess: 'A',
 	},
-	guess: 'A',
 };
 
-export const GuessedWithNumber: StoryFn<typeof Cell> = Template.bind({});
-GuessedWithNumber.args = {
-	data: {
-		x: 0,
-		y: 0,
-		number: 1,
-		group: ['1-across'],
+export const GuessedWithNumber: Story = {
+	args: {
+		data: {
+			x: 0,
+			y: 0,
+			number: 1,
+			group: ['1-across'],
+		},
+		guess: 'A',
 	},
-	guess: 'A',
 };
 
-export const BigCellGuessedWithNumber: StoryFn<typeof Cell> = Template.bind({});
-BigCellGuessedWithNumber.args = {
-	data: {
-		x: 0,
-		y: 0,
-		number: 1,
-		group: ['1-across'],
-	},
-	guess: 'A',
-	theme: {
-		...defaultTheme,
-		cellSize: 50,
+export const BigCellGuessedWithNumber: Story = {
+	args: {
+		data: {
+			x: 0,
+			y: 0,
+			number: 1,
+			group: ['1-across'],
+		},
+		guess: 'A',
+		theme: {
+			...defaultTheme,
+			cellSize: 50,
+		},
 	},
 };

--- a/libs/@guardian/react-crossword/src/components/Crossword.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.stories.tsx
@@ -1,50 +1,21 @@
-import type { Meta, StoryFn } from '@storybook/react';
-import { cryptic } from '../stories/cryptic';
-import { everyman } from '../stories/everyman';
-import { prize } from '../stories/prize';
-import { quick } from '../stories/quick';
-import { quickCryptic } from '../stories/quick-cryptic';
-import { quiptic } from '../stories/quiptic';
-import { special } from '../stories/special';
-import { speedy } from '../stories/speedy';
-import { weekend } from '../stories/weekend';
+import type { Meta, StoryObj } from '@storybook/react';
+import { cryptic } from '../../stories/formats/cryptic';
+import { defaultTheme } from '../theme';
 import { Crossword } from './Crossword';
-import type { CrosswordProps } from './Crossword';
 
 const meta: Meta<typeof Crossword> = {
 	component: Crossword,
-	title: 'Crossword',
+	title: 'Components/Crossword',
+	args: {
+		theme: defaultTheme,
+	},
 };
 
 export default meta;
+type Story = StoryObj<typeof Crossword>;
 
-const Template: StoryFn<typeof Crossword> = (args: CrosswordProps) => {
-	return <Crossword {...args} />;
+export const Default: Story = {
+	args: {
+		data: cryptic,
+	},
 };
-
-export const Cryptic: StoryFn<typeof Crossword> = Template.bind({});
-Cryptic.args = { data: cryptic };
-
-export const Everyman: StoryFn<typeof Crossword> = Template.bind({});
-Everyman.args = { data: everyman };
-
-export const Prize: StoryFn<typeof Crossword> = Template.bind({});
-Prize.args = { data: prize };
-
-export const Quick: StoryFn<typeof Crossword> = Template.bind({});
-Quick.args = { data: quick };
-
-export const QuickCryptic: StoryFn<typeof Crossword> = Template.bind({});
-QuickCryptic.args = { data: quickCryptic };
-
-export const Quiptic: StoryFn<typeof Crossword> = Template.bind({});
-Quiptic.args = { data: quiptic };
-
-export const Special: StoryFn<typeof Crossword> = Template.bind({});
-Special.args = { data: special };
-
-export const Speedy: StoryFn<typeof Crossword> = Template.bind({});
-Speedy.args = { data: speedy };
-
-export const Weekend: StoryFn<typeof Crossword> = Template.bind({});
-Weekend.args = { data: weekend };

--- a/libs/@guardian/react-crossword/src/components/Grid.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.stories.tsx
@@ -1,79 +1,24 @@
-import type { Meta, StoryFn } from '@storybook/react';
-import { cryptic } from '../stories/cryptic';
-import { everyman } from '../stories/everyman';
-import { prize } from '../stories/prize';
-import { quick } from '../stories/quick';
-import { quickCryptic } from '../stories/quick-cryptic';
-import { quiptic } from '../stories/quiptic';
-import { special } from '../stories/special';
-import { speedy } from '../stories/speedy';
-import { weekend } from '../stories/weekend';
+import type { Meta, StoryObj } from '@storybook/react';
+import { cryptic } from '../../stories/formats/cryptic';
 import { defaultTheme } from '../theme';
 import { getCells } from '../utils/getCells';
-import type { GridProps } from './Grid';
 import { Grid } from './Grid';
 
 const meta: Meta<typeof Grid> = {
 	component: Grid,
-	title: 'Grid',
+	title: 'Components/Grid',
+	args: {
+		theme: defaultTheme,
+		progress: [],
+	},
 };
 
 export default meta;
+type Story = StoryObj<typeof Grid>;
 
-const Template: StoryFn<typeof Grid> = (args: GridProps) => {
-	return <Grid {...args} theme={defaultTheme} progress={[]} />;
-};
-
-export const Cryptic: StoryFn<typeof Grid> = Template.bind({});
-Cryptic.args = {
-	cells: getCells(cryptic),
-	dimensions: cryptic.dimensions,
-};
-
-export const Everyman: StoryFn<typeof Grid> = Template.bind({});
-Everyman.args = {
-	cells: getCells(everyman),
-	dimensions: everyman.dimensions,
-};
-
-export const Prize: StoryFn<typeof Grid> = Template.bind({});
-Prize.args = {
-	cells: getCells(prize),
-	dimensions: prize.dimensions,
-};
-
-export const Quick: StoryFn<typeof Grid> = Template.bind({});
-Quick.args = {
-	cells: getCells(quick),
-	dimensions: quick.dimensions,
-};
-
-export const QuickCryptic: StoryFn<typeof Grid> = Template.bind({});
-QuickCryptic.args = {
-	cells: getCells(quickCryptic),
-	dimensions: quickCryptic.dimensions,
-};
-
-export const Quiptic: StoryFn<typeof Grid> = Template.bind({});
-Quiptic.args = {
-	cells: getCells(quiptic),
-	dimensions: quiptic.dimensions,
-};
-
-export const Special: StoryFn<typeof Grid> = Template.bind({});
-Special.args = {
-	cells: getCells(special),
-	dimensions: special.dimensions,
-};
-
-export const Speedy: StoryFn<typeof Grid> = Template.bind({});
-Speedy.args = {
-	cells: getCells(speedy),
-	dimensions: speedy.dimensions,
-};
-
-export const Weekend: StoryFn<typeof Grid> = Template.bind({});
-Weekend.args = {
-	cells: getCells(weekend),
-	dimensions: weekend.dimensions,
+export const Default: Story = {
+	args: {
+		cells: getCells(cryptic),
+		dimensions: cryptic.dimensions,
+	},
 };

--- a/libs/@guardian/react-crossword/stories/Formats.stories.tsx
+++ b/libs/@guardian/react-crossword/stories/Formats.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Crossword } from '../src/index';
+import { defaultTheme } from '../src/theme';
+import { cryptic } from './formats/cryptic';
+import { everyman } from './formats/everyman';
+import { prize } from './formats/prize';
+import { quick } from './formats/quick';
+import { quickCryptic } from './formats/quick-cryptic';
+import { quiptic } from './formats/quiptic';
+import { special } from './formats/special';
+import { speedy } from './formats/speedy';
+import { weekend } from './formats/weekend';
+
+const meta: Meta<typeof Crossword> = {
+	component: Crossword,
+	title: 'Formats',
+	args: {
+		theme: defaultTheme,
+	},
+};
+
+export default meta;
+type Story = StoryObj<typeof Crossword>;
+
+export const Cryptic: Story = {
+	args: { data: cryptic },
+};
+
+export const Everyman: Story = {
+	args: { data: everyman },
+};
+
+export const Prize: Story = {
+	args: { data: prize },
+};
+
+export const Quick: Story = {
+	args: { data: quick },
+};
+
+export const QuickCryptic: Story = {
+	args: { data: quickCryptic },
+};
+
+export const Quiptic: Story = {
+	args: { data: quiptic },
+};
+
+export const Special: Story = {
+	args: { data: special },
+};
+
+export const Speedy: Story = {
+	args: { data: speedy },
+};
+
+export const Weekend: Story = {
+	args: { data: weekend },
+};

--- a/libs/@guardian/react-crossword/stories/README.mdx
+++ b/libs/@guardian/react-crossword/stories/README.mdx
@@ -1,0 +1,4 @@
+import ReadMe from '../README.md?raw';
+import { Markdown } from '@storybook/blocks';
+
+<Markdown>{ReadMe}</Markdown>

--- a/libs/@guardian/react-crossword/stories/formats/cryptic.ts
+++ b/libs/@guardian/react-crossword/stories/formats/cryptic.ts
@@ -1,4 +1,4 @@
-import type { CAPICrossword } from '../@types/CAPI';
+import type { CAPICrossword } from '../../src/@types/CAPI';
 
 export const cryptic: CAPICrossword = {
 	id: 'crosswords/cryptic/29528',

--- a/libs/@guardian/react-crossword/stories/formats/everyman.ts
+++ b/libs/@guardian/react-crossword/stories/formats/everyman.ts
@@ -1,4 +1,4 @@
-import type { CAPICrossword } from '../@types/CAPI';
+import type { CAPICrossword } from '../../src/@types/CAPI';
 
 export const everyman: CAPICrossword = {
 	id: 'crosswords/everyman/4071',

--- a/libs/@guardian/react-crossword/stories/formats/prize.ts
+++ b/libs/@guardian/react-crossword/stories/formats/prize.ts
@@ -1,4 +1,4 @@
-import type { CAPICrossword } from '../@types/CAPI';
+import type { CAPICrossword } from '../../src/@types/CAPI';
 
 export const prize: CAPICrossword = {
 	id: 'crosswords/prize/29524',

--- a/libs/@guardian/react-crossword/stories/formats/quick-cryptic.ts
+++ b/libs/@guardian/react-crossword/stories/formats/quick-cryptic.ts
@@ -1,4 +1,4 @@
-import type { CAPICrossword } from '../@types/CAPI';
+import type { CAPICrossword } from '../../src/@types/CAPI';
 
 export const quickCryptic: CAPICrossword = {
 	id: 'crosswords/quick-cryptic/30',

--- a/libs/@guardian/react-crossword/stories/formats/quick.ts
+++ b/libs/@guardian/react-crossword/stories/formats/quick.ts
@@ -1,4 +1,4 @@
-import type { CAPICrossword } from '../@types/CAPI';
+import type { CAPICrossword } from '../../src/@types/CAPI';
 
 export const quick: CAPICrossword = {
 	id: 'crosswords/quick/17001',

--- a/libs/@guardian/react-crossword/stories/formats/quiptic.ts
+++ b/libs/@guardian/react-crossword/stories/formats/quiptic.ts
@@ -1,4 +1,4 @@
-import type { CAPICrossword } from '../@types/CAPI';
+import type { CAPICrossword } from '../../src/@types/CAPI';
 
 export const quiptic: CAPICrossword = {
 	id: 'crosswords/quiptic/1301',

--- a/libs/@guardian/react-crossword/stories/formats/special.ts
+++ b/libs/@guardian/react-crossword/stories/formats/special.ts
@@ -1,4 +1,4 @@
-import type { CAPICrossword } from '../@types/CAPI';
+import type { CAPICrossword } from '../../src/@types/CAPI';
 
 export const special: CAPICrossword = {
 	id: 'crosswords/special/1',

--- a/libs/@guardian/react-crossword/stories/formats/speedy.ts
+++ b/libs/@guardian/react-crossword/stories/formats/speedy.ts
@@ -1,4 +1,4 @@
-import type { CAPICrossword } from '../@types/CAPI';
+import type { CAPICrossword } from '../../src/@types/CAPI';
 
 export const speedy: CAPICrossword = {
 	id: 'crosswords/speedy/1516',

--- a/libs/@guardian/react-crossword/stories/formats/weekend.ts
+++ b/libs/@guardian/react-crossword/stories/formats/weekend.ts
@@ -1,4 +1,4 @@
-import type { CAPICrossword } from '../@types/CAPI';
+import type { CAPICrossword } from '../../src/@types/CAPI';
 
 export const weekend: CAPICrossword = {
 	id: 'crosswords/weekend/720',


### PR DESCRIPTION
## What are you changing?

- adds the readme
- creates format stories and component stories

refs https://github.com/guardian/dotcom-rendering/issues/12809

## Why?

- to isolate the specifics of each component/usage

<img width="281" alt="image" src="https://github.com/user-attachments/assets/f2e295ef-b1b4-4789-a520-06e61c886dd1">

