### PR TITLE
Make crossword theme settings standard props

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Crossword.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.stories.tsx
@@ -16,3 +16,21 @@ export default meta;
 type Story = StoryObj<typeof Crossword>;
 
 export const Default: Story = {};
+
+export const Themed: Story = {
+	args: {
+		background: 'red',
+		foreground: 'blue',
+		text: 'purple',
+		gutter: 5,
+		highlight: 'yellow',
+		focus: 'limegreen',
+		active: 'orange',
+		cellSize: 30,
+		buttonBackground: 'cyan',
+		buttonBackgroundHover: 'magenta',
+		border: 'brown',
+		clueMinWidthRem: 20,
+		clueMaxWidthRem: 30,
+	},
+};

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -19,14 +19,13 @@ const keyDownRegex = /^[A-Za-zÀ-ÿ0-9]$/;
 
 export type CrosswordProps = {
 	data: CAPICrossword;
-	theme?: Partial<Theme>;
 	progress?: Progress;
-};
+} & Partial<Theme>;
 
 export const Crossword = ({
-	theme: userTheme,
 	data,
 	progress: userProgress,
+	...userTheme
 }: CrosswordProps) => {
 	const [currentEntryId, setCurrentEntryId] = useState<EntryID | undefined>(
 		data.entries[0].id,
@@ -371,6 +370,7 @@ export const Crossword = ({
 						flex: 1;
 						gap: ${space[4]}px;
 						align-content: flex-start;
+						color: ${theme.text};
 					`}
 				>
 					<Clues

--- a/libs/@guardian/react-crossword/stories/Formats.stories.tsx
+++ b/libs/@guardian/react-crossword/stories/Formats.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Crossword } from '../src';
-import { defaultTheme } from '../src/theme';
 import { cryptic } from './formats/cryptic';
 import { everyman } from './formats/everyman';
 import { groupedClues } from './formats/grouped-clues';
@@ -16,9 +15,6 @@ import { weekend } from './formats/weekend';
 const meta: Meta<typeof Crossword> = {
 	component: Crossword,
 	title: 'Formats',
-	args: {
-		theme: defaultTheme,
-	},
 };
 
 export default meta;


### PR DESCRIPTION
## What are you changing?

- replaces the `theme` prop with the different theme options as top-level props of `Crossword`
- adds a user-themed story
  <img width="1036" alt="image" src="https://github.com/user-attachments/assets/002e4a4c-1515-4608-9da7-43db516fb3d7">


## Why?

it's more reactish
