### PR TITLE
Add cheat mode to crossword

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import { memo, useCallback, useEffect, useRef } from 'react';
 import type { Coords, Separator, Theme } from '../@types/crossword';
@@ -10,8 +11,6 @@ import { useTheme } from '../context/Theme';
 import { useCheatMode } from '../hooks/useCheatMode';
 import { keyDownRegex } from '../utils/keydownRegex';
 import { Cell } from './Cell';
-
-// define and cache the regex for valid keydown events
 
 const getCellPosition = (index: number, { cellSize, gutter }: Theme) =>
 	index * (cellSize + gutter) + gutter;
@@ -96,10 +95,11 @@ export const Grid = () => {
 	const { progress, setCellProgress } = useProgress();
 	const { currentCell, setCurrentCell } = useCurrentCell();
 	const { currentEntryId, setCurrentEntryId } = useCurrentClue();
-	const cheatMode = useCheatMode();
 
 	const gridRef = useRef<SVGSVGElement>(null);
 	const workingDirectionRef = useRef<Direction>('across');
+
+	const [cheatMode, cheatStyles] = useCheatMode(gridRef);
 
 	// keep workingDirectionRef.current up to date with the current entry
 	useEffect(() => {
@@ -360,11 +360,14 @@ export const Grid = () => {
 
 	return (
 		<svg
-			style={{
-				background: theme.background,
-				width: '100%',
-				maxWidth: width,
-			}}
+			css={[
+				css`
+					background: ${theme.background};
+					width: 100%;
+					max-width: ${width};
+				`,
+				cheatStyles,
+			]}
 			ref={gridRef}
 			viewBox={`0 0 ${width} ${height}`}
 			tabIndex={-1}

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -374,7 +374,7 @@ export const Grid = () => {
 				css`
 					background: ${theme.background};
 					width: 100%;
-					max-width: ${width};
+					max-width: ${width}px;
 				`,
 				cheatStyles,
 			]}

--- a/libs/@guardian/react-crossword/src/hooks/useCheatMode.ts
+++ b/libs/@guardian/react-crossword/src/hooks/useCheatMode.ts
@@ -1,3 +1,5 @@
+import { css } from '@emotion/react';
+import type { RefObject } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 
 const konamiCode = [
@@ -13,7 +15,49 @@ const konamiCode = [
 	'a',
 ];
 
-export const useCheatMode = () => {
+const cheatStyles = css`
+	@keyframes violent-shake {
+		0% {
+			transform: translate(0, 0) rotate(0deg);
+		}
+		10% {
+			transform: translate(-5px, -5px) rotate(-2deg);
+		}
+		20% {
+			transform: translate(5px, -5px) rotate(2deg);
+		}
+		30% {
+			transform: translate(-5px, 5px) rotate(-2deg);
+		}
+		40% {
+			transform: translate(5px, 5px) rotate(2deg);
+		}
+		50% {
+			transform: translate(-5px, -5px) rotate(-2deg);
+		}
+		60% {
+			transform: translate(5px, -5px) rotate(2deg);
+		}
+		70% {
+			transform: translate(-5px, 5px) rotate(-2deg);
+		}
+		80% {
+			transform: translate(5px, 5px) rotate(2deg);
+		}
+		90% {
+			transform: translate(-5px, -5px) rotate(-2deg);
+		}
+		100% {
+			transform: translate(0, 0) rotate(0deg);
+		}
+	}
+
+	&.cheat-mode {
+		animation: violent-shake 0.15s ease-out;
+	}
+`;
+
+export const useCheatMode = (ref: RefObject<SVGSVGElement>) => {
 	const [konamiProgress, setKonamiProgress] = useState<string[]>([]);
 	const [cheatMode, setCheatMode] = useState(false);
 
@@ -36,13 +80,14 @@ export const useCheatMode = () => {
 		if (konamiProgress.length === konamiCode.length) {
 			document.removeEventListener('keydown', onKeyDown);
 			setCheatMode(true);
+			ref.current?.classList.add('cheat-mode');
 		}
-	}, [konamiProgress.length, onKeyDown]);
+	}, [konamiProgress.length, onKeyDown, ref]);
 
 	useEffect(() => {
 		document.addEventListener('keydown', onKeyDown);
 		return () => document.removeEventListener('keydown', onKeyDown);
 	}, [onKeyDown]);
 
-	return cheatMode;
+	return [cheatMode, cheatStyles];
 };

--- a/libs/@guardian/react-crossword/src/hooks/useCheatMode.ts
+++ b/libs/@guardian/react-crossword/src/hooks/useCheatMode.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const konamiCode = [
+	'ArrowUp',
+	'ArrowUp',
+	'ArrowDown',
+	'ArrowDown',
+	'ArrowLeft',
+	'ArrowRight',
+	'ArrowLeft',
+	'ArrowRight',
+	'b',
+	'a',
+];
+
+export const useCheatMode = () => {
+	const [konamiProgress, setKonamiProgress] = useState<string[]>([]);
+	const [cheatMode, setCheatMode] = useState(false);
+
+	const onKeyDown = useCallback(
+		(event: KeyboardEvent) => {
+			if (cheatMode) {
+				return;
+			}
+
+			if (konamiCode[konamiProgress.length] === event.key) {
+				setKonamiProgress([...konamiProgress, event.key]);
+			} else {
+				setKonamiProgress([]);
+			}
+		},
+		[cheatMode, konamiProgress],
+	);
+
+	useEffect(() => {
+		if (konamiProgress.length === konamiCode.length) {
+			document.removeEventListener('keydown', onKeyDown);
+			setCheatMode(true);
+		}
+	}, [konamiProgress.length, onKeyDown]);
+
+	useEffect(() => {
+		document.addEventListener('keydown', onKeyDown);
+		return () => document.removeEventListener('keydown', onKeyDown);
+	}, [onKeyDown]);
+
+	return cheatMode;
+};


### PR DESCRIPTION
## What are you changing?

if you type the [konami code](https://simple.wikipedia.org/wiki/Konami_Code) into the crossword grid, you enter cheat mode where any key press will enter the correct letter for each cell

## Why?
🥂
