### PR TITLE
Improve clue list a11y

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Clue.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clue.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/react';
+import { visuallyHidden } from '@guardian/source/foundations';
 import { SvgTickRound } from '@guardian/source/react-components';
 import type { HTMLAttributes } from 'react';
 import { memo } from 'react';
 import type { CAPIEntry } from '../@types/CAPI';
 import { useTheme } from '../context/Theme';
 import { useValidAnswers } from '../context/ValidAnswers';
+import { VisuallyHidden } from './VisuallyHidden';
 
 type Props = {
 	entry: CAPIEntry;
@@ -37,6 +39,10 @@ const ClueComponent = ({
 
 				padding: 0.5em 0;
 				color: currentColor;
+
+				.visuallyHidden {
+					${visuallyHidden}
+				}
 			`}
 			{...props}
 		>
@@ -48,13 +54,18 @@ const ClueComponent = ({
 					padding-right: 0.625em;
 				`}
 			>
-				{entry.humanNumber}
+				{entry.humanNumber} <VisuallyHidden>{entry.direction},</VisuallyHidden>
 			</span>
 			<span
 				css={css`
 					display: table-cell;
 				`}
-				dangerouslySetInnerHTML={{ __html: entry.clue }}
+				dangerouslySetInnerHTML={{
+					__html: entry.clue.replace(
+						/\((\d+)\)/g,
+						'($1<span class="visuallyHidden"> letters</span>)',
+					),
+				}}
 			/>
 			{validAnswers.has(entry.id) && (
 				<span

--- a/libs/@guardian/react-crossword/src/components/Clue.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clue.tsx
@@ -21,18 +21,14 @@ const formatClueForScreenReader = (clueString: string) => {
 		return punctuateString(clueString);
 	}
 
-	const [last, ...rest] = lengths.split(',').reverse();
+	const [last, ...rest] = lengths
+		.split(',')
+		.map((_) => _.trim() + ' letters')
+		.reverse();
 
-	const lengthsToSentence =
-		[
-			rest
-				.map((_) => _.trim() + ' letters')
-				.reverse()
-				.join(', '),
-			last?.trim(),
-		]
-			.filter(Boolean)
-			.join(' and ') + ' letters';
+	const lengthsToSentence = [rest.reverse().join(', '), last?.trim()]
+		.filter(Boolean)
+		.join(' and ');
 
 	const clueWithPunctuation = punctuateString(clue);
 

--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -149,7 +149,8 @@ export const Clues = ({ direction, Header }: Props) => {
 				aria-activedescendant={
 					// this must be undefined or match the format used for
 					// Clue#id in loop below
-					currentEntryId && getId(currentEntryId)
+					cluesEntries[currentCluesEntriesIndex] &&
+					getId(cluesEntries[currentCluesEntriesIndex].id)
 				}
 				ref={cluesRef}
 			>

--- a/libs/@guardian/react-crossword/src/components/VisuallyHidden.tsx
+++ b/libs/@guardian/react-crossword/src/components/VisuallyHidden.tsx
@@ -1,0 +1,8 @@
+import { css } from '@emotion/react';
+import { visuallyHidden } from '@guardian/source/foundations';
+import type { ReactNode } from 'react';
+
+/** Hides children visually, while keeping them for screen readers etc */
+export const VisuallyHidden = ({ children }: { children: ReactNode }) => {
+	return <span css={css(visuallyHidden)}>{children}</span>;
+};

--- a/libs/@guardian/react-crossword/src/components/VisuallyHidden.tsx
+++ b/libs/@guardian/react-crossword/src/components/VisuallyHidden.tsx
@@ -1,8 +1,0 @@
-import { css } from '@emotion/react';
-import { visuallyHidden } from '@guardian/source/foundations';
-import type { ReactNode } from 'react';
-
-/** Hides children visually, while keeping them for screen readers etc */
-export const VisuallyHidden = ({ children }: { children: ReactNode }) => {
-	return <span css={css(visuallyHidden)}>{children}</span>;
-};


### PR DESCRIPTION
## What are you changing?

- add more context the clues for screen readers
	- "8 across. Writer in retreat welcomed by fat cat. 7 letters."
- set each clue list's `aria-activedescendant` to the clue list's current clue, not the grid's

## Why?

- fix a11y bugs
