### PR TITLE
Fix for stored state. 

### DIFF
--- a/libs/@guardian/react-crossword/src/context/Progress.tsx
+++ b/libs/@guardian/react-crossword/src/context/Progress.tsx
@@ -1,4 +1,4 @@
-import { log } from '@guardian/libs';
+import { isUndefined, log } from '@guardian/libs';
 import type { Dispatch, SetStateAction } from 'react';
 import { createContext, type ReactNode, useContext } from 'react';
 import type { CAPICrossword } from '../@types/CAPI';
@@ -86,14 +86,18 @@ export const ProgressProvider = ({
 	children: ReactNode;
 }) => {
 	const [progress, setProgress, { isPersistent }] = useStoredState(id, {
-		defaultValue: getInitialProgress({ id, dimensions, userProgress }),
 		validator: (progress: unknown) => isValid(progress, { dimensions }),
 	});
+
+	const defaultProgress = getInitialProgress({ id, dimensions, userProgress });
+	if (isUndefined(progress)) {
+		setProgress(defaultProgress);
+	}
 
 	return (
 		<ProgressContext.Provider
 			value={{
-				progress,
+				progress: progress ?? defaultProgress,
 				setProgress,
 				isStored: isPersistent,
 			}}

--- a/libs/@guardian/react-crossword/src/hooks/useStoredState.ts
+++ b/libs/@guardian/react-crossword/src/hooks/useStoredState.ts
@@ -2,7 +2,6 @@
  * Wrapper for https://github.com/astoilkov/use-local-storage-state that:
  *
  * - adds a `validator` option
- * - makes `defaultValue` required
  * - provides our own serializer to keep the data stored in localStorage in a
  *   format that matches the format used by @guardian/libs#storage
  *
@@ -12,7 +11,7 @@
  * the type we stored without validation.
  */
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import useLocalStorageState from 'use-local-storage-state';
 import type { LocalStorageOptions } from 'use-local-storage-state';
 
@@ -39,31 +38,26 @@ const serializer: LocalStorageOptions<unknown>['serializer'] = {
 
 type Options<T> = Omit<LocalStorageOptions<T>, 'serializer'> & {
 	validator: Validator<T>;
-	defaultValue: NonNullable<LocalStorageOptions<T>['defaultValue']>;
 };
 
 export function useStoredState<
 	V extends Validator<unknown>,
 	T = ValidatesAs<V>,
 >(key: string, { validator, ...options }: Options<T>) {
-	const [defaultValue] = useState(options.defaultValue);
-
 	const [state, setState, rest] = useLocalStorageState(key, {
 		...options,
 		serializer,
 	});
 
-	const validatedState: T = useMemo(() => {
+	const validatedState: T | undefined = useMemo(() => {
 		// If the state is valid, return it (now properly typed).
 		if (validator(state)) {
 			return state;
 		}
 
-		// The state is invalid, set the state to the default value and return the default value
-		// (which may be undefined).
-		setState(defaultValue);
-		return defaultValue;
-	}, [validator, state, setState, defaultValue]);
+		// The state is invalid, so return undefined.
+		return undefined;
+	}, [validator, state]);
 
 	return [validatedState, setState, rest] as const;
 }

--- a/libs/@guardian/react-crossword/src/hooks/useStoredState.ts
+++ b/libs/@guardian/react-crossword/src/hooks/useStoredState.ts
@@ -53,16 +53,17 @@ export function useStoredState<
 		serializer,
 	});
 
-	const validatedState = useMemo(() => {
+	const validatedState: T = useMemo(() => {
 		// If the state is valid, return it (now properly typed).
 		if (validator(state)) {
 			return state;
 		}
 
-		// The state is invalid, so return the default value (which may be
-		// undefined).
+		// The state is invalid, set the state to the default value and return the default value
+		// (which may be undefined).
+		setState(defaultValue);
 		return defaultValue;
-	}, [validator, state, defaultValue]);
+	}, [validator, state, setState, defaultValue]);
 
 	return [validatedState, setState, rest] as const;
 }


### PR DESCRIPTION
If the state received is invalid then set the state to be the default state and return the default state.
- Currently it is returning the default state provided as the state but not resetting the state to the default value.