### PR TITLE
Crossword housekeeping

### DIFF
--- a/libs/@guardian/react-crossword/src/@types/crossword.ts
+++ b/libs/@guardian/react-crossword/src/@types/crossword.ts
@@ -17,7 +17,10 @@ export type Cell = {
 	solution?: string;
 };
 
-export type Cells = Map<`x${number}y${number}`, Cell>;
+export type Cells = Map<`x${number}y${number}`, Cell> & {
+	getByCoords: (x: number, y: number) => ReturnType<Cells['get']>;
+};
+
 export type Entries = Map<EntryID, CAPIEntry>;
 
 export type Progress = string[][];

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -25,8 +25,9 @@ export type CrosswordProps = {
 	theme?: Partial<Theme>;
 };
 
-export const Crossword = ({ theme: userTheme, ...props }: CrosswordProps) => {
-	const { id, dimensions } = props.data;
+export const Crossword = ({ theme: userTheme, data }: CrosswordProps) => {
+	const { id, dimensions } = data;
+
 	const [progress, setProgress] = useState<Progress>(
 		getStoredProgress({ id, dimensions }) ?? getEmptyProgress(dimensions),
 	);
@@ -57,11 +58,11 @@ export const Crossword = ({ theme: userTheme, ...props }: CrosswordProps) => {
 
 	const [currentEntryId, setCurrentEntryId] = useState<
 		CurrentEntryId | undefined
-	>(props.data.entries[0].id);
+	>(data.entries[0].id);
 
 	const [currentCell, setCurrentCell] = useState<CurrentCell | undefined>({
-		x: props.data.entries[0].position.x,
-		y: props.data.entries[0].position.y,
+		x: data.entries[0].position.x,
+		y: data.entries[0].position.y,
 	});
 
 	const workingDirectionRef = useRef<Direction>('across');
@@ -70,10 +71,7 @@ export const Crossword = ({ theme: userTheme, ...props }: CrosswordProps) => {
 
 	const theme = { ...defaultTheme, ...userTheme };
 
-	const { entries, cells } = useMemo(
-		() => parseCrosswordData(props.data),
-		[props.data],
-	);
+	const { entries, cells } = useMemo(() => parseCrosswordData(data), [data]);
 
 	const moveFocus = useCallback(
 		({
@@ -369,13 +367,13 @@ export const Crossword = ({ theme: userTheme, ...props }: CrosswordProps) => {
 			<div>
 				<Clues
 					direction="across"
-					entries={props.data.entries}
+					entries={data.entries}
 					currentEntryId={currentEntryId}
 					theme={theme}
 				/>
 				<Clues
 					direction="down"
-					entries={props.data.entries}
+					entries={data.entries}
 					currentEntryId={currentEntryId}
 					theme={theme}
 				/>

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -32,30 +32,6 @@ export const Crossword = ({ theme: userTheme, data }: CrosswordProps) => {
 		getStoredProgress({ id, dimensions }) ?? getEmptyProgress(dimensions),
 	);
 
-	// Storage event listener to update progress when another instance of the crossword is updated
-	// 'storage' event is fired when localStorage is updated in another tab or window
-	const handleLocalStorageEvent = useCallback(
-		(event: StorageEvent) => {
-			if (event.key === id) {
-				const storedProgress = getStoredProgress({
-					id,
-					dimensions,
-				});
-				if (storedProgress) {
-					setProgress(storedProgress);
-				}
-			}
-		},
-		[dimensions, id],
-	);
-
-	useEffect(() => {
-		window.addEventListener('storage', handleLocalStorageEvent);
-		return () => {
-			window.removeEventListener('storage', handleLocalStorageEvent);
-		};
-	}, [handleLocalStorageEvent]);
-
 	const [currentEntryId, setCurrentEntryId] = useState<
 		CurrentEntryId | undefined
 	>(data.entries[0].id);
@@ -329,19 +305,43 @@ export const Crossword = ({ theme: userTheme, data }: CrosswordProps) => {
 		[entries],
 	);
 
+	// Storage event listener to update progress when another instance of the crossword is updated
+	// 'storage' event is fired when localStorage is updated in another tab or window
+	const handleLocalStorageEvent = useCallback(
+		(event: StorageEvent) => {
+			if (event.key === id) {
+				const storedProgress = getStoredProgress({
+					id,
+					dimensions,
+				});
+				if (storedProgress) {
+					setProgress(storedProgress);
+				}
+			}
+		},
+		[dimensions, id],
+	);
+
 	useEffect(() => {
 		const application = applicationRef.current;
 
 		application?.addEventListener('keydown', handleKeyDown);
 		application?.addEventListener('click', handleClueClick);
 		application?.addEventListener('click', selectClickedCell);
+		window.addEventListener('storage', handleLocalStorageEvent);
 
 		return () => {
 			application?.removeEventListener('keydown', handleKeyDown);
 			application?.removeEventListener('click', handleClueClick);
 			application?.removeEventListener('click', selectClickedCell);
+			window.removeEventListener('storage', handleLocalStorageEvent);
 		};
-	}, [handleKeyDown, handleClueClick, selectClickedCell]);
+	}, [
+		handleKeyDown,
+		handleClueClick,
+		selectClickedCell,
+		handleLocalStorageEvent,
+	]);
 
 	return (
 		<div

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -11,7 +11,7 @@ import type {
 import type { Direction } from '../@types/Direction';
 import type { EntryID } from '../@types/Entry';
 import { defaultTheme } from '../theme';
-import { parseCrosswordData } from '../utils/getCells';
+import { parseCrosswordData } from '../utils/parseCrosswordData';
 import {
 	getEmptyProgress,
 	getStoredProgress,
@@ -89,7 +89,7 @@ export const Crossword = ({ theme: userTheme, ...props }: CrosswordProps) => {
 
 			const newX = currentCell.x + delta.x;
 			const newY = currentCell.y + delta.y;
-			const newCell = cells.get(`x${newX}y${newY}`);
+			const newCell = cells.getByCoords(newX, newY);
 
 			if (!newCell) {
 				return;
@@ -249,8 +249,9 @@ export const Crossword = ({ theme: userTheme, ...props }: CrosswordProps) => {
 			let newEntryId = currentEntryId;
 
 			// Get the entry IDs that apply to the clicked cell:
-			const entryIdsForCell = cells.get(
-				`x${clickedCellX}y${clickedCellY}`,
+			const entryIdsForCell = cells.getByCoords(
+				clickedCellX,
+				clickedCellY,
 			)?.group;
 
 			// If there are no entries for this cell (i.e. it's a black one),

--- a/libs/@guardian/react-crossword/src/components/Grid.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { cryptic } from '../../stories/formats/cryptic';
 import { defaultTheme } from '../theme';
-import { parseCrosswordData } from '../utils/getCells';
+import { parseCrosswordData } from '../utils/parseCrosswordData';
 import { Grid } from './Grid';
 
 const meta: Meta<typeof Grid> = {

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -37,8 +37,6 @@ export const Grid = ({
 	const SVGWidth =
 		theme.cellSize * dimensions.cols + theme.gutter * (dimensions.cols + 1);
 
-	const cellSpace = theme.cellSize + theme.gutter + theme.gutter;
-
 	return (
 		<svg
 			style={{
@@ -51,17 +49,13 @@ export const Grid = ({
 			tabIndex={-1}
 		>
 			{Array.from(cells.values()).map((cell) => {
-				const x = cell.x * cellSpace;
-				const y = cell.y * cellSpace;
-
+				const x = cell.x * (theme.cellSize + theme.gutter) + theme.gutter;
+				const y = cell.y * (theme.cellSize + theme.gutter) + theme.gutter;
 				const guess = progress[cell.x]?.[cell.y];
-
 				const isFocused = currentCell?.x === cell.x && currentCell.y === cell.y;
-
 				const isHighlighted = currentEntryId
 					? cell.group?.includes(currentEntryId)
 					: false;
-
 				return (
 					<Cell
 						key={`x${cell.x}y${cell.y}`}

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -37,6 +37,8 @@ export const Grid = ({
 	const SVGWidth =
 		theme.cellSize * dimensions.cols + theme.gutter * (dimensions.cols + 1);
 
+	const cellSpace = theme.cellSize + theme.gutter + theme.gutter;
+
 	return (
 		<svg
 			style={{
@@ -49,13 +51,17 @@ export const Grid = ({
 			tabIndex={-1}
 		>
 			{Array.from(cells.values()).map((cell) => {
-				const x = cell.x * (theme.cellSize + theme.gutter) + theme.gutter;
-				const y = cell.y * (theme.cellSize + theme.gutter) + theme.gutter;
+				const x = cell.x * cellSpace;
+				const y = cell.y * cellSpace;
+
 				const guess = progress[cell.x]?.[cell.y];
+
 				const isFocused = currentCell?.x === cell.x && currentCell.y === cell.y;
+
 				const isHighlighted = currentEntryId
 					? cell.group?.includes(currentEntryId)
 					: false;
+
 				return (
 					<Cell
 						key={`x${cell.x}y${cell.y}`}

--- a/libs/@guardian/react-crossword/src/utils/parseCrosswordData.ts
+++ b/libs/@guardian/react-crossword/src/utils/parseCrosswordData.ts
@@ -12,13 +12,20 @@ export const parseCrosswordData = (data: CAPICrossword) => {
 
 	// create a map of all possible cells that assumes they are all empty (black)
 	const { cols, rows } = data.dimensions;
+
 	/**
 	 * A map of all cells in the crossword, indexed by their x and y coordinates.
 	 */
-	const cells: Cells = new Map(
-		Array.from({ length: cols }, (_, x) =>
-			Array.from({ length: rows }, (_, y) => [`x${x}y${y}`, { x, y }] as const),
-		).flat(),
+	const cells: Cells = Object.assign(
+		new Map(
+			Array.from({ length: cols }, (_, x) =>
+				Array.from(
+					{ length: rows },
+					(_, y) => [`x${x}y${y}`, { x, y }] as const,
+				),
+			).flat(),
+		),
+		{ getByCoords: (x: number, y: number) => cells.get(`x${x}y${y}`) },
 	);
 
 	// Now loop through all entries. For each entry, we'll populate the entriesById and allCells maps.
@@ -38,7 +45,7 @@ export const parseCrosswordData = (data: CAPICrossword) => {
 				y += i;
 			}
 
-			const cell = cells.get(`x${x}y${y}`);
+			const cell = cells.getByCoords(x, y);
 			const group: Cell['group'] = [entry.id, ...(cell?.group ?? [])];
 			const number: Cell['number'] = i === 0 ? entry.number : undefined;
 


### PR DESCRIPTION
- add `cells.getByCoords`
- destruct `data` from props in `Crossword`
- use one `useEffect` and put all state at the top of `Crossword`