### PR TITLE
use input to capture key press on android

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -180,8 +180,10 @@ export const Grid = () => {
 				: keyDownRegex.test(key) && key.toUpperCase();
 
 			if (value) {
+				// This mimics moving to a new input cell after typing a letter
 				inputRef.current?.blur();
 				inputRef.current?.focus();
+
 				updateCell({
 					x: currentCell.x,
 					y: currentCell.y,

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -447,6 +447,7 @@ export const Grid = () => {
 			<input
 				ref={inputRef}
 				value={inputValue}
+				autoCapitalize={'characters'}
 				id={getId('overlay-input')}
 				type="text"
 				pattern={'^[A-Za-zÀ-ÿ0-9]$'}

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -180,7 +180,10 @@ export const Grid = () => {
 				: keyDownRegex.test(key) && key.toUpperCase();
 
 			if (value) {
-				// This mimics moving to a new input cell after typing a letter
+				// This mimics moving to a new input cell after typing a letter.
+				// This is needed for a quirk in the Android keyboard.
+				// It stores typed text even if it is cleared by react
+				// and the backspace key does not work as expected.
 				inputRef.current?.blur();
 				inputRef.current?.focus();
 
@@ -380,6 +383,7 @@ export const Grid = () => {
 				width: 100%;
 				max-width: ${width}px;
 				max-height: ${height}px;
+				// This is to prevent the default blue highlight on click on andriod
 				-webkit-tap-highlight-color: transparent;
 			`}
 			onClick={selectClickedCell}

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -388,6 +388,7 @@ export const Grid = () => {
 	return (
 		<div
 			contentEditable={true}
+			suppressContentEditableWarning={true}
 			ref={gridWrapperRef}
 			css={css`
 				cursor: pointer;


### PR DESCRIPTION
## What are you changing?

-  Adding an input which is not visible but is over the entire crossword to capture the input from the letters added to the grid


## Why?

- I chose this method as opposed to the floating input as when doing a clue the keyboard and screen jump around following the input this felt quite clumsy on mobile

