### PR TITLE
Allow user to navigate clues without being taken to grid using arrow keys

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -93,6 +93,15 @@ export const Clues = ({ direction, Header }: Props) => {
 	const handleKeyDown = useCallback(
 		(event: KeyboardEvent) => {
 			switch (event.key) {
+				case ' ':
+				case 'Enter':
+					{
+						const entry = cluesEntries[currentCluesEntriesIndex];
+						if (entry) {
+							selectClue(entry);
+						}
+					}
+					break;
 				case 'ArrowDown':
 					setCurrentCluesEntriesIndex((prev) =>
 						Math.min(prev + 1, cluesEntries.length - 1),
@@ -113,16 +122,17 @@ export const Clues = ({ direction, Header }: Props) => {
 					break;
 			}
 		},
-		[cluesEntries],
+		[cluesEntries, currentCluesEntriesIndex, selectClue],
 	);
 
 	// Call `setCurrentEntryId` if `currentCluesEntriesIndex` changes
 	useEffect(() => {
 		const entry = cluesEntries[currentCluesEntriesIndex];
 		if (entry) {
-			setCurrentEntryId(entry.id);
+			const clue = document.getElementById(getId(entry.id));
+			clue?.focus();
 		}
-	}, [currentCluesEntriesIndex, cluesEntries, setCurrentEntryId]);
+	}, [currentCluesEntriesIndex, cluesEntries, setCurrentEntryId, getId]);
 
 	// Add event listeners
 	useEffect(() => {


### PR DESCRIPTION
## What are you changing?

- Previously when moving between the clues using the arrow keys you would also select them. Now you can navigate focus with the arrow keys and then use the spacebar or the enter key to select the clue and focus the grid.

## Why?

- This is a better experience for keyboard navigation
