### PR TITLE
Handle Crossword input for IMEs / Android native keyboard.

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -257,7 +257,7 @@ export const Grid = () => {
 	 * This function is used to handle keyboard input in the crossword grid.
 	 * It works for devices with a physical keyboard, for mobile devices that use IMEs we use the onInput event.
 	 */
-	const handleInputKeyDown = useCallback(
+	const handleKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLInputElement>) => {
 			if (event.key === 'Backspace' || event.key === 'Delete') {
 				event.preventDefault();
@@ -499,7 +499,7 @@ export const Grid = () => {
 												autoCapitalize={'none'}
 												type="text"
 												pattern={'^[A-Za-zÀ-ÿ0-9]$'}
-												onKeyDown={handleInputKeyDown}
+												onKeyDown={handleKeyDown}
 												id={getId(`cell-input-${cell.x}-${cell.y}`)}
 												onInput={(event: FormEvent) => {
 													handleInput(event, guess);


### PR DESCRIPTION
## What are you changing?

- Adding an onInput event handler to the crossword cells. To remove or add letters if the onKeydown event doesn't have the required information.

## Why?

- IMEs which includes the android keyboard dont add information about which key was pressed.
    - To handle this in react we need to use the native event. 
    - The native event has the information we need to know if we are supposed to add or remove a letter
Resources which explain the problem
   - https://github.com/facebook/react/issues/14512
   - https://clark.engineering/input-on-android-229-unidentified-1d92105b9a04

