### PR TITLE
Zetterise crossword input

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Cell.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Cell.stories.tsx
@@ -97,6 +97,17 @@ export const Progress: Story = {
 	},
 };
 
+export const DiacriticProgress: Story = {
+	args: {
+		data: {
+			x: 0,
+			y: 0,
+			group: ['1-across'],
+		},
+		guess: 'Å',
+	},
+};
+
 export const ProgressWithNumber: Story = {
 	args: {
 		...args,

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -161,9 +161,8 @@ export const Crossword = ({
 					break;
 				}
 				default: {
-					const upperCaseKey = key.toUpperCase();
-					if (keyDownRegex.test(upperCaseKey) && currentEntryId) {
-						setCellProgress({ ...currentCell, value: upperCaseKey });
+					if (currentEntryId && keyDownRegex.test(key)) {
+						setCellProgress({ ...currentCell, value: key.toUpperCase() });
 						if (direction === 'across') {
 							moveFocus({ delta: { x: 1, y: 0 }, isTyping: true });
 						}

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -15,6 +15,9 @@ import { Clues } from './Clues';
 import { Controls } from './Controls';
 import { Grid } from './Grid';
 
+// define and cache the regex for valid keydown events
+const keyDownRegex = /^[A-Za-zÀ-ÿ0-9]$/;
+
 export type CrosswordProps = {
 	data: CAPICrossword;
 	theme?: Partial<Theme>;
@@ -159,7 +162,7 @@ export const Crossword = ({
 				}
 				default: {
 					const upperCaseKey = key.toUpperCase();
-					if (/^[A-Z]$/.test(upperCaseKey) && currentEntryId) {
+					if (keyDownRegex.test(upperCaseKey) && currentEntryId) {
 						setCellProgress({ ...currentCell, value: upperCaseKey });
 						if (direction === 'across') {
 							moveFocus({ delta: { x: 1, y: 0 }, isTyping: true });


### PR DESCRIPTION
## What are you changing?

handle entries with numbers and diacritics in their solution

## Why?

https://github.com/guardian/frontend/pull/20733 – always in our hearts
