### PR TITLE
Make the controls tabbable

### DIFF
--- a/libs/@guardian/react-crossword/src/components/AnagramHelper.tsx
+++ b/libs/@guardian/react-crossword/src/components/AnagramHelper.tsx
@@ -9,8 +9,8 @@ import { useTheme } from '../context/Theme';
 import { useUIState } from '../context/UI';
 import { biasedShuffle } from '../utils/biasedShuffle';
 import { getCellsWithProgressForGroup } from '../utils/getCellsWithProgressForGroup';
-import { Button } from './Button';
 import { Clue } from './Clue';
+import { CrosswordButton } from './CrosswordButton';
 import { SolutionDisplay } from './SolutionDisplay';
 import { WordWheel } from './WordWheel';
 
@@ -82,13 +82,13 @@ export const AnagramHelper = () => {
 					margin-bottom: ${space[4]}px;
 				`}
 			>
-				<Button
-					onSuccess={() => setShowAnagramHelper(false)}
+				<CrosswordButton
+					onClick={() => setShowAnagramHelper(false)}
 					size="small"
 					priority="tertiary"
 				>
 					<SvgCross size="xsmall" />
-				</Button>
+				</CrosswordButton>
 			</div>
 			<div
 				css={css`
@@ -118,17 +118,17 @@ export const AnagramHelper = () => {
 								maxLength={cellsWithProgress.length}
 							/>
 						</div>
-						<Button
+						<CrosswordButton
 							cssOverrides={css`
 								margin: ${space[1]}px 0 0 ${space[1]}px;
 							`}
-							onSuccess={start}
+							onClick={start}
 							disabled={letters.length < 1}
 							priority="primary"
 							size="default"
 						>
 							Start
-						</Button>
+						</CrosswordButton>
 						<span>
 							{letters.length}/{cellsWithProgress.length}
 						</span>
@@ -145,12 +145,20 @@ export const AnagramHelper = () => {
 								}
 							`}
 						>
-							<Button onSuccess={reset} size={'default'} priority="secondary">
+							<CrosswordButton
+								onClick={reset}
+								size={'default'}
+								priority="secondary"
+							>
 								Back
-							</Button>
-							<Button onSuccess={shuffle} size={'default'} priority="primary">
+							</CrosswordButton>
+							<CrosswordButton
+								onClick={shuffle}
+								size={'default'}
+								priority="primary"
+							>
 								Shuffle
-							</Button>
+							</CrosswordButton>
 						</div>
 					</>
 				)}

--- a/libs/@guardian/react-crossword/src/components/Controls.tsx
+++ b/libs/@guardian/react-crossword/src/components/Controls.tsx
@@ -250,6 +250,7 @@ export const Controls = () => {
 	);
 	const [focusedClueControlIndex, setFocusedClueControlIndex] = useState(0);
 	const [focusedGridControlIndex, setFocusedGridControlIndex] = useState(0);
+	const [shouldFocus, setShouldFocus] = useState(false);
 	const controlsRef = useRef<HTMLDivElement | null>(null);
 
 	const cluesControls = [
@@ -267,6 +268,8 @@ export const Controls = () => {
 
 	const onKeyDown = useCallback(
 		(event: KeyboardEvent) => {
+			setShouldFocus(true);
+
 			switch (event.key) {
 				case 'ArrowLeft':
 					if (group === 'clues') {
@@ -308,14 +311,19 @@ export const Controls = () => {
 					return;
 			}
 		},
-		[cluesControls.length, disableClueControls, gridControls.length, group],
+		[cluesControls.length, gridControls.length, disableClueControls, group],
 	);
 
 	useEffect(() => {
-		(
-			controlsRef.current?.querySelector('[tabindex="0"]') as HTMLElement | null
-		)?.focus();
-	}, [group, focusedClueControlIndex, focusedGridControlIndex]);
+		// We only want to focus the a control after user input
+		if (shouldFocus) {
+			(
+				controlsRef.current?.querySelector(
+					'[tabindex="0"]',
+				) as HTMLElement | null
+			)?.focus();
+		}
+	}, [shouldFocus, group, focusedClueControlIndex, focusedGridControlIndex]);
 
 	useEffect(() => {
 		const controls = controlsRef.current;

--- a/libs/@guardian/react-crossword/src/components/Controls.tsx
+++ b/libs/@guardian/react-crossword/src/components/Controls.tsx
@@ -356,6 +356,7 @@ export const Controls = () => {
 							key: index,
 							disabled: disableClueControls,
 							tabIndex: isTabTarget ? 0 : -1,
+							role: 'menuitem',
 						});
 					}
 					return null;
@@ -374,6 +375,7 @@ export const Controls = () => {
 						return cloneElement(child, {
 							key: index,
 							tabIndex: isTabTarget ? 0 : -1,
+							role: 'menuitem',
 						});
 					}
 					return null;

--- a/libs/@guardian/react-crossword/src/components/Controls.tsx
+++ b/libs/@guardian/react-crossword/src/components/Controls.tsx
@@ -302,9 +302,19 @@ export const Controls = () => {
 					event.preventDefault();
 					break;
 				case 'Home':
+					if (group === 'clues') {
+						setFocusedClueControlIndex(0);
+					} else {
+						setFocusedGridControlIndex(0);
+					}
 					event.preventDefault();
 					break;
 				case 'End':
+					if (group === 'clues') {
+						setFocusedClueControlIndex(cluesControls.length - 1);
+					} else {
+						setFocusedGridControlIndex(gridControls.length - 1);
+					}
 					event.preventDefault();
 					break;
 				default:

--- a/libs/@guardian/react-crossword/src/components/CrosswordButton.tsx
+++ b/libs/@guardian/react-crossword/src/components/CrosswordButton.tsx
@@ -3,23 +3,23 @@ import { Button as SourceButton } from '@guardian/source/react-components';
 import type { MouseEventHandler } from 'react';
 import { memo, useRef, useState } from 'react';
 
-type ButtonProps = SourceButtonProps & {
-	onSuccess: MouseEventHandler<HTMLButtonElement>;
+export type CrosswordButtonProps = SourceButtonProps & {
+	onClick: MouseEventHandler<HTMLButtonElement>;
 	requireConfirmation?: boolean;
 };
 
 const ButtonComponent = ({
 	children,
 	requireConfirmation = false,
-	onSuccess,
+	onClick: userOnClick,
 	...props
-}: ButtonProps) => {
+}: CrosswordButtonProps) => {
 	const [isConfirming, setIsConfirming] = useState<boolean>(false);
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
 	const onClick: MouseEventHandler<HTMLButtonElement> = (event) => {
 		if (!requireConfirmation) {
-			onSuccess(event);
+			userOnClick(event);
 			return;
 		}
 		if (!isConfirming) {
@@ -30,7 +30,7 @@ const ButtonComponent = ({
 		if (timeoutRef.current) {
 			clearTimeout(timeoutRef.current);
 		}
-		onSuccess(event);
+		userOnClick(event);
 		setIsConfirming(false);
 	};
 
@@ -42,4 +42,4 @@ const ButtonComponent = ({
 	);
 };
 
-export const Button = memo(ButtonComponent);
+export const CrosswordButton = memo(ButtonComponent);


### PR DESCRIPTION
## What are you changing?

- makes the controls tabbable, breaking them into two `group`s of `menuitem`s inside a `menu`: clue `menuitem`s and grid `menuitem`s
- `←` and `→` keys move you between `menuitem`s of a `group`
- `↑` and `↓` keys move you between `group`s
- moving between `group`s re-selects the previously selected `menuitem`
- tabbing out of and back into `menu` re-selects the previously selected `menuitem`
- clue `menuitem`s (buttons) are disabled when there's no clue selected, rather than not rendered

It includes some refactors i found made it easier to reason about what i was trying to do:

- control buttons are now all individual components that are composed in the main `Controls` component
- `Button` → `CrosswordButton`
- `Button#onSuccess` → `CrosswordButton#onClick`

<img width="459" alt="image" src="https://github.com/user-attachments/assets/48211639-9f4d-4930-9b3c-6caef45eeed3" />

## Why?

- so that controls can be accessed from the keyboard/by a screen reader

