### PR TITLE
Stop loading the cmp if user is on info page

### DIFF
--- a/.changeset/wise-dancers-travel.md
+++ b/.changeset/wise-dancers-travel.md
@@ -1,5 +1,5 @@
 ---
-'@guardian/libs': minor
+'@guardian/libs': major
 ---
 
-Stop showing CMP on info pages
+The CMP will no longer show for pages with `window.guardian.config.page.section: 'info' | 'help'`

--- a/.changeset/wise-dancers-travel.md
+++ b/.changeset/wise-dancers-travel.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Stop showing CMP on info pages

--- a/@types/window.d.ts
+++ b/@types/window.d.ts
@@ -20,6 +20,7 @@ declare global {
 				tests?: ServerSideTests;
 				page?: {
 					isPreview: boolean;
+					section?: string;
 				};
 				stage?: string;
 				isDev?: boolean;

--- a/libs/@guardian/libs/src/consent-management-platform/exclusionList.test.js
+++ b/libs/@guardian/libs/src/consent-management-platform/exclusionList.test.js
@@ -1,0 +1,15 @@
+import { isExcludedFromCMP } from './exclusionList.ts';
+
+describe('isExcludedFromCMP', () => {
+	test('should return false if empty', () => {
+		expect(isExcludedFromCMP('')).toBe(false);
+	});
+
+	test('should return false if param not in sectionExclusionList', () => {
+		expect(isExcludedFromCMP('foo')).toBe(false);
+	});
+
+	test('should return true if param in sectionExclusionList', () => {
+		expect(isExcludedFromCMP('info')).toBe(true);
+	});
+});

--- a/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
@@ -1,6 +1,5 @@
 const sectionExclusionList = ['info', 'help', 'community', 'identity'];
 
 export const isExcludedFromCMP = (pageSection: string): boolean => {
-	console.log('pageSection', pageSection);
 	return sectionExclusionList.some((section) => section === pageSection);
 };

--- a/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
@@ -1,5 +1,6 @@
 const sectionExclusionList = ['info', 'help'];
 
 export const isExcludedFromCMP = (pageSection: string): boolean => {
+	console.log('pageSection', pageSection);
 	return sectionExclusionList.some((section) => section === pageSection);
 };

--- a/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
@@ -1,0 +1,6 @@
+const sectionExclusionList = ['info', 'help', 'community', 'identity'];
+
+export const isExcludedFromCMP = (pageSection: string): boolean => {
+	console.log('pageSection', pageSection);
+	return sectionExclusionList.some((section) => section === pageSection);
+};

--- a/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
@@ -1,5 +1,5 @@
 const sectionExclusionList = ['info', 'help'];
 
-export const isExcludedFromCMP = (pageSection: string): boolean => {
+export const isExcludedFromCMP = (pageSection: string | undefined): boolean => {
 	return sectionExclusionList.some((section) => section === pageSection);
 };

--- a/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
@@ -1,4 +1,4 @@
-const sectionExclusionList = ['info', 'help', 'community', 'identity'];
+const sectionExclusionList = ['info', 'help'];
 
 export const isExcludedFromCMP = (pageSection: string): boolean => {
 	return sectionExclusionList.some((section) => section === pageSection);

--- a/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/exclusionList.ts
@@ -1,6 +1,5 @@
 const sectionExclusionList = ['info', 'help'];
 
 export const isExcludedFromCMP = (pageSection: string): boolean => {
-	console.log('pageSection', pageSection);
 	return sectionExclusionList.some((section) => section === pageSection);
 };

--- a/libs/@guardian/libs/src/consent-management-platform/lib/sourcepointConfig.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/lib/sourcepointConfig.ts
@@ -2,7 +2,8 @@ import { isGuardianDomain } from './domain';
 
 export const ACCOUNT_ID = 1257;
 export const PRIVACY_MANAGER_USNAT = 1068329;
-export const PROPERTY_ID = 7417;
+// export const PROPERTY_ID = 7417;
+export const PROPERTY_ID = 9398;
 export const PROPERTY_ID_AUSTRALIA = 13348;
 export const PRIVACY_MANAGER_TCFV2 = 106842;
 export const PRIVACY_MANAGER_AUSTRALIA = 1178486;

--- a/libs/@guardian/libs/src/consent-management-platform/lib/sourcepointConfig.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/lib/sourcepointConfig.ts
@@ -2,8 +2,7 @@ import { isGuardianDomain } from './domain';
 
 export const ACCOUNT_ID = 1257;
 export const PRIVACY_MANAGER_USNAT = 1068329;
-// export const PROPERTY_ID = 7417;
-export const PROPERTY_ID = 9398;
+export const PROPERTY_ID = 7417;
 export const PROPERTY_ID_AUSTRALIA = 13348;
 export const PRIVACY_MANAGER_TCFV2 = 106842;
 export const PRIVACY_MANAGER_AUSTRALIA = 1178486;

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -75,7 +75,8 @@ export const init = (framework: ConsentFramework, pubData = {}): void => {
 
 	log('cmp', `framework: ${framework}`);
 	log('cmp', `frameworkMessageType: ${frameworkMessageType}`);
-	const pageSection = window.guardian?.config?.page?.section as string;
+
+	const pageSection = window.guardian?.config?.page?.section;
 
 	window._sp_queue = [];
 	/* istanbul ignore next */
@@ -198,15 +199,12 @@ export const init = (framework: ConsentFramework, pubData = {}): void => {
 
 	switch (framework) {
 		case 'tcfv2':
-			{
-				const pageSection = window.guardian?.config?.page?.section as string;
-				window._sp_.config.gdpr = {
-					targetingParams: {
-						framework,
-						excludePage: isExcludedFromCMP(pageSection),
-					},
-				};
-			}
+			window._sp_.config.gdpr = {
+				targetingParams: {
+					framework,
+					excludePage: isExcludedFromCMP(pageSection),
+				},
+			};
 			break;
 		case 'usnat':
 			window._sp_.config.usnat = {

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -30,7 +30,8 @@ const getPropertyHref = (framework: ConsentFramework): Property => {
 	if (framework == 'aus') {
 		return 'https://au.theguardian.com';
 	}
-	return isGuardianDomain() ? null : 'https://test.theguardian.com';
+	return isGuardianDomain() ? null : 'http://ui-dev';
+	// return isGuardianDomain() ? null : 'https://test.theguardian.com';
 };
 
 const getPropertyId = (framework: ConsentFramework): number => {

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -30,8 +30,7 @@ const getPropertyHref = (framework: ConsentFramework): Property => {
 	if (framework == 'aus') {
 		return 'https://au.theguardian.com';
 	}
-	// return isGuardianDomain() ? null : 'https://test.theguardian.com';
-	return isGuardianDomain() ? null : 'http://ui-dev';
+	return isGuardianDomain() ? null : 'https://test.theguardian.com';
 };
 
 const getPropertyId = (framework: ConsentFramework): number => {

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -30,7 +30,8 @@ const getPropertyHref = (framework: ConsentFramework): Property => {
 	if (framework == 'aus') {
 		return 'https://au.theguardian.com';
 	}
-	return isGuardianDomain() ? null : 'https://test.theguardian.com';
+	// return isGuardianDomain() ? null : 'https://test.theguardian.com';
+	return isGuardianDomain() ? null : 'http://ui-dev';
 };
 
 const getPropertyId = (framework: ConsentFramework): number => {

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -1,4 +1,5 @@
 import { log } from '../logger/logger';
+import { isExcludedFromCMP } from './exclusionList';
 import { setCurrentFramework } from './getCurrentFramework';
 import { isGuardianDomain } from './lib/domain';
 import { mark } from './lib/mark';
@@ -194,11 +195,15 @@ export const init = (framework: ConsentFramework, pubData = {}): void => {
 
 	switch (framework) {
 		case 'tcfv2':
-			window._sp_.config.gdpr = {
-				targetingParams: {
-					framework,
-				},
-			};
+			{
+				const pageSection = window.guardian?.config?.page?.section as string;
+				window._sp_.config.gdpr = {
+					targetingParams: {
+						framework,
+						excludePage: isExcludedFromCMP(pageSection),
+					},
+				};
+			}
 			break;
 		case 'usnat':
 			window._sp_.config.usnat = {

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -30,8 +30,7 @@ const getPropertyHref = (framework: ConsentFramework): Property => {
 	if (framework == 'aus') {
 		return 'https://au.theguardian.com';
 	}
-	return isGuardianDomain() ? null : 'http://ui-dev';
-	// return isGuardianDomain() ? null : 'https://test.theguardian.com';
+	return isGuardianDomain() ? null : 'https://test.theguardian.com';
 };
 
 const getPropertyId = (framework: ConsentFramework): number => {

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -74,6 +74,7 @@ export const init = (framework: ConsentFramework, pubData = {}): void => {
 
 	log('cmp', `framework: ${framework}`);
 	log('cmp', `frameworkMessageType: ${frameworkMessageType}`);
+	const pageSection = window.guardian?.config?.page?.section as string;
 
 	window._sp_queue = [];
 	/* istanbul ignore next */
@@ -84,6 +85,7 @@ export const init = (framework: ConsentFramework, pubData = {}): void => {
 			propertyHref: getPropertyHref(framework),
 			targetingParams: {
 				framework,
+				excludePage: isExcludedFromCMP(pageSection),
 			},
 			pubData: { ...pubData, cmpInitTimeUtc: new Date().getTime() },
 

--- a/libs/@guardian/libs/src/consent-management-platform/types/window.d.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/types/window.d.ts
@@ -45,6 +45,7 @@ declare global {
 				gdpr?: {
 					targetingParams?: {
 						framework: ConsentFramework;
+						excludePage: boolean;
 					};
 				};
 				usnat?: {

--- a/libs/@guardian/libs/src/consent-management-platform/types/window.d.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/types/window.d.ts
@@ -36,6 +36,7 @@ declare global {
 				propertyId?: number;
 				targetingParams: {
 					framework: ConsentFramework;
+					excludePage: boolean;
 				};
 				ccpa?: {
 					targetingParams?: {


### PR DESCRIPTION
## What are you changing?

- Preventing the CMP banner from loading on informational pages.
- Configuring the excludePage as a targeting parameter for Sourcepoint.


## Why?

- The CMP banner should not show on info pages.
