### PR TITLE
Fix for stacking content issue with SVG foreign object.

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Cell.tsx
+++ b/libs/@guardian/react-crossword/src/components/Cell.tsx
@@ -88,9 +88,6 @@ const CellComponent = ({
 						y={y}
 						width={theme.gridCellSize}
 						height={theme.gridCellSize}
-						css={css`
-							position: relative;
-						`}
 					>
 						<input
 							value={guess}
@@ -104,9 +101,6 @@ const CellComponent = ({
 							aria-label="Crossword cell"
 							aria-description={data.description ?? ''}
 							css={css`
-								position: absolute;
-								top: 0;
-								left: 0;
 								width: 100%;
 								height: 100%;
 								background: transparent;


### PR DESCRIPTION
## What are you changing?

- removing the position from the foreign object in the SVG

## Why?

- Stacking content in foreign object causing the input boxes to not be positioned correctly on mobile safari browser
- https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
These properties can cause issues with display on foreign objects

Before 
<img width="393" alt="Screenshot 2025-01-30 at 10 01 10" src="https://github.com/user-attachments/assets/ee854476-00b0-4584-b205-fc01a2c0ea1f" />

After
<img width="394" alt="Screenshot 2025-01-30 at 10 01 27" src="https://github.com/user-attachments/assets/75b1ce23-eff3-4bd3-9ccb-3c12de00b808" />


