### PR TITLE
Remove Twitter from CMP vendorlist

### DIFF
--- a/.changeset/few-candles-invite.md
+++ b/.changeset/few-candles-invite.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Removed Twitter from the vendor list to align with the Sourcepoint vendor list.

--- a/libs/@guardian/libs/src/consent-management-platform/vendors.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/vendors.ts
@@ -35,7 +35,6 @@ export const TCFV2VendorIDs = {
 	remarketing: ['5ed0eb688a76503f1016578f'],
 	sentry: ['5f0f39014effda6e8bbd2006'],
 	teads: ['5eab3d5ab8e05c2bbe33f399'],
-	twitter: ['5e71760b69966540e4554f01'],
 	'youtube-player': ['5e7ac3fae30e7d1bc1ebf5e8'],
 } satisfies VendorIDType;
 


### PR DESCRIPTION
## What are you changing?

- Removing Twitter from list of supported vendor lists.

## Why?

- The vendor list was removed from the Sourcepoint vendor list
