### PR TITLE
ErrorSummary component update

### DIFF
--- a/.changeset/flat-comics-clap.md
+++ b/.changeset/flat-comics-clap.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-development-kitchen': minor
+---
+
+Replace deprecated warning icon in ErrorSummary component

--- a/libs/@guardian/source-development-kitchen/src/react-components/summary/ErrorSummary.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/summary/ErrorSummary.tsx
@@ -1,5 +1,5 @@
 import { error as errorColors } from '@guardian/source/foundations';
-import { SvgAlertTriangle } from '@guardian/source/react-components';
+import { SvgAlertRound } from '@guardian/source/react-components';
 import {
 	contextStyles,
 	iconStyles,
@@ -25,7 +25,7 @@ export const ErrorSummary = ({
 }: ErrorSummaryProps) => (
 	<div css={[wrapperStyles(errorColors[400]), cssOverrides]} {...props}>
 		<div css={iconStyles(errorColors[400])}>
-			<SvgAlertTriangle />
+			<SvgAlertRound />
 		</div>
 		<div css={messageWrapperStyles}>
 			<div css={messageStyles(errorColors[400])}>{message}</div>


### PR DESCRIPTION
## What are you changing?
Replacing the `SvgAlertTriangle` component with `SvgAlertRound` in the `ErrorSummary` component in the development kitchen.

## Why? 
`SvgAlertTriangle` is deprecated


## Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/68d1adb3-e61d-41da-9d22-c17177c29552)  |  ![](https://github.com/user-attachments/assets/287b3a34-f7d5-4d01-9c79-2c90913130a3)

