### PR TITLE
Say that crosswords are saved

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
-import { space } from '@guardian/source/foundations';
+import { space, textSans12 } from '@guardian/source/foundations';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CAPICrossword } from '../@types/CAPI';
 import type { Coords, Progress, Theme } from '../@types/crossword';
@@ -34,10 +34,8 @@ export const Crossword = ({
 		data.entries[0].position,
 	);
 
-	const [progress, setProgress, setCellProgress, clearProgress] = useProgress(
-		data,
-		userProgress,
-	);
+	const [progress, setProgress, setCellProgress, clearProgress, isStored] =
+		useProgress(data, userProgress);
 
 	const workingDirectionRef = useRef<Direction>('across');
 	const applicationRef = useRef<HTMLDivElement | null>(null);
@@ -350,6 +348,17 @@ export const Crossword = ({
 							solutionsAvailable={data.solutionAvailable}
 							currentEntryId={currentEntryId}
 						/>
+						<p
+							css={css`
+								${textSans12};
+								font-style: italic;
+								color: ${theme.text};
+							`}
+						>
+							{isStored
+								? 'Crosswords are saved automatically.'
+								: 'Crossword will not be saved.'}
+						</p>
 					</div>
 					<div
 						css={css`


### PR DESCRIPTION
_depends on #1805_

## What are you changing?

displays a message saying that crosswords are saved (or that they're not, if not)

### `localStorage` is available
<img width="336" alt="image" src="https://github.com/user-attachments/assets/3a47e062-107d-4d0c-b799-29b01bd7a572">

### `localStorage` is not available
<img width="339" alt="image" src="https://github.com/user-attachments/assets/6118f0af-4af5-45fa-9593-4444b9de1e29">



## Why?

parity with prod, and a little bit more