### PR TITLE
Back to regex

### DIFF
--- a/libs/@guardian/react-crossword/src/utils/stripHtmlTags.test.ts
+++ b/libs/@guardian/react-crossword/src/utils/stripHtmlTags.test.ts
@@ -1,0 +1,76 @@
+import { stripHtmlTags } from './stripHtmlTags';
+
+describe('stripHtmlTags', () => {
+	test('removes <b> tags and retains the text content', () => {
+		const input = 'This is <b>bold</b> text.';
+		const expected = 'This is bold text.';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+	test('removes <i> tags and retains the text content', () => {
+		const input = 'This is <i>italic</i> text.';
+		const expected = 'This is italic text.';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+
+	test('removes <span> tags with attributes and retains the text content', () => {
+		const input = 'Here is a <span class="highlight">span element</span>.';
+		const expected = 'Here is a span element.';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+
+	test('removes <sup> and <sub> tags and retains the text content', () => {
+		const input = 'This is a <sup>superscript</sup> and <sub>subscript</sub>.';
+		const expected = 'This is a superscript and subscript.';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+
+	test('handles nested tags properly', () => {
+		const input = '<b>This is <i>bold and italic</i></b>.';
+		const expected = 'This is bold and italic.';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+
+	test('handles multiple instances of the same tag', () => {
+		const input = '<b>Bold</b> and <b>another bold</b>.';
+		const expected = 'Bold and another bold.';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+
+	test('handles a mix of allowed and disallowed tags', () => {
+		const input = '<b>Bold</b>, <i>italic</i>, and <em>emphasized</em> text.';
+		const expected = 'Bold, italic, and <em>emphasized</em> text.';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+
+	test('leaves unmentioned tags untouched', () => {
+		const input =
+			'Here is <u>underlined</u> and <mark>highlighted</mark> text.';
+		const expected =
+			'Here is <u>underlined</u> and <mark>highlighted</mark> text.';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+
+	test('handles empty input gracefully', () => {
+		const input = '';
+		const expected = '';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+
+	test('handles strings without HTML tags', () => {
+		const input = 'Plain text with no tags.';
+		const expected = 'Plain text with no tags.';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+
+	test('handles strings with other tags', () => {
+		const input = '<text> tags.';
+		const expected = '<text> tags.';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+
+	test('handles strings < and >', () => {
+		const input = 'Plain < text > with no tags.';
+		const expected = 'Plain < text > with no tags.';
+		expect(stripHtmlTags(input)).toBe(expected);
+	});
+});

--- a/libs/@guardian/react-crossword/src/utils/stripHtmlTags.ts
+++ b/libs/@guardian/react-crossword/src/utils/stripHtmlTags.ts
@@ -1,4 +1,8 @@
+const regex = /<\/?(span|i|b|sup|sub)[^>]*?>/g;
 export const stripHtmlTags = (html: string): string => {
-	const doc = new DOMParser().parseFromString(html, 'text/html');
-	return doc.body.textContent ?? '';
+	// Remove the allowed tags for a clue: span, i, b, sup, sub
+	// Reference: https://crossword.info/docs/schema-doc.html#h464208646
+	// On the server, there is no DOMParser, so we have to use regex.
+	// As we know the tags that are allowed, this approach is sufficient.
+	return html.replace(regex, '');
 };

--- a/libs/@guardian/react-crossword/src/utils/stripHtmlTags.ts
+++ b/libs/@guardian/react-crossword/src/utils/stripHtmlTags.ts
@@ -2,7 +2,7 @@ const regex = /<\/?(span|i|b|sup|sub)[^>]*?>/g;
 export const stripHtmlTags = (html: string): string => {
 	// Remove the allowed tags for a clue: span, i, b, sup, sub
 	// Reference: https://crossword.info/docs/schema-doc.html#h464208646
-	// On the server, there is no DOMParser, so we have to use regex.
+	// On the server, there is no DOMParser, so we have to use regex or install a html parsing library.
 	// As we know the tags that are allowed, this approach is sufficient.
 	return html.replace(regex, '');
 };

--- a/libs/@guardian/react-crossword/src/utils/stripHtmlTags.ts
+++ b/libs/@guardian/react-crossword/src/utils/stripHtmlTags.ts
@@ -3,6 +3,6 @@ export const stripHtmlTags = (html: string): string => {
 	// Remove the allowed tags for a clue: span, i, b, sup, sub
 	// Reference: https://crossword.info/docs/schema-doc.html#h464208646
 	// On the server, there is no DOMParser, so we have to use regex or install a html parsing library.
-	// As we know the tags that are allowed, this approach is sufficient.
+	// As we know the tags that are allowed, regex is sufficient.
 	return html.replace(regex, '');
 };


### PR DESCRIPTION
## What are you changing?

- Using regex to strip tags rather than DOMParser

## Why?

- This code needs to run on the server where there is no DOMParser and jsdom is 3.1mb.
- We know which tags can be possible from the docs here https://crossword.info/docs/schema-doc.html#h464208646 therefore, we can be confident that the regex will be sufficient. 

