### PR TITLE
Crossword input box same height as grid cell

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -622,10 +622,12 @@ export const Grid = () => {
 					css={css`
 						position: absolute;
 						pointer-events: none;
-						top: 0;
+						top: ${(currentCell?.y ?? 0) *
+							(theme.gridCellSize + theme.gridGutterSize) +
+						theme.gridGutterSize}px;
 						left: 0;
 						width: 100%;
-						height: 100%;
+						height: ${theme.gridCellSize}px;
 						opacity: 0;
 					`}
 					autoComplete="off"


### PR DESCRIPTION
## What are you changing?

- Make the input cell the same height as the grid cell

## Why?

- This prevents the grid input from moving the page on a smaller container. Previously it would center the input which was the full height of the grid. 
