### PR TITLE
Identity Auth | Account for `profile` subdomain in `redirect_uri`

### DIFF
--- a/.changeset/big-donkeys-move.md
+++ b/.changeset/big-donkeys-move.md
@@ -1,0 +1,5 @@
+---
+'@guardian/identity-auth-frontend': patch
+---
+
+Add `profile` subdomain as valid `redirect_uri`

--- a/libs/@guardian/identity-auth-frontend/src/index.ts
+++ b/libs/@guardian/identity-auth-frontend/src/index.ts
@@ -41,11 +41,17 @@ const getIssuer = (stage: Stage) =>
 const getClientId = (stage: Stage) =>
 	stage === 'PROD' ? '0oa79m1fmgzrtaHc1417' : '0oa53x6k5wGYXOGzm0x7';
 
-const getRedirectUri = (stage: Stage) => {
+const getRedirectUri = (stage: Stage, origin: string) => {
 	switch (stage) {
 		case 'PROD':
+			if (origin === 'https://profile.theguardian.com') {
+				return 'https://profile.theguardian.com/';
+			}
 			return 'https://www.theguardian.com/';
 		case 'CODE':
+			if (origin === 'https://profile.code.dev-theguardian.com') {
+				return 'https://profile.code.dev-theguardian.com/';
+			}
 			return 'https://m.code.dev-theguardian.com/';
 		case 'DEV':
 		default:
@@ -71,7 +77,7 @@ export const getIdentityAuth = () => {
 	>({
 		issuer: getIssuer(stageOrDev),
 		clientId: getClientId(stageOrDev),
-		redirectUri: getRedirectUri(stageOrDev),
+		redirectUri: getRedirectUri(stageOrDev, window.location.origin),
 		idCookieSessionRefresh: switches?.idCookieRefresh ?? false,
 		scopes: [
 			'openid', // required for open id connect, returns an id token


### PR DESCRIPTION
## What are you changing?

Checks for the users origin (domain) and sets the correct `redirect_uri` accordingly, i.e the `profile` subdomain if the page is loaded from `profile`, or default domain otherwise.

## Why?

On a user's "Comments and Replies" page, e.g. https://profile.theguardian.com/user/id/101796494?page=1, the user doesn't appear signed in, even if they already are.

This is because we kept getting returned an `OAuthError`

<img width="1190" alt="Screenshot 2024-12-12 at 08 31 16" src="https://github.com/user-attachments/assets/eb2c55a4-7253-4755-bad6-028b34ef8df6" />

This is because the `redirect_uri` for performing OAuth on frontend is set to `https://www.theguardian.com/`, but the comments and replies page is on the `https://profile.theguardian.com/` domain, despite the code for this page living in [guardian/frontend](https://github.com/guardian/frontend/tree/main/identity)

This meant when users went to this page, they don't appear to be signed in.

## Related

Sibling PR in `identity-platform` to update our OAuth configuration: https://github.com/guardian/identity-platform/pull/791