### PR TITLE
Anagram helper control its own visibility

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -1,4 +1,3 @@
-import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import {
@@ -32,7 +31,7 @@ export type CrosswordProps = {
 	Layout?: ComponentType<LayoutProps>;
 } & Partial<Theme>;
 
-const defaultWrapperStyles = css`
+const wrapperStyles = css`
 	*,
 	*::before,
 	*::after {
@@ -42,6 +41,7 @@ const defaultWrapperStyles = css`
 	}
 	height: 100%;
 	width: 100%;
+	position: relative;
 	container-type: inline-size;
 `;
 
@@ -65,13 +65,7 @@ const layoutComponents: Omit<LayoutProps, 'gridWidth'> = {
 	SavedMessage,
 };
 
-const TabWrangler = ({
-	children,
-	wrapperStyles = defaultWrapperStyles,
-}: {
-	children: ReactNode;
-	wrapperStyles?: SerializedStyles;
-}) => {
+const ApplicationWrapper = ({ children }: { children: ReactNode }) => {
 	const { currentFocus, focusOn } = useFocus();
 	const { getId } = useData();
 	const previousDirectionRef = useRef<TabDirection | undefined>(undefined);
@@ -175,11 +169,11 @@ export const Crossword = ({
 			userProgress={progress}
 			selectedEntryId={data.entries[0].id}
 		>
-			<TabWrangler>
+			<ApplicationWrapper>
 				{children ?? (
 					<LayoutComponent {...layoutComponents} gridWidth={gridWidth} />
 				)}
-			</TabWrangler>
+			</ApplicationWrapper>
 		</ContextProvider>
 	);
 };

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -1,3 +1,4 @@
+import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import {
@@ -11,6 +12,7 @@ import type { CAPICrossword } from '../@types/CAPI';
 import type { Progress, Theme } from '../@types/crossword';
 import type { LayoutProps } from '../@types/Layout';
 import { ContextProvider } from '../context/ContextProvider';
+import { useData } from '../context/Data';
 import { focusTargets } from '../context/Focus';
 import { useFocus } from '../context/Focus';
 import { useProgress } from '../context/Progress';
@@ -29,6 +31,19 @@ export type CrosswordProps = {
 	children?: ReactNode;
 	Layout?: ComponentType<LayoutProps>;
 } & Partial<Theme>;
+
+const defaultWrapperStyles = css`
+	*,
+	*::before,
+	*::after {
+		box-sizing: border-box;
+		padding: 0;
+		margin: 0;
+	}
+	height: 100%;
+	width: 100%;
+	container-type: inline-size;
+`;
 
 const SavedMessage = () => {
 	const { isStored } = useProgress();
@@ -50,8 +65,15 @@ const layoutComponents: Omit<LayoutProps, 'gridWidth'> = {
 	SavedMessage,
 };
 
-const TabWrangler = ({ children }: { children: ReactNode }) => {
+const TabWrangler = ({
+	children,
+	wrapperStyles = defaultWrapperStyles,
+}: {
+	children: ReactNode;
+	wrapperStyles?: SerializedStyles;
+}) => {
 	const { currentFocus, focusOn } = useFocus();
+	const { getId } = useData();
 	const previousDirectionRef = useRef<TabDirection | undefined>(undefined);
 	const tabWrapperRef = useRef<HTMLDivElement | null>(null);
 
@@ -94,7 +116,9 @@ const TabWrangler = ({ children }: { children: ReactNode }) => {
 
 	return (
 		<div
-			id={'tab-wrapper'}
+			role="application"
+			css={wrapperStyles}
+			id={getId('crossword')}
 			ref={tabWrapperRef}
 			tabIndex={0}
 			onKeyDown={(event) => {
@@ -152,25 +176,9 @@ export const Crossword = ({
 			selectedEntryId={data.entries[0].id}
 		>
 			<TabWrangler>
-				<div
-					role="application"
-					css={css`
-						*,
-						*::before,
-						*::after {
-							box-sizing: border-box;
-							padding: 0;
-							margin: 0;
-						}
-						height: 100%;
-						width: 100%;
-						container-type: inline-size;
-					`}
-				>
-					{children ?? (
-						<LayoutComponent {...layoutComponents} gridWidth={gridWidth} />
-					)}
-				</div>
+				{children ?? (
+					<LayoutComponent {...layoutComponents} gridWidth={gridWidth} />
+				)}
 			</TabWrangler>
 		</ContextProvider>
 	);

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -112,6 +112,11 @@ const TabWrangler = ({ children }: { children: ReactNode }) => {
 					event.preventDefault();
 				}
 			}}
+			onFocus={() => {
+				if (isUndefined(currentFocus)) {
+					focusOn('application');
+				}
+			}}
 		>
 			{children}
 		</div>

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -599,7 +599,7 @@ export const Grid = () => {
 					spellCheck="false"
 					autoCorrect="off"
 					aria-hidden="false"
-					aria-live="polite"
+					aria-live={currentFocus === 'grid' ? 'assertive' : 'off'}
 					aria-label={currentCellLabel}
 				/>
 			</div>

--- a/libs/@guardian/react-crossword/src/context/Focus.tsx
+++ b/libs/@guardian/react-crossword/src/context/Focus.tsx
@@ -25,7 +25,9 @@ export const focusTargets: FocusTarget[] = [
 const FocusContext = createContext<Context | undefined>(undefined);
 
 export const FocusProvider = ({ children }: { children: ReactNode }) => {
-	const [currentFocus, setCurrentFocus] = useState<FocusTarget>('application');
+	const [currentFocus, setCurrentFocus] = useState<FocusTarget | undefined>(
+		undefined,
+	);
 
 	const focusOn = useCallback((target: FocusTarget) => {
 		setCurrentFocus(target);

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -44,7 +44,6 @@ const Layout = ({
 		<div
 			css={css`
 				color: ${textColor};
-				position: relative;
 				display: flex;
 				flex-direction: column;
 				gap: ${space[4]}px;


### PR DESCRIPTION
## What are you changing?

- Adding the `position:relative` to the `ApplicationWrapper` and the `position:absolute` to the anagram helper. 

## Why?

- This means we can make sure that the anagram helper is always relative to the whole space given to the crossword.
