### PR TITLE
Lint js/ts files in react config

### DIFF
--- a/libs/@guardian/eslint-config/CHANGELOG.md
+++ b/libs/@guardian/eslint-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/eslint-config
 
+## 10.0.0-beta.7
+
+### Breaking Changes
+
+- Run react checks on `js` and `ts` files too (e.g. for custom hooks).
+
 ## 10.0.0-beta.6
 
 ### Patch Changes

--- a/libs/@guardian/eslint-config/configs/react.js
+++ b/libs/@guardian/eslint-config/configs/react.js
@@ -6,7 +6,7 @@ import globals from 'globals';
 export default [
 	{
 		name: '@guardian/react',
-		files: ['**/*.{jsx,mjsx,tsx,mtsx}'],
+		files: ['**/*.{js,ts,jsx,mjsx,tsx,mtsx}'],
 		languageOptions: {
 			...react.configs.flat.recommended.languageOptions,
 			globals: {

--- a/libs/@guardian/eslint-config/package.json
+++ b/libs/@guardian/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/eslint-config",
-	"version": "10.0.0-beta.6",
+	"version": "10.0.0-beta.7",
 	"description": "ESLint config for Guardian JavaScript projects",
 	"type": "module",
 	"main": "index.js",


### PR DESCRIPTION
## What are you changing?

- adding `js`/`ts` extensions to the list of files covered by the react config

## Why?

so that things like custom hooks are linted
