### PR TITLE
Make the grid hydrate on the client automatically

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -132,6 +132,7 @@ export const Grid = () => {
 	const { currentCell, setCurrentCell } = useCurrentCell();
 	const { currentEntryId, setCurrentEntryId } = useCurrentClue();
 	const [focused, setFocused] = useState(false);
+	const [, setHydrated] = useState(false);
 
 	const gridRef = useRef<SVGSVGElement>(null);
 	const workingDirectionRef = useRef<Direction>('across');
@@ -384,6 +385,11 @@ export const Grid = () => {
 			),
 		[],
 	);
+
+	// As the cells are all memoized we need to force a rerender for the initial load on the client
+	useEffect(() => {
+		setHydrated(true);
+	}, []);
 
 	// Handle changes to the current cell
 	useEffect(() => {


### PR DESCRIPTION
## What are you changing?

- Make the grid hydrate on the client in a useEffect and retrieve the progress from local storage. 
- Previously the grid was empty until the user interacted with it. It would update the cells with the locally stored progress.

## Why?

- The grid was not hydrating when the crossword was loading on the client after SSR. 
- As the cells are memoised and were not aware of the progress changing they did not re-render
