### PR TITLE
Make keyboard appear on mobile and Ipad

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -21,7 +21,7 @@ type Props = {
 };
 
 export const Clues = ({ direction, Header }: Props) => {
-	const { entries, getId } = useData();
+	const { entries, getId, cells } = useData();
 	const { progress } = useProgress();
 	const { currentEntryId, setCurrentEntryId } = useCurrentClue();
 	const { setCurrentCell } = useCurrentCell();
@@ -40,10 +40,12 @@ export const Clues = ({ direction, Header }: Props) => {
 
 			if (entry) {
 				setCurrentEntryId(entry.id);
-				setCurrentCell({ x: entry.position.x, y: entry.position.y });
+				setCurrentCell(
+					cells.getByCoords({ x: entry.position.x, y: entry.position.y }),
+				);
 			}
 		},
-		[entries, setCurrentCell, setCurrentEntryId],
+		[cells, entries, setCurrentCell, setCurrentEntryId],
 	);
 
 	useEffect(() => {

--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -21,7 +21,7 @@ type Props = {
 };
 
 export const Clues = ({ direction, Header }: Props) => {
-	const { entries, getId, cells } = useData();
+	const { entries, getId } = useData();
 	const { progress } = useProgress();
 	const { currentEntryId, setCurrentEntryId } = useCurrentClue();
 	const { setCurrentCell } = useCurrentCell();
@@ -40,12 +40,10 @@ export const Clues = ({ direction, Header }: Props) => {
 
 			if (entry) {
 				setCurrentEntryId(entry.id);
-				setCurrentCell(
-					cells.getByCoords({ x: entry.position.x, y: entry.position.y }),
-				);
+				setCurrentCell({ x: entry.position.x, y: entry.position.y });
 			}
 		},
-		[cells, entries, setCurrentCell, setCurrentEntryId],
+		[entries, setCurrentCell, setCurrentEntryId],
 	);
 
 	useEffect(() => {

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -392,6 +392,8 @@ export const Grid = () => {
 			css={css`
 				cursor: pointer;
 				caret-color: transparent;
+				width: 100%;
+				max-width: ${width}px;
 			`}
 			tabIndex={-1}
 		>
@@ -399,8 +401,6 @@ export const Grid = () => {
 				css={[
 					css`
 						background: ${theme.gridBackgroundColor};
-						width: 100%;
-						max-width: ${width}px;
 					`,
 					cheatStyles,
 				]}

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -107,6 +107,7 @@ export const Grid = () => {
 	const { currentEntryId, setCurrentEntryId } = useCurrentClue();
 
 	const gridRef = useRef<SVGSVGElement>(null);
+	// do not call focus() on this element as it will trigger the selection menu on safari
 	const gridWrapperRef = useRef<HTMLDivElement>(null);
 	const workingDirectionRef = useRef<Direction>('across');
 
@@ -392,7 +393,7 @@ export const Grid = () => {
 				cursor: pointer;
 				caret-color: transparent;
 			`}
-			tabIndex={0}
+			tabIndex={-1}
 		>
 			<svg
 				css={[

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -363,17 +363,17 @@ export const Grid = () => {
 			event.preventDefault();
 		};
 
-		const editableElement = gridWrapperRef.current;
-		editableElement?.addEventListener('beforeinput', preventDefault);
-		editableElement?.addEventListener('click', selectClickedCell);
-		editableElement?.addEventListener('keydown', handleKeyDown);
-		editableElement?.addEventListener('selectstart', preventDefault);
+		const gridWrapper = gridWrapperRef.current;
+		gridWrapper?.addEventListener('beforeinput', preventDefault);
+		gridWrapper?.addEventListener('click', selectClickedCell);
+		gridWrapper?.addEventListener('keydown', handleKeyDown);
+		gridWrapper?.addEventListener('selectstart', preventDefault);
 
 		return () => {
-			editableElement?.removeEventListener('beforeinput', preventDefault);
-			editableElement?.removeEventListener('click', selectClickedCell);
-			editableElement?.removeEventListener('keydown', handleKeyDown);
-			editableElement?.removeEventListener('selectstart', preventDefault);
+			gridWrapper?.removeEventListener('beforeinput', preventDefault);
+			gridWrapper?.removeEventListener('click', selectClickedCell);
+			gridWrapper?.removeEventListener('keydown', handleKeyDown);
+			gridWrapper?.removeEventListener('selectstart', preventDefault);
 		};
 	}, [handleKeyDown, selectClickedCell]);
 

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -147,13 +147,13 @@ export const Grid = () => {
 			}
 
 			if (delta.x !== 0) {
-				setCurrentCell({ x: newX, y: newY });
+				setCurrentCell(newCell);
 				setCurrentEntryId(possibleAcross ?? possibleDown);
 				return;
 			}
 
 			if (delta.y !== 0) {
-				setCurrentCell({ x: newX, y: newY });
+				setCurrentCell(newCell);
 				setCurrentEntryId(possibleDown ?? possibleAcross);
 				return;
 			}
@@ -178,7 +178,8 @@ export const Grid = () => {
 			const direction = currentEntryId?.includes('across') ? 'across' : 'down';
 			let preventDefault = true;
 			const { key } = event;
-
+			console.log('upperCase', key.toUpperCase());
+			console.log(keyDownRegex.test(key));
 			switch (key) {
 				case 'ArrowUp':
 					moveFocus({ delta: { x: 0, y: -1 } });
@@ -291,11 +292,13 @@ export const Grid = () => {
 			// applies:
 			let newEntryId = currentEntryId;
 
-			// Get the entry IDs that apply to the clicked cell:
-			const entryIdsForCell = cells.getByCoords({
+			// Get the clicked cell
+			const clickedCell = cells.getByCoords({
 				x: clickedCellX,
 				y: clickedCellY,
-			})?.group;
+			});
+			// Get the entry IDs that apply to the clicked cell:
+			const entryIdsForCell = clickedCell?.group;
 
 			// If there are no entries for this cell (i.e. it's a black one),
 			// set the selected entry to undefined
@@ -352,26 +355,27 @@ export const Grid = () => {
 			}
 
 			// Set the new current cell and entry:
-			setCurrentCell({ x: clickedCellX, y: clickedCellY });
+			setCurrentCell(clickedCell);
 			setCurrentEntryId(newEntryId);
 		},
 		[cells, currentCell, currentEntryId, setCurrentCell, setCurrentEntryId],
 	);
-	const preventDefault = (event: Event) => {
-		event.preventDefault();
-	};
 
 	useEffect(() => {
+		const preventDefault = (event: Event) => {
+			event.preventDefault();
+		};
+
 		const editableElement = gridWrapperRef.current;
+		editableElement?.addEventListener('beforeinput', preventDefault);
 		editableElement?.addEventListener('click', selectClickedCell);
 		editableElement?.addEventListener('keydown', handleKeyDown);
-		editableElement?.addEventListener('beforeinput', preventDefault);
 		editableElement?.addEventListener('selectstart', preventDefault);
 
 		return () => {
+			editableElement?.removeEventListener('beforeinput', preventDefault);
 			editableElement?.removeEventListener('click', selectClickedCell);
 			editableElement?.removeEventListener('keydown', handleKeyDown);
-			editableElement?.removeEventListener('beforeinput', preventDefault);
 			editableElement?.removeEventListener('selectstart', preventDefault);
 		};
 	}, [handleKeyDown, selectClickedCell]);
@@ -391,7 +395,7 @@ export const Grid = () => {
 				cursor: pointer;
 				caret-color: transparent;
 			`}
-			tabIndex={1}
+			tabIndex={0}
 		>
 			<svg
 				css={[

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -107,6 +107,7 @@ export const Grid = () => {
 	const { currentEntryId, setCurrentEntryId } = useCurrentClue();
 
 	const gridRef = useRef<SVGSVGElement>(null);
+	const gridWrapperRef = useRef<HTMLDivElement>(null);
 	const workingDirectionRef = useRef<Direction>('across');
 
 	const [cheatMode, cheatStyles] = useCheatMode(gridRef);
@@ -132,8 +133,6 @@ export const Grid = () => {
 			if (!newCell) {
 				return;
 			}
-
-			// TODO: this logic is very similar to the click handler entry selection stuff.
 			// maybe we can refactor this out into a shared function?
 			const possibleAcross = newCell.group?.find((group) =>
 				group.includes('across'),
@@ -358,16 +357,22 @@ export const Grid = () => {
 		},
 		[cells, currentCell, currentEntryId, setCurrentCell, setCurrentEntryId],
 	);
+	const preventDefault = (event: Event) => {
+		event.preventDefault();
+	};
 
 	useEffect(() => {
-		const grid = gridRef.current;
-
-		grid?.addEventListener('click', selectClickedCell);
-		grid?.addEventListener('keydown', handleKeyDown);
+		const editableElement = gridWrapperRef.current;
+		editableElement?.addEventListener('click', selectClickedCell);
+		editableElement?.addEventListener('keydown', handleKeyDown);
+		editableElement?.addEventListener('beforeinput', preventDefault);
+		editableElement?.addEventListener('selectstart', preventDefault);
 
 		return () => {
-			grid?.removeEventListener('click', selectClickedCell);
-			grid?.removeEventListener('keydown', handleKeyDown);
+			editableElement?.removeEventListener('click', selectClickedCell);
+			editableElement?.removeEventListener('keydown', handleKeyDown);
+			editableElement?.removeEventListener('beforeinput', preventDefault);
+			editableElement?.removeEventListener('selectstart', preventDefault);
 		};
 	}, [handleKeyDown, selectClickedCell]);
 
@@ -379,63 +384,73 @@ export const Grid = () => {
 		theme.gridGutterSize * (dimensions.cols + 1);
 
 	return (
-		<svg
-			css={[
-				css`
-					background: ${theme.gridBackgroundColor};
-					width: 100%;
-					max-width: ${width}px;
-				`,
-				cheatStyles,
-			]}
-			ref={gridRef}
-			viewBox={`0 0 ${width} ${height}`}
-			tabIndex={-1}
+		<div
+			contentEditable={true}
+			ref={gridWrapperRef}
+			css={css`
+				cursor: pointer;
+				caret-color: transparent;
+			`}
+			tabIndex={1}
 		>
-			{
-				/* Render the cells */
-				Array.from(cells.values()).map((cell) => {
-					const x = getCellPosition(cell.x, theme);
-					const y = getCellPosition(cell.y, theme);
+			<svg
+				css={[
+					css`
+						background: ${theme.gridBackgroundColor};
+						width: 100%;
+						max-width: ${width}px;
+					`,
+					cheatStyles,
+				]}
+				ref={gridRef}
+				viewBox={`0 0 ${width} ${height}`}
+				tabIndex={-1}
+			>
+				{
+					/* Render the cells */
+					Array.from(cells.values()).map((cell) => {
+						const x = getCellPosition(cell.x, theme);
+						const y = getCellPosition(cell.y, theme);
 
-					const guess = progress[cell.x]?.[cell.y];
+						const guess = progress[cell.x]?.[cell.y];
 
-					const currentGroup =
-						currentEntryId && entries.get(currentEntryId)?.group;
+						const currentGroup =
+							currentEntryId && entries.get(currentEntryId)?.group;
 
-					const isHighlighted = currentGroup?.some((entryId) =>
-						cell.group?.includes(entryId),
-					);
+						const isHighlighted = currentGroup?.some((entryId) =>
+							cell.group?.includes(entryId),
+						);
 
-					const isActive = currentEntryId
-						? cell.group?.includes(currentEntryId)
-						: false;
+						const isActive = currentEntryId
+							? cell.group?.includes(currentEntryId)
+							: false;
 
-					return (
-						<Cell
-							key={`x${cell.x}y${cell.y}`}
-							data={cell}
-							x={x}
-							y={y}
-							guess={guess}
-							isActive={isActive}
-							isHighlighted={isHighlighted}
+						return (
+							<Cell
+								key={`x${cell.x}y${cell.y}`}
+								data={cell}
+								x={x}
+								y={y}
+								guess={guess}
+								isActive={isActive}
+								isHighlighted={isHighlighted}
+							/>
+						);
+					})
+				}
+				{
+					/* Render the separators between cells */
+					separators.map(({ type, position, direction }) => (
+						<Separator
+							type={type}
+							position={position}
+							direction={direction}
+							key={`${type}${position.x}${position.y}${direction}`}
 						/>
-					);
-				})
-			}
-			{
-				/* Render the separators between cells */
-				separators.map(({ type, position, direction }) => (
-					<Separator
-						type={type}
-						position={position}
-						direction={direction}
-						key={`${type}${position.x}${position.y}${direction}`}
-					/>
-				))
-			}
-			{currentCell && <FocusIndicator currentCell={currentCell} />}
-		</svg>
+					))
+				}
+				{currentCell && <FocusIndicator currentCell={currentCell} />}
+			</svg>
+		</div>
 	);
 };

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -394,6 +394,7 @@ export const Grid = () => {
 				caret-color: transparent;
 				width: 100%;
 				max-width: ${width}px;
+				max-height: ${height}px;
 			`}
 			tabIndex={-1}
 		>

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -147,13 +147,13 @@ export const Grid = () => {
 			}
 
 			if (delta.x !== 0) {
-				setCurrentCell(newCell);
+				setCurrentCell({ x: newX, y: newY });
 				setCurrentEntryId(possibleAcross ?? possibleDown);
 				return;
 			}
 
 			if (delta.y !== 0) {
-				setCurrentCell(newCell);
+				setCurrentCell({ x: newX, y: newY });
 				setCurrentEntryId(possibleDown ?? possibleAcross);
 				return;
 			}
@@ -178,8 +178,7 @@ export const Grid = () => {
 			const direction = currentEntryId?.includes('across') ? 'across' : 'down';
 			let preventDefault = true;
 			const { key } = event;
-			console.log('upperCase', key.toUpperCase());
-			console.log(keyDownRegex.test(key));
+
 			switch (key) {
 				case 'ArrowUp':
 					moveFocus({ delta: { x: 0, y: -1 } });
@@ -292,13 +291,11 @@ export const Grid = () => {
 			// applies:
 			let newEntryId = currentEntryId;
 
-			// Get the clicked cell
-			const clickedCell = cells.getByCoords({
+			// Get the entry IDs that apply to the clicked cell:
+			const entryIdsForCell = cells.getByCoords({
 				x: clickedCellX,
 				y: clickedCellY,
-			});
-			// Get the entry IDs that apply to the clicked cell:
-			const entryIdsForCell = clickedCell?.group;
+			})?.group;
 
 			// If there are no entries for this cell (i.e. it's a black one),
 			// set the selected entry to undefined
@@ -355,7 +352,7 @@ export const Grid = () => {
 			}
 
 			// Set the new current cell and entry:
-			setCurrentCell(clickedCell);
+			setCurrentCell({ x: clickedCellX, y: clickedCellY });
 			setCurrentEntryId(newEntryId);
 		},
 		[cells, currentCell, currentEntryId, setCurrentCell, setCurrentEntryId],

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -74,7 +74,13 @@ const Layout = ({
 				`}
 			>
 				{showAnagramHelper ? <AnagramHelper /> : <Grid />}
-				<Controls />
+				<div
+					css={css`
+						margin-top: ${space[1]}px;
+					`}
+				>
+					<Controls />
+				</div>
 				<div
 					css={css`
 						${textSans12};


### PR DESCRIPTION
## What are you changing?

add a wrapper to the grid which adds `contenteditable` property so that the keyboard appears on mobile - we still need to prevent default on input and select to stop you from actually editing the grid components - We want to edit the content using the keydown not the input to change the value of the cells. We need to prevent default on the select start because we do not want the text to be selected as we do not want the text selected either.

## Why?

- Make the keyboard appear on mobile and Ipad
