### PR TITLE
Fix for usnat supported api lookup

### DIFF
--- a/.changeset/silver-taxis-learn.md
+++ b/.changeset/silver-taxis-learn.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': patch
+---
+
+Fix cmp usnat supported api lookup

--- a/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.test.js
+++ b/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.test.js
@@ -7,6 +7,9 @@ import { getConsentState } from './getConsentState.ts';
 jest.mock('./api');
 
 describe('getConsentState', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
 	it('gets the gpp consent state correctly - doNotSell is false', async () => {
 		getGPPData.mockResolvedValue(gppDataCanSell);
 

--- a/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.ts
@@ -1,18 +1,29 @@
 import { type USNATConsentState } from '../types/usnat';
 import { getGPPData } from './api';
 
+const getSupportedAPIv1 = (
+	supportedAPI: string | undefined,
+): string | undefined => {
+	if (supportedAPI?.includes('usnat')) {
+		return supportedAPI.includes('v1') ? supportedAPI : `${supportedAPI}'v1'`;
+	}
+	return supportedAPI;
+};
+
 export const getConsentState: () => Promise<USNATConsentState> = async () => {
 	let doNotSell = false; // Opt-Out
 	const gppData = await getGPPData();
 
-	const supportedAPIs = gppData.supportedAPIs[0]?.split(':')[1]; // E.G: '7:usnatv1', '8:uscav1'
+	const supportedAPI = gppData.supportedAPIs[0]?.split(':')[1]; // E.G: '7:usnatv1', '8:uscav1'
+	// Temporary fix 21/11/2024
+	const supportedAPIv1 = getSupportedAPIv1(supportedAPI);
 
-	if (supportedAPIs) {
-		//0 Not Applicable. SharingOptOutNotice value was not applicable or no notice was provided, 1 Opted Out, 2 Did Not Opt Out
-		doNotSell =
-			gppData.parsedSections[supportedAPIs]?.SaleOptOut !== 2 ||
-			gppData.parsedSections[supportedAPIs].Gpc;
+	if (supportedAPIv1) {
 		// https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/US-National/IAB%20Privacy%E2%80%99s%20National%20Privacy%20Technical%20Specification.md
+		// 0 Not Applicable. SharingOptOutNotice value was not applicable or no notice was provided, 1 Opted Out, 2 Did Not Opt Out
+		doNotSell =
+			gppData.parsedSections[supportedAPIv1]?.SaleOptOut !== 2 ||
+			gppData.parsedSections[supportedAPIv1].Gpc;
 	}
 
 	return {

--- a/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.ts
@@ -1,31 +1,15 @@
 import { type USNATConsentState } from '../types/usnat';
 import { getGPPData } from './api';
 
-const usnatStates = ['usnat', 'usca', 'usva', 'usco', 'usut', 'usct'];
-
-const getSupportedAPIv1 = (
-	supportedAPI: string | undefined,
-): string | undefined => {
-	if (supportedAPI && usnatStates.includes(supportedAPI)) {
-		return supportedAPI.includes('v1') ? supportedAPI : `${supportedAPI}v1`;
-	}
-	return supportedAPI;
-};
-
 export const getConsentState: () => Promise<USNATConsentState> = async () => {
 	let doNotSell = false; // Opt-Out
 	const gppData = await getGPPData();
+	const supportedAPI = gppData.parsedSections[0];
 
-	const supportedAPI = gppData.supportedAPIs[0]?.split(':')[1]; // E.G: '7:usnatv1', '8:uscav1'
-	// Temporary fix 21/11/2024
-	const supportedAPIv1 = getSupportedAPIv1(supportedAPI);
-
-	if (supportedAPIv1) {
+	if (supportedAPI) {
 		// https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/US-National/IAB%20Privacy%E2%80%99s%20National%20Privacy%20Technical%20Specification.md
 		// 0 Not Applicable. SharingOptOutNotice value was not applicable or no notice was provided, 1 Opted Out, 2 Did Not Opt Out
-		doNotSell =
-			gppData.parsedSections[supportedAPIv1]?.SaleOptOut !== 2 ||
-			gppData.parsedSections[supportedAPIv1].Gpc;
+		doNotSell = supportedAPI.SaleOptOut !== 2 || supportedAPI.Gpc;
 	}
 
 	return {

--- a/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.ts
@@ -4,7 +4,7 @@ import { getGPPData } from './api';
 export const getConsentState: () => Promise<USNATConsentState> = async () => {
 	let doNotSell = false; // Opt-Out
 	const gppData = await getGPPData();
-	const supportedAPI = gppData.parsedSections[0];
+	const supportedAPI = Object.values(gppData.parsedSections)[0];
 
 	if (supportedAPI) {
 		// https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/US-National/IAB%20Privacy%E2%80%99s%20National%20Privacy%20Technical%20Specification.md

--- a/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.ts
@@ -5,7 +5,7 @@ const getSupportedAPIv1 = (
 	supportedAPI: string | undefined,
 ): string | undefined => {
 	if (supportedAPI?.includes('usnat')) {
-		return supportedAPI.includes('v1') ? supportedAPI : `${supportedAPI}'v1'`;
+		return supportedAPI.includes('v1') ? supportedAPI : `${supportedAPI}v1`;
 	}
 	return supportedAPI;
 };

--- a/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/usnat/getConsentState.ts
@@ -1,10 +1,12 @@
 import { type USNATConsentState } from '../types/usnat';
 import { getGPPData } from './api';
 
+const usnatStates = ['usnat', 'usca', 'usva', 'usco', 'usut', 'usct'];
+
 const getSupportedAPIv1 = (
 	supportedAPI: string | undefined,
 ): string | undefined => {
-	if (supportedAPI?.includes('usnat')) {
+	if (supportedAPI && usnatStates.includes(supportedAPI)) {
 		return supportedAPI.includes('v1') ? supportedAPI : `${supportedAPI}v1`;
 	}
 	return supportedAPI;


### PR DESCRIPTION
## Why?

Since 19/11/2034 ~ 18:00 UTC the consent state property `doNotSell` is being set to true for all US users regardless of their consent choice. This mean third party integrations that check for `doNotSell` before loading are not running e.g. prebid, comscore and a9 (Amazon ads).

### gppData

We read the `gppData` object as provided by Sourcepoint:

<img src="https://github.com/user-attachments/assets/fec25081-79dc-4e89-b19e-d7c032f91061" width="300px" />

### supportedAPIs string

In order to lookup the usnat metadata we read the `gppData.supportedAPIs` property and split the string to set the `supportedAPIs` string (e.g. `usnat`) 

### supportedAPIs lookup

We then use the `supportedAPIs` string to lookup the property on `gppData.parsedSection[supportedAPIs]`

However currently the `supportedAPIs` string is resolving to `usnat` but the property on `gppData.parsedSection` is `usnatv1`

This causes the lookup to fail and sets `doNotSell` to true.

## What are you changing?

This change updates the logic so rather than using the `supportedAPIs` string it directly attempts to read the first object in `gppData.parsedSection`.
