### PR TITLE
Use `use-local-storage-state` for crosswords

### DIFF
--- a/configs/jest.config.js
+++ b/configs/jest.config.js
@@ -3,7 +3,9 @@ export const config = {
 	clearMocks: true,
 	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
 	testPathIgnorePatterns: ['/node_modules/', '/.wireit/'],
-	transformIgnorePatterns: ['node_modules/.pnpm/(?!@guardian)'],
+	transformIgnorePatterns: [
+		'node_modules/.pnpm/(?!@guardian|use-local-storage-state)',
+	],
 	transform: {
 		'^.+\\.[tj]sx?$': ['ts-jest'],
 	},

--- a/libs/@guardian/react-crossword/package.json
+++ b/libs/@guardian/react-crossword/package.json
@@ -27,7 +27,8 @@
 		"verify-dist": "wireit"
 	},
 	"dependencies": {
-		"tslib": "2.6.2"
+		"tslib": "2.6.2",
+		"use-local-storage-state": "19.5.0"
 	},
 	"devDependencies": {
 		"@emotion/react": "11.11.3",

--- a/libs/@guardian/react-crossword/src/components/Clues.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof Clues> = {
 				value={{
 					progress,
 					setProgress: () => {},
-					updateProgress: () => {},
+					setCellProgress: () => {},
 					clearProgress: () => {},
 				}}
 			>

--- a/libs/@guardian/react-crossword/src/components/Controls.tsx
+++ b/libs/@guardian/react-crossword/src/components/Controls.tsx
@@ -18,7 +18,7 @@ export const Controls = ({
 	cells,
 	currentEntryId,
 }: ControlProps) => {
-	const { progress, updateProgress, clearProgress } =
+	const { progress, setCellProgress, clearProgress } =
 		useContext(ProgressContext);
 	const theme = useContext(ThemeContext);
 
@@ -30,14 +30,14 @@ export const Controls = ({
 	const revealEntry = useCallback(() => {
 		for (const cell of cells.values()) {
 			if (currentEntryId && cell.group?.includes(currentEntryId)) {
-				updateProgress({
+				setCellProgress({
 					x: cell.x,
 					y: cell.y,
 					value: cell.solution ?? '',
 				});
 			}
 		}
-	}, [cells, currentEntryId, updateProgress]);
+	}, [cells, currentEntryId, setCellProgress]);
 
 	const revealGrid = useCallback(() => {
 		for (const cell of cells.values()) {
@@ -52,28 +52,28 @@ export const Controls = ({
 	const clearEntry = useCallback(() => {
 		for (const cell of cells.values()) {
 			if (currentEntryId && cell.group?.includes(currentEntryId)) {
-				updateProgress({
+				setCellProgress({
 					x: cell.x,
 					y: cell.y,
 					value: '',
 				});
 			}
 		}
-	}, [cells, currentEntryId, updateProgress]);
+	}, [cells, currentEntryId, setCellProgress]);
 
 	const checkCell = useCallback(
 		(cell: Cell) => {
 			const currentProgress = progress[cell.x]?.[cell.y];
 			const isCorrect = currentProgress && currentProgress === cell.solution;
 			if (!isCorrect) {
-				updateProgress({
+				setCellProgress({
 					x: cell.x,
 					y: cell.y,
 					value: '',
 				});
 			}
 		},
-		[progress, updateProgress],
+		[progress, setCellProgress],
 	);
 
 	const checkEntry = useCallback(() => {

--- a/libs/@guardian/react-crossword/src/components/Controls.tsx
+++ b/libs/@guardian/react-crossword/src/components/Controls.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import type { ThemeButton } from '@guardian/source/react-components';
 import { useCallback, useContext } from 'react';
-import type { Cell, Cells } from '../@types/crossword';
+import type { Cell, Cells, Progress } from '../@types/crossword';
 import type { EntryID } from '../@types/Entry';
 import { ProgressContext } from '../context/ProgressContext';
 import { ThemeContext } from '../context/ThemeContext';
@@ -18,7 +18,7 @@ export const Controls = ({
 	cells,
 	currentEntryId,
 }: ControlProps) => {
-	const { progress, setCellProgress, clearProgress } =
+	const { progress, setProgress, setCellProgress, clearProgress } =
 		useContext(ProgressContext);
 	const theme = useContext(ThemeContext);
 
@@ -40,14 +40,15 @@ export const Controls = ({
 	}, [cells, currentEntryId, setCellProgress]);
 
 	const revealGrid = useCallback(() => {
+		const newProgress: Progress = [];
+
 		for (const cell of cells.values()) {
-			updateProgress({
-				x: cell.x,
-				y: cell.y,
-				value: cell.solution ?? '',
-			});
+			const column = (newProgress[cell.x] ||= []);
+			column[cell.y] = cell.solution ?? '';
 		}
-	}, [cells, updateProgress]);
+
+		setProgress(newProgress);
+	}, [cells, setProgress]);
 
 	const clearEntry = useCallback(() => {
 		for (const cell of cells.values()) {

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -34,7 +34,7 @@ export const Crossword = ({
 		data.entries[0].position,
 	);
 
-	const [progress, setProgress, updateProgress, clearProgress] = useProgress(
+	const [progress, setProgress, setCellProgress, clearProgress] = useProgress(
 		data,
 		userProgress,
 	);
@@ -148,7 +148,7 @@ export const Crossword = ({
 					if (!currentEntryId) {
 						return;
 					}
-					updateProgress({ ...currentCell, value: '' });
+					setCellProgress({ ...currentCell, value: '' });
 					if (key === 'Backspace') {
 						if (direction === 'across') {
 							moveFocus({ delta: { x: -1, y: 0 }, isTyping: true });
@@ -162,7 +162,7 @@ export const Crossword = ({
 				default: {
 					const upperCaseKey = key.toUpperCase();
 					if (/^[A-Z]$/.test(upperCaseKey) && currentEntryId) {
-						updateProgress({ ...currentCell, value: upperCaseKey });
+						setCellProgress({ ...currentCell, value: upperCaseKey });
 						if (direction === 'across') {
 							moveFocus({ delta: { x: 1, y: 0 }, isTyping: true });
 						}
@@ -180,7 +180,7 @@ export const Crossword = ({
 				event.preventDefault();
 			}
 		},
-		[currentCell, currentEntryId, moveFocus, handleTab, updateProgress],
+		[currentCell, currentEntryId, moveFocus, handleTab, setCellProgress],
 	);
 
 	const selectClickedCell = useCallback(
@@ -316,7 +316,7 @@ export const Crossword = ({
 	return (
 		<ThemeContext.Provider value={theme}>
 			<ProgressContext.Provider
-				value={{ progress, setProgress, updateProgress, clearProgress }}
+				value={{ progress, setProgress, setCellProgress, clearProgress }}
 			>
 				<div
 					role="application"

--- a/libs/@guardian/react-crossword/src/components/Grid.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta<typeof Grid> = {
 				value={{
 					progress,
 					setProgress: () => {},
-					updateProgress: () => {},
+					setCellProgress: () => {},
 					clearProgress: () => {},
 				}}
 			>

--- a/libs/@guardian/react-crossword/src/context/ProgressContext.ts
+++ b/libs/@guardian/react-crossword/src/context/ProgressContext.ts
@@ -6,13 +6,14 @@ type Hook = ReturnType<typeof useProgress>;
 type Context = {
 	progress: Hook[0];
 	setProgress: Hook[1];
-	updateProgress: Hook[2];
+	setCellProgress: Hook[2];
 	clearProgress: Hook[3];
 };
 
 export const ProgressContext = createContext<Context>({
 	progress: [],
 	setProgress: () => console.log('setProgress not provided to context!!'),
-	updateProgress: () => console.log('updateProgress not provided to context!!'),
+	setCellProgress: () =>
+		console.log('updateProgress not provided to context!!'),
 	clearProgress: () => console.log('clearProgress not provided to context!!'),
 });

--- a/libs/@guardian/react-crossword/src/hooks/useProgress.ts
+++ b/libs/@guardian/react-crossword/src/hooks/useProgress.ts
@@ -103,7 +103,6 @@ export const useProgress = (data: CAPICrossword, userProgress?: Progress) => {
 		setProgress(getEmptyProgress(dimensions));
 	}, [dimensions]);
 
-	const updateProgress = useCallback(
 		({ x, y, value }: { x: number; y: number; value: string }) => {
 			// call `setProgress` using callback method to make sure the new
 			// `progress` state is derived from the current state
@@ -118,6 +117,7 @@ export const useProgress = (data: CAPICrossword, userProgress?: Progress) => {
 		},
 		[setProgress],
 	);
+	const setCellProgress = useCallback(
 
 	// Keep local storage in sync with progress state
 	useEffect(() => {
@@ -150,5 +150,5 @@ export const useProgress = (data: CAPICrossword, userProgress?: Progress) => {
 		};
 	}, [handleLocalStorageEvent]);
 
-	return [progress, setProgress, updateProgress, clearProgress] as const;
+	return [progress, setProgress, setCellProgress, clearProgress] as const;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,6 +510,9 @@ importers:
       tslib:
         specifier: 2.6.2
         version: 2.6.2
+      use-local-storage-state:
+        specifier: 19.5.0
+        version: 19.5.0(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@emotion/react':
         specifier: 11.11.3
@@ -9803,7 +9806,6 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.2
-    dev: true
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -9820,7 +9822,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: true
 
   /read-package-up@11.0.0:
     resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
@@ -10283,7 +10284,6 @@ packages:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
     dependencies:
       loose-envify: 1.4.0
-    dev: true
 
   /scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
@@ -11327,6 +11327,17 @@ packages:
       querystringify: 2.2.0
       requires-port: 1.0.0
     dev: true
+
+  /use-local-storage-state@19.5.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-sUJAyFvsmqMpBhdwaRr7GTKkkoxb6PWeNVvpBDrLuwQF1PpbJRKIbOYeLLeqJI7B3wdfFlLLCBbmOdopiSTBOw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}


### PR DESCRIPTION
## What are you changing?

- replaces our own state-to-`localStorage` handling with [`use-local-storage-state`](https://www.npmjs.com/package/use-local-storage-state)
- renames `updateProgress` → `setCellProgress` (i was getting update/set mixed up when reading)
- updated `revealGrid` to make one change to the state (rather than one call per cell, which was causing a lot of local storage writes)

## Why?

Simpler code for us, and better performance for users
