### PR TITLE
remove early exit if ctrl or option pressed for grid nav

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -287,9 +287,6 @@ export const Grid = () => {
 
 	const handleKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLInputElement>): void => {
-			if (event.ctrlKey || event.altKey || event.metaKey) {
-				return;
-			}
 			if (!currentCell) {
 				return;
 			}


### PR DESCRIPTION
## What are you changing?

- This was copied from myCrossword but is not needed.