### PR TITLE
Crossword fix for keydown event handler

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -260,8 +260,8 @@ export const Grid = () => {
 	const handleKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLInputElement>) => {
 			if (event.key === 'Backspace' || event.key === 'Delete') {
-				event.preventDefault();
 				if ('value' in event.target && isString(event.target.value)) {
+					event.preventDefault();
 					deleteLetter(event.target.value);
 				}
 			} else {

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -265,7 +265,7 @@ export const Grid = () => {
 					deleteLetter(event.target.value);
 				}
 			} else {
-				if (event.key) {
+				if (event.key && event.key.length === 1) {
 					event.preventDefault();
 					typeLetter(event.key);
 				}


### PR DESCRIPTION
## What are you changing?

We only want to prevent default for keys which have length 1. 
- currently this is getting in the way of other control keys, for example tab | ctrl | shift etc. 

## Why?

- Other keys should still perform the default actions.
