### PR TITLE
Standardise crossword event handler names

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -80,13 +80,13 @@ export const Clues = ({ direction, Header }: Props) => {
 	 * If not, it's set to -1 pressing the down arrow key will select the first
 	 * clue in the list.
 	 */
-	const onFocus = useCallback(() => {
+	const handleFocus = useCallback(() => {
 		setCurrentCluesEntriesIndex(
 			cluesEntries.findIndex((entry) => entry.id === currentEntryId),
 		);
 	}, [currentEntryId, cluesEntries]);
 
-	const onKeyDown = useCallback(
+	const handleKeyDown = useCallback(
 		(event: KeyboardEvent) => {
 			switch (event.key) {
 				case 'ArrowDown':
@@ -124,14 +124,14 @@ export const Clues = ({ direction, Header }: Props) => {
 	useEffect(() => {
 		const clues = cluesRef.current;
 
-		clues?.addEventListener('keydown', onKeyDown);
-		clues?.addEventListener('focus', onFocus);
+		clues?.addEventListener('keydown', handleKeyDown);
+		clues?.addEventListener('focus', handleFocus);
 
 		return () => {
-			clues?.removeEventListener('keydown', onKeyDown);
-			clues?.removeEventListener('focus', onFocus);
+			clues?.removeEventListener('keydown', handleKeyDown);
+			clues?.removeEventListener('focus', handleFocus);
 		};
-	}, [onKeyDown, onFocus]);
+	}, [handleKeyDown, handleFocus]);
 
 	return (
 		<div>

--- a/libs/@guardian/react-crossword/src/components/Controls.tsx
+++ b/libs/@guardian/react-crossword/src/components/Controls.tsx
@@ -299,7 +299,7 @@ export const Controls = () => {
 		solutionAvailable && <RevealGrid />,
 	].filter(Boolean);
 
-	const onKeyDown = useCallback(
+	const handleKeyDown = useCallback(
 		(event: KeyboardEvent) => {
 			setShouldSetFocus(true);
 
@@ -385,12 +385,12 @@ export const Controls = () => {
 			return;
 		}
 
-		controls.addEventListener('keydown', onKeyDown);
+		controls.addEventListener('keydown', handleKeyDown);
 
 		return () => {
-			controls.removeEventListener('keydown', onKeyDown);
+			controls.removeEventListener('keydown', handleKeyDown);
 		};
-	}, [onKeyDown]);
+	}, [handleKeyDown]);
 
 	return (
 		<div role="menu" ref={controlsRef} aria-label="Crossword controls">

--- a/libs/@guardian/react-crossword/src/components/CrosswordButton.tsx
+++ b/libs/@guardian/react-crossword/src/components/CrosswordButton.tsx
@@ -17,7 +17,7 @@ const ButtonComponent = ({
 	const [isConfirming, setIsConfirming] = useState<boolean>(false);
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-	const onClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+	const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
 		if (!requireConfirmation) {
 			userOnClick(event);
 			return;
@@ -35,7 +35,7 @@ const ButtonComponent = ({
 	};
 
 	return (
-		<SourceButton onClick={onClick} size="xsmall" {...props}>
+		<SourceButton onClick={handleClick} size="xsmall" {...props}>
 			{isConfirming && 'Confirm '}
 			{children}
 		</SourceButton>

--- a/libs/@guardian/react-crossword/src/hooks/useCheatMode.ts
+++ b/libs/@guardian/react-crossword/src/hooks/useCheatMode.ts
@@ -61,7 +61,7 @@ export const useCheatMode = (ref: RefObject<SVGSVGElement>) => {
 	const [konamiProgress, setKonamiProgress] = useState<string[]>([]);
 	const [cheatMode, setCheatMode] = useState(false);
 
-	const onKeyDown = useCallback(
+	const handleKeyDown = useCallback(
 		(event: KeyboardEvent) => {
 			if (cheatMode) {
 				return;
@@ -78,16 +78,16 @@ export const useCheatMode = (ref: RefObject<SVGSVGElement>) => {
 
 	useEffect(() => {
 		if (konamiProgress.length === konamiCode.length) {
-			document.removeEventListener('keydown', onKeyDown);
+			document.removeEventListener('keydown', handleKeyDown);
 			setCheatMode(true);
 			ref.current?.classList.add('cheat-mode');
 		}
-	}, [konamiProgress.length, onKeyDown, ref]);
+	}, [konamiProgress.length, handleKeyDown, ref]);
 
 	useEffect(() => {
-		document.addEventListener('keydown', onKeyDown);
-		return () => document.removeEventListener('keydown', onKeyDown);
-	}, [onKeyDown]);
+		document.addEventListener('keydown', handleKeyDown);
+		return () => document.removeEventListener('keydown', handleKeyDown);
+	}, [handleKeyDown]);
 
 	return [cheatMode, cheatStyles];
 };


### PR DESCRIPTION
## What are you changing?

- standardises event handler names on `handle_` 

## Why?

- we have a mixture of `onEvent` and `handleEvent` naming for event handlers and it looks weird
