### PR TITLE
Tabbing around the crossword tree

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -69,8 +69,18 @@ export const Clues = ({ direction, Header }: Props) => {
 				focusOn('grid');
 			}
 			setCurrentEntryId(entry.id);
+			setCurrentCell(
+				cells.getByCoords({ x: entry.position.x, y: entry.position.y }),
+			);
 		},
-		[currentFocus, currentEntryId, setCurrentEntryId, focusOn],
+		[
+			currentFocus,
+			currentEntryId,
+			setCurrentEntryId,
+			setCurrentCell,
+			cells,
+			focusOn,
+		],
 	);
 
 	/**

--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -66,22 +66,11 @@ export const Clues = ({ direction, Header }: Props) => {
 	const handleClick = useCallback(
 		(entry: CAPIEntry) => {
 			if (!(currentFocus === 'grid') && entry.id === currentEntryId) {
-				setCurrentCell(
-					cells.getByCoords({ x: entry.position.x, y: entry.position.y }),
-				);
-				setCurrentCluesEntriesIndex(-1);
 				focusOn('grid');
 			}
 			setCurrentEntryId(entry.id);
 		},
-		[
-			currentFocus,
-			currentEntryId,
-			setCurrentEntryId,
-			setCurrentCell,
-			cells,
-			focusOn,
-		],
+		[currentFocus, currentEntryId, setCurrentEntryId, focusOn],
 	);
 
 	/**

--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -63,12 +63,12 @@ export const Clues = ({ direction, Header }: Props) => {
 
 	const handleClick = useCallback(
 		(entry: CAPIEntry) => {
-			if (!(currentFocus === 'grid') && entry.id === currentEntryId) {
+			if (currentFocus === direction) {
 				focusOn('grid');
 			}
 			setCurrentEntryId(entry.id);
 		},
-		[currentFocus, currentEntryId, setCurrentEntryId, focusOn],
+		[currentFocus, direction, setCurrentEntryId, focusOn],
 	);
 
 	/**

--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -3,7 +3,6 @@ import type { ComponentType, ReactNode } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { CAPIEntry } from '../@types/CAPI';
 import type { Direction } from '../@types/Direction';
-import { useCurrentCell } from '../context/CurrentCell';
 import { useCurrentClue } from '../context/CurrentClue';
 import { useData } from '../context/Data';
 import { useFocus } from '../context/Focus';
@@ -39,11 +38,10 @@ const Label = memo(({ direction }: { direction: Direction }) => {
 });
 
 export const Clues = ({ direction, Header }: Props) => {
-	const { entries, getId, cells } = useData();
+	const { entries, getId } = useData();
 	const { progress } = useProgress();
 	const { currentFocus, focusOn } = useFocus();
 	const { currentEntryId, setCurrentEntryId } = useCurrentClue();
-	const { setCurrentCell } = useCurrentCell();
 
 	const cluesEntries = useMemo(() => {
 		const cluesEntries: CAPIEntry[] = [];
@@ -69,18 +67,8 @@ export const Clues = ({ direction, Header }: Props) => {
 				focusOn('grid');
 			}
 			setCurrentEntryId(entry.id);
-			setCurrentCell(
-				cells.getByCoords({ x: entry.position.x, y: entry.position.y }),
-			);
 		},
-		[
-			currentFocus,
-			currentEntryId,
-			setCurrentEntryId,
-			setCurrentCell,
-			cells,
-			focusOn,
-		],
+		[currentFocus, currentEntryId, setCurrentEntryId, focusOn],
 	);
 
 	/**
@@ -131,22 +119,13 @@ export const Clues = ({ direction, Header }: Props) => {
 		[cluesEntries, currentCluesEntriesIndex, handleClick],
 	);
 
-	// Call `setCurrentEntryId` and `setCurrentCell` if `currentCluesEntriesIndex` changes
+	// Call `setCurrentEntryId` if `currentCluesEntriesIndex` changes
 	useEffect(() => {
 		const entry = cluesEntries[currentCluesEntriesIndex];
 		if (entry) {
 			setCurrentEntryId(entry.id);
-			setCurrentCell(
-				cells.getByCoords({ x: entry.position.x, y: entry.position.y }),
-			);
 		}
-	}, [
-		currentCluesEntriesIndex,
-		cluesEntries,
-		setCurrentEntryId,
-		setCurrentCell,
-		cells,
-	]);
+	}, [currentCluesEntriesIndex, cluesEntries, setCurrentEntryId]);
 
 	// Add event listeners
 	useEffect(() => {

--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -132,7 +132,7 @@ export const Clues = ({ direction, Header }: Props) => {
 		[cluesEntries, currentCluesEntriesIndex, handleClick],
 	);
 
-	// Call `setCurrentEntryId` if `currentCluesEntriesIndex` changes
+	// Call `setCurrentEntryId` and `setCurrentCell` if `currentCluesEntriesIndex` changes
 	useEffect(() => {
 		const entry = cluesEntries[currentCluesEntriesIndex];
 		if (entry) {

--- a/libs/@guardian/react-crossword/src/components/Controls.tsx
+++ b/libs/@guardian/react-crossword/src/components/Controls.tsx
@@ -375,10 +375,8 @@ export const Controls = () => {
 					'[aria-selected="true"]',
 				) as HTMLElement | null
 			)?.focus();
-		} else if (shouldSetFocus) {
-			setShouldSetFocus(false);
 		}
-	}, [currentFocus, shouldSetFocus]);
+	}, [currentFocus]);
 
 	useEffect(() => {
 		// Only set focus after user input

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -99,7 +99,6 @@ const TabWrangler = ({ children }: { children: ReactNode }) => {
 				}
 			}}
 		>
-			{currentFocus}
 			{children}
 		</div>
 	);

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -22,8 +22,6 @@ import { Clues } from './Clues';
 import { Controls } from './Controls';
 import { Grid } from './Grid';
 
-type TabDirection = 'back' | 'forward';
-
 export type CrosswordProps = {
 	data: CAPICrossword;
 	progress?: Progress;
@@ -67,7 +65,6 @@ const layoutComponents: Omit<LayoutProps, 'gridWidth'> = {
 const ApplicationWrapper = ({ children }: { children: ReactNode }) => {
 	const { currentFocus, focusOn } = useFocus();
 	const { getId } = useData();
-	const previousDirectionRef = useRef<TabDirection | undefined>(undefined);
 	const startRef = useRef<HTMLDivElement | null>(null);
 	const endRef = useRef<HTMLDivElement | null>(null);
 
@@ -77,13 +74,7 @@ const ApplicationWrapper = ({ children }: { children: ReactNode }) => {
 			(direction === 'back' && currentFocus === 'application-start') ||
 			(direction === 'forward' && currentFocus === 'application-end')
 		) {
-			previousDirectionRef.current = undefined;
 			return undefined;
-		}
-
-		// Update previousDirection if needed
-		if (previousDirectionRef.current !== direction) {
-			previousDirectionRef.current = direction;
 		}
 
 		const currentIndex = focusTargets.findIndex(

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -29,6 +29,17 @@ export type CrosswordProps = {
 	Layout?: ComponentType<LayoutProps>;
 } & Partial<Theme>;
 
+const visuallyHidden = css`
+	position: absolute;
+	width: 100%;
+	height: 1px;
+	padding: 0;
+	margin: -1px 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+`;
 const wrapperStyles = css`
 	*,
 	*::before,
@@ -126,6 +137,7 @@ const ApplicationWrapper = ({ children }: { children: ReactNode }) => {
 			<div
 				ref={startRef}
 				tabIndex={0}
+				css={visuallyHidden}
 				onFocus={() => {
 					focusOn('application-start');
 				}}
@@ -136,6 +148,7 @@ const ApplicationWrapper = ({ children }: { children: ReactNode }) => {
 			<div
 				ref={endRef}
 				tabIndex={0}
+				css={visuallyHidden}
 				onFocus={() => {
 					focusOn('application-end');
 				}}

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -1,3 +1,4 @@
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import {
@@ -11,6 +12,7 @@ import type { CAPICrossword } from '../@types/CAPI';
 import type { Progress, Theme } from '../@types/crossword';
 import type { LayoutProps } from '../@types/Layout';
 import { ContextProvider } from '../context/ContextProvider';
+import { useData } from '../context/Data';
 import { focusTargets } from '../context/Focus';
 import { useFocus } from '../context/Focus';
 import { useProgress } from '../context/Progress';
@@ -29,6 +31,19 @@ export type CrosswordProps = {
 	children?: ReactNode;
 	Layout?: ComponentType<LayoutProps>;
 } & Partial<Theme>;
+
+const defaultWrapperStyles = css`
+	*,
+	*::before,
+	*::after {
+		box-sizing: border-box;
+		padding: 0;
+		margin: 0;
+	}
+	height: 100%;
+	width: 100%;
+	container-type: inline-size;
+`;
 
 const SavedMessage = () => {
 	const { isStored } = useProgress();
@@ -50,8 +65,15 @@ const layoutComponents: Omit<LayoutProps, 'gridWidth'> = {
 	SavedMessage,
 };
 
-const TabWrangler = ({ children }: { children: ReactNode }) => {
+const TabWrangler = ({
+	children,
+	wrapperStyles = defaultWrapperStyles,
+}: {
+	children: ReactNode;
+	wrapperStyles?: SerializedStyles;
+}) => {
 	const { currentFocus, focusOn } = useFocus();
+	const { getId } = useData();
 	const previousDirectionRef = useRef<TabDirection | undefined>(undefined);
 	const tabWrapperRef = useRef<HTMLDivElement | null>(null);
 
@@ -94,7 +116,9 @@ const TabWrangler = ({ children }: { children: ReactNode }) => {
 
 	return (
 		<div
-			id={'tab-wrapper'}
+			role="application"
+			css={wrapperStyles}
+			id={getId('crossword')}
 			ref={tabWrapperRef}
 			tabIndex={0}
 			onKeyDown={(event) => {
@@ -152,25 +176,9 @@ export const Crossword = ({
 			selectedEntryId={data.entries[0].id}
 		>
 			<TabWrangler>
-				<div
-					role="application"
-					css={css`
-						*,
-						*::before,
-						*::after {
-							box-sizing: border-box;
-							padding: 0;
-							margin: 0;
-						}
-						height: 100%;
-						width: 100%;
-						container-type: inline-size;
-					`}
-				>
-					{children ?? (
-						<LayoutComponent {...layoutComponents} gridWidth={gridWidth} />
-					)}
-				</div>
+				{children ?? (
+					<LayoutComponent {...layoutComponents} gridWidth={gridWidth} />
+				)}
 			</TabWrangler>
 		</ContextProvider>
 	);

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -31,10 +31,10 @@ export type CrosswordProps = {
 
 const visuallyHidden = css`
 	position: absolute;
-	width: 100%;
+	width: 1px;
 	height: 1px;
 	padding: 0;
-	margin: -1px 0;
+	margin: -1px;
 	overflow: hidden;
 	clip: rect(0, 0, 0, 0);
 	white-space: nowrap;

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -1,4 +1,3 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import {
@@ -32,7 +31,7 @@ export type CrosswordProps = {
 	Layout?: ComponentType<LayoutProps>;
 } & Partial<Theme>;
 
-const defaultWrapperStyles = css`
+const wrapperStyles = css`
 	*,
 	*::before,
 	*::after {
@@ -65,13 +64,7 @@ const layoutComponents: Omit<LayoutProps, 'gridWidth'> = {
 	SavedMessage,
 };
 
-const TabWrangler = ({
-	children,
-	wrapperStyles = defaultWrapperStyles,
-}: {
-	children: ReactNode;
-	wrapperStyles?: SerializedStyles;
-}) => {
+const ApplicationWrapper = ({ children }: { children: ReactNode }) => {
 	const { currentFocus, focusOn } = useFocus();
 	const { getId } = useData();
 	const previousDirectionRef = useRef<TabDirection | undefined>(undefined);
@@ -175,11 +168,11 @@ export const Crossword = ({
 			userProgress={progress}
 			selectedEntryId={data.entries[0].id}
 		>
-			<TabWrangler>
+			<ApplicationWrapper>
 				{children ?? (
 					<LayoutComponent {...layoutComponents} gridWidth={gridWidth} />
 				)}
-			</TabWrangler>
+			</ApplicationWrapper>
 		</ContextProvider>
 	);
 };

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -68,13 +68,14 @@ const ApplicationWrapper = ({ children }: { children: ReactNode }) => {
 	const { currentFocus, focusOn } = useFocus();
 	const { getId } = useData();
 	const previousDirectionRef = useRef<TabDirection | undefined>(undefined);
-	const tabWrapperRef = useRef<HTMLDivElement | null>(null);
+	const startRef = useRef<HTMLDivElement | null>(null);
+	const endRef = useRef<HTMLDivElement | null>(null);
 
 	const getTarget = (direction: 'back' | 'forward') => {
 		// If direction is the same and we're on 'application', reset previousDirection and return
 		if (
-			direction === previousDirectionRef.current &&
-			currentFocus === 'application'
+			(direction === 'back' && currentFocus === 'application-start') ||
+			(direction === 'forward' && currentFocus === 'application-end')
 		) {
 			previousDirectionRef.current = undefined;
 			return undefined;
@@ -102,8 +103,11 @@ const ApplicationWrapper = ({ children }: { children: ReactNode }) => {
 	};
 
 	useEffect(() => {
-		if (currentFocus === 'application') {
-			tabWrapperRef.current?.focus();
+		if (currentFocus === 'application-start') {
+			startRef.current?.focus();
+		}
+		if (currentFocus === 'application-end') {
+			endRef.current?.focus();
 		}
 	}, [currentFocus]);
 
@@ -112,8 +116,6 @@ const ApplicationWrapper = ({ children }: { children: ReactNode }) => {
 			role="application"
 			css={wrapperStyles}
 			id={getId('crossword')}
-			ref={tabWrapperRef}
-			tabIndex={0}
 			onKeyDown={(event) => {
 				if (event.key === 'Tab') {
 					let nextTarget;
@@ -129,13 +131,26 @@ const ApplicationWrapper = ({ children }: { children: ReactNode }) => {
 					event.preventDefault();
 				}
 			}}
-			onFocus={() => {
-				if (isUndefined(currentFocus)) {
-					focusOn('application');
-				}
-			}}
 		>
+			<div
+				ref={startRef}
+				tabIndex={0}
+				onFocus={() => {
+					focusOn('application-start');
+				}}
+			>
+				Crossword Application Start
+			</div>
 			{children}
+			<div
+				ref={endRef}
+				tabIndex={0}
+				onFocus={() => {
+					focusOn('application-end');
+				}}
+			>
+				Crossword Application End
+			</div>
 		</div>
 	);
 };

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -112,6 +112,11 @@ const TabWrangler = ({ children }: { children: ReactNode }) => {
 					event.preventDefault();
 				}
 			}}
+			onFocus={() => {
+				if (isUndefined(currentFocus)) {
+					focusOn('application');
+				}
+			}}
 		>
 			{children}
 		</div>

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -132,7 +132,7 @@ export const Grid = () => {
 	const { updateCell } = useUpdateCell();
 	const { currentCell, setCurrentCell } = useCurrentCell();
 	const { currentEntryId, setCurrentEntryId } = useCurrentClue();
-	const { currentFocus } = useFocus();
+	const { currentFocus, focusOn } = useFocus();
 	const [focused, setFocused] = useState(false);
 	const [inputValue, setInputValue] = useState('');
 
@@ -152,7 +152,6 @@ export const Grid = () => {
 	}, [currentEntryId, entries]);
 
 	useEffect(() => {
-		console.log('focus changed', currentFocus);
 		if (currentFocus === 'grid') {
 			inputRef.current?.focus();
 		}
@@ -458,7 +457,8 @@ export const Grid = () => {
 
 	const focusInput = useCallback(() => {
 		inputRef.current?.focus();
-	}, []);
+		focusOn('grid');
+	}, [focusOn]);
 
 	const onFocus = useCallback(() => {
 		if (!currentCell) {

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -170,8 +170,10 @@ export const Grid = () => {
 		: undefined;
 
 	const focusInput = useCallback(() => {
-		focusOn('grid');
-	}, [focusOn]);
+		if (currentFocus !== 'grid') {
+			focusOn('grid');
+		}
+	}, [currentFocus, focusOn]);
 
 	// keep workingDirectionRef.current up to date with the current entry
 	useEffect(() => {
@@ -499,13 +501,16 @@ export const Grid = () => {
 			// Set the new current cell and entry:
 			setCurrentCell(clickedCell);
 			setCurrentEntryId(newEntryId);
-			focusOn('grid');
+			if (currentFocus !== 'grid') {
+				focusOn('grid');
+			}
 		},
 		[
 			cells,
 			currentCell?.x,
 			currentCell?.y,
 			currentEntryId,
+			currentFocus,
 			focusOn,
 			setCurrentCell,
 			setCurrentEntryId,

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -13,6 +13,7 @@ import type { Direction } from '../@types/Direction';
 import { useCurrentCell } from '../context/CurrentCell';
 import { useCurrentClue } from '../context/CurrentClue';
 import { useData } from '../context/Data';
+import { useFocus } from '../context/Focus';
 import { useProgress } from '../context/Progress';
 import { useTheme } from '../context/Theme';
 import { useCheatMode } from '../hooks/useCheatMode';
@@ -131,6 +132,7 @@ export const Grid = () => {
 	const { updateCell } = useUpdateCell();
 	const { currentCell, setCurrentCell } = useCurrentCell();
 	const { currentEntryId, setCurrentEntryId } = useCurrentClue();
+	const { currentFocus } = useFocus();
 	const [focused, setFocused] = useState(false);
 	const [inputValue, setInputValue] = useState('');
 
@@ -148,6 +150,13 @@ export const Grid = () => {
 				entries.get(currentEntryId)?.direction ?? workingDirectionRef.current;
 		}
 	}, [currentEntryId, entries]);
+
+	useEffect(() => {
+		console.log('focus changed', currentFocus);
+		if (currentFocus === 'grid') {
+			inputRef.current?.focus();
+		}
+	}, [currentFocus]);
 
 	const getProgressForEntry = useCallback(
 		(entry: CAPIEntry): string => {
@@ -242,16 +251,13 @@ export const Grid = () => {
 			if (delta.x !== 0) {
 				setCurrentCell(newCell);
 				setCurrentEntryId(possibleAcross ?? possibleDown);
-				inputRef.current?.focus();
-				return;
 			}
 
 			if (delta.y !== 0) {
 				setCurrentCell(newCell);
 				setCurrentEntryId(possibleDown ?? possibleAcross);
-				inputRef.current?.focus();
-				return;
 			}
+			inputRef.current?.focus();
 		},
 		[currentCell, cells, setCurrentCell, setCurrentEntryId],
 	);
@@ -287,9 +293,6 @@ export const Grid = () => {
 
 	const handleKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLInputElement>): void => {
-			if (event.ctrlKey || event.altKey || event.metaKey) {
-				return;
-			}
 			if (!currentCell) {
 				return;
 			}
@@ -582,7 +585,7 @@ export const Grid = () => {
 					onChange={handleChange}
 					onFocus={onFocus}
 					onBlur={() => setFocused(false)}
-					tabIndex={0}
+					tabIndex={-1}
 					css={css`
 						position: absolute;
 						pointer-events: none;

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -622,12 +622,10 @@ export const Grid = () => {
 					css={css`
 						position: absolute;
 						pointer-events: none;
-						top: ${(currentCell?.y ?? 0) *
-							(theme.gridCellSize + theme.gridGutterSize) +
-						theme.gridGutterSize}px;
+						top: 0;
 						left: 0;
 						width: 100%;
-						height: ${theme.gridCellSize}px;
+						height: 100%;
 						opacity: 0;
 					`}
 					autoComplete="off"

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -599,7 +599,7 @@ export const Grid = () => {
 					spellCheck="false"
 					autoCorrect="off"
 					aria-hidden="false"
-					aria-live="polite"
+					aria-live={currentFocus === 'grid' ? 'assertive' : 'off'}
 					aria-label={currentCellLabel}
 				/>
 			</div>

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -181,9 +181,12 @@ export const Grid = () => {
 		}
 	}, [currentEntryId, entries]);
 
+	// If the current focus is the grid
+	// and the current cell or current entry ID changes refocus the input.
 	useEffect(() => {
 		if (currentFocus === 'grid') {
-			// if there is a current cell and a current entry, but the cell is not in the entry
+			// If there is a current cell and a current entry, but the cell is not in the entry.
+			// Set the current cell to the first cell in the entry.
 			if (
 				currentEntry &&
 				currentCell &&
@@ -191,7 +194,8 @@ export const Grid = () => {
 			) {
 				setCurrentCell(cells.getByCoords(currentEntry.position));
 			}
-			// if there is no current cell set one
+			// if there is no current cell but there is an Entry
+			// Set the current cell to the first cell in the current entry
 			if (!currentCell && currentEntry) {
 				setCurrentCell(cells.getByCoords(currentEntry.position));
 			}

--- a/libs/@guardian/react-crossword/src/context/ContextProvider.tsx
+++ b/libs/@guardian/react-crossword/src/context/ContextProvider.tsx
@@ -25,6 +25,7 @@ import type { EntryID } from '../@types/Entry';
 import { CurrentCellProvider } from './CurrentCell';
 import { CurrentClueProvider } from './CurrentClue';
 import { DataProvider } from './Data';
+import { FocusProvider } from './Focus';
 import { ProgressProvider } from './Progress';
 import { ShowAnagramHelperProvider } from './ShowAnagramHelper';
 import { ThemeProvider } from './Theme';
@@ -61,7 +62,9 @@ export const ContextProvider = ({
 					>
 						<CurrentCellProvider>
 							<CurrentClueProvider selectedEntryId={selectedEntryId}>
-								<ValidAnswersProvider>{children}</ValidAnswersProvider>
+								<FocusProvider>
+									<ValidAnswersProvider>{children}</ValidAnswersProvider>
+								</FocusProvider>
 							</CurrentClueProvider>
 						</CurrentCellProvider>
 					</ProgressProvider>

--- a/libs/@guardian/react-crossword/src/context/Focus.tsx
+++ b/libs/@guardian/react-crossword/src/context/Focus.tsx
@@ -25,7 +25,9 @@ export const focusTargets: FocusTarget[] = [
 const FocusContext = createContext<Context | undefined>(undefined);
 
 export const FocusProvider = ({ children }: { children: ReactNode }) => {
-	const [currentFocus, setCurrentFocus] = useState<FocusTarget>('application');
+	const [currentFocus, setCurrentFocus] = useState<FocusTarget | undefined>(
+		undefined,
+	);
 
 	const focusOn = useCallback((target: FocusTarget) => {
 		setCurrentFocus(target);

--- a/libs/@guardian/react-crossword/src/context/Focus.tsx
+++ b/libs/@guardian/react-crossword/src/context/Focus.tsx
@@ -1,28 +1,28 @@
 import { createContext, type ReactNode, useContext, useState } from 'react';
 import type { Direction } from '../@types/Direction';
 
-export type FocusTarget = Direction | 'grid' | 'controls';
+export type FocusTarget = Direction | 'grid' | 'controls' | 'application';
 
 type Context = {
 	currentFocus?: FocusTarget;
-	focusOn: (target: FocusTarget | undefined) => void;
+	focusOn: (target: FocusTarget) => void;
 };
 
 export const focusTargets: FocusTarget[] = [
+	'application',
 	'across',
 	'grid',
 	'down',
 	'controls',
+	'application',
 ] as const;
 
 const FocusContext = createContext<Context | undefined>(undefined);
 
 export const FocusProvider = ({ children }: { children: ReactNode }) => {
-	const [currentFocus, setCurrentFocus] = useState<FocusTarget | undefined>(
-		undefined,
-	);
+	const [currentFocus, setCurrentFocus] = useState<FocusTarget>('application');
 
-	const focusOn = (target: FocusTarget | undefined) => {
+	const focusOn = (target: FocusTarget) => {
 		setCurrentFocus(target);
 	};
 

--- a/libs/@guardian/react-crossword/src/context/Focus.tsx
+++ b/libs/@guardian/react-crossword/src/context/Focus.tsx
@@ -1,0 +1,46 @@
+import { createContext, type ReactNode, useContext, useState } from 'react';
+import type { Direction } from '../@types/Direction';
+
+export type FocusTarget = Direction | 'grid' | 'controls';
+
+type Context = {
+	currentFocus?: FocusTarget;
+	focusOn: (target: FocusTarget | undefined) => void;
+};
+
+export const focusTargets: FocusTarget[] = [
+	'across',
+	'grid',
+	'down',
+	'controls',
+] as const;
+
+const FocusContext = createContext<Context | undefined>(undefined);
+
+export const FocusProvider = ({ children }: { children: ReactNode }) => {
+	const [currentFocus, setCurrentFocus] = useState<FocusTarget | undefined>(
+		undefined,
+	);
+
+	const focusOn = (target: FocusTarget | undefined) => {
+		setCurrentFocus(target);
+	};
+
+	return (
+		<FocusContext.Provider value={{ currentFocus, focusOn }}>
+			{children}
+		</FocusContext.Provider>
+	);
+};
+
+export const useFocus = () => {
+	const context = useContext(FocusContext);
+
+	if (!context) {
+		throw new Error(
+			'FocusContext does not exist. Have you used a Crossword subcomponent outside a Crossword component?',
+		);
+	}
+
+	return context;
+};

--- a/libs/@guardian/react-crossword/src/context/Focus.tsx
+++ b/libs/@guardian/react-crossword/src/context/Focus.tsx
@@ -7,7 +7,12 @@ import {
 } from 'react';
 import type { Direction } from '../@types/Direction';
 
-export type FocusTarget = Direction | 'grid' | 'controls' | 'application';
+export type FocusTarget =
+	| Direction
+	| 'grid'
+	| 'controls'
+	| 'application-start'
+	| 'application-end';
 
 type Context = {
 	currentFocus?: FocusTarget;
@@ -15,11 +20,12 @@ type Context = {
 };
 
 export const focusTargets: FocusTarget[] = [
-	'application',
+	'application-start',
 	'across',
 	'grid',
 	'down',
 	'controls',
+	'application-end',
 ] as const;
 
 const FocusContext = createContext<Context | undefined>(undefined);

--- a/libs/@guardian/react-crossword/src/context/Focus.tsx
+++ b/libs/@guardian/react-crossword/src/context/Focus.tsx
@@ -20,7 +20,6 @@ export const focusTargets: FocusTarget[] = [
 	'grid',
 	'down',
 	'controls',
-	'application',
 ] as const;
 
 const FocusContext = createContext<Context | undefined>(undefined);

--- a/libs/@guardian/react-crossword/src/context/Focus.tsx
+++ b/libs/@guardian/react-crossword/src/context/Focus.tsx
@@ -1,4 +1,10 @@
-import { createContext, type ReactNode, useContext, useState } from 'react';
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useState,
+} from 'react';
 import type { Direction } from '../@types/Direction';
 
 export type FocusTarget = Direction | 'grid' | 'controls' | 'application';
@@ -22,9 +28,9 @@ const FocusContext = createContext<Context | undefined>(undefined);
 export const FocusProvider = ({ children }: { children: ReactNode }) => {
 	const [currentFocus, setCurrentFocus] = useState<FocusTarget>('application');
 
-	const focusOn = (target: FocusTarget) => {
+	const focusOn = useCallback((target: FocusTarget) => {
 		setCurrentFocus(target);
-	};
+	}, []);
 
 	return (
 		<FocusContext.Provider value={{ currentFocus, focusOn }}>


### PR DESCRIPTION
## What are you changing?

- Controlling focus within the crossword.
- When pressing Tab, move forward in the crossword - across, grid, down, controls

## Why?

- This means it is easier to navigate the crossword for screen readers and accessibility reasons, You are only one tab from the clues to the grid. This also allows for our custom layout with the same tab order. no matter which order the components are in
