### PR TITLE
Crossword print styles

### DIFF
--- a/libs/@guardian/react-crossword/src/@types/crossword.ts
+++ b/libs/@guardian/react-crossword/src/@types/crossword.ts
@@ -54,6 +54,8 @@ export type Theme = {
 	gridBackgroundColor: string;
 	/** The background colour of 'white' squares on the grid */
 	gridForegroundColor: string;
+	/** The background colour of 'black' squares on grid when printed */
+	gridPrintBackgroundColor: string;
 	/** The size of the gap between grid cells */
 	gridGutterSize: number;
 	/** The length of one side of a cell on on the grid */

--- a/libs/@guardian/react-crossword/src/components/Cell.tsx
+++ b/libs/@guardian/react-crossword/src/components/Cell.tsx
@@ -52,6 +52,13 @@ const CellComponent = ({
 				: theme.connectedColor
 			: theme.gridForegroundColor;
 
+	const cellStyles = css`
+		fill: ${backgroundColor};
+		@media print {
+			fill: ${isBlackCell ? 'transparent' : theme.gridForegroundColor};
+		}
+	`;
+
 	/**
 	 * Have to do this in a useEffect because there is an issue with preact
 	 * not normalising tabIndex attribute: https://github.com/preactjs/preact/issues/1061
@@ -71,9 +78,9 @@ const CellComponent = ({
 				y={y}
 				width={theme.gridCellSize}
 				height={theme.gridCellSize}
-				fill={backgroundColor}
 				aria-hidden="true"
 				role="presentation"
+				css={cellStyles}
 			/>
 			{!isBlackCell && (
 				<>

--- a/libs/@guardian/react-crossword/src/components/Clue.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clue.tsx
@@ -86,6 +86,7 @@ const ClueComponent = ({
 				@media print {
 					padding: 0.125em 0;
 					background-color: transparent;
+					opacity: 1;
 				}
 			`}
 			{...props}

--- a/libs/@guardian/react-crossword/src/components/Clue.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clue.tsx
@@ -82,6 +82,11 @@ const ClueComponent = ({
 				.visuallyHidden {
 					${visuallyHidden}
 				}
+
+				@media print {
+					padding: 0.125em 0;
+					background-color: transparent;
+				}
 			`}
 			{...props}
 		>

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -427,7 +427,7 @@ export const Grid = () => {
 		<svg
 			css={[
 				css`
-					background-color: ${theme.gridBackgroundColor};
+					background: ${theme.gridBackgroundColor};
 					position: relative;
 					cursor: pointer;
 					width: 100%;
@@ -450,7 +450,7 @@ export const Grid = () => {
 					}
 
 					@media print {
-						background-color: ${theme.gridPrintBackgroundColor};
+						background: ${theme.gridPrintBackgroundColor};
 					}
 				`,
 				cheatStyles,

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -434,9 +434,16 @@ export const Grid = () => {
 					max-width: ${maxWidth}px;
 					max-height: ${maxHeight}px;
 
-					// This is to prevent the default blue highlight on click on
-					// android
+					// This is to prevent the default blue highlight on click on Android
 					-webkit-tap-highlight-color: transparent;
+
+					/**
+					 * Request that the browser respects background colours when printing
+					 * so that the crossword grid and cells are visible. Emotion uses
+					 * Stylis to apply prefixes which only supports the deprecated
+					 * color-adjust property, hence using the prefixed version here.
+					 */
+					-webkit-print-color-adjust: exact;
 
 					*:focus {
 						outline: none;

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -427,7 +427,7 @@ export const Grid = () => {
 		<svg
 			css={[
 				css`
-					background: ${theme.gridBackgroundColor};
+					background-color: ${theme.gridBackgroundColor};
 					position: relative;
 					cursor: pointer;
 					width: 100%;
@@ -447,6 +447,10 @@ export const Grid = () => {
 
 					*:focus {
 						outline: none;
+					}
+
+					@media print {
+						background-color: ${theme.gridPrintBackgroundColor};
 					}
 				`,
 				cheatStyles,

--- a/libs/@guardian/react-crossword/src/components/StickyClue.tsx
+++ b/libs/@guardian/react-crossword/src/components/StickyClue.tsx
@@ -28,6 +28,9 @@ export const StickyClueComponent = ({ additionalCss }: StickyClueProps) => {
 		align-items: start;
 		${textSans12};
 		background: ${theme.stickyClueBackgroundColour};
+		@media print {
+			display: none;
+		}
 	`;
 
 	return (

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -19,6 +19,10 @@ const CluesHeader = memo(({ children }: { children: ReactNode }) => {
 				height: 2em;
 				margin-bottom: 0.5em;
 				text-transform: capitalize;
+
+				@media print {
+					border-top: none;
+				}
 			`}
 		>
 			{children}

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -79,6 +79,9 @@ const Layout = ({
 				<div
 					css={css`
 						margin-top: ${space[1]}px;
+						@media print {
+							display: none;
+						}
 					`}
 				>
 					<Controls />
@@ -88,6 +91,9 @@ const Layout = ({
 						${textSans12};
 						font-style: italic;
 						color: ${theme.textColor};
+						@media print {
+							display: none;
+						}
 					`}
 				>
 					<SavedMessage />

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -59,6 +59,10 @@ const Layout = ({
 				@container (min-width: ${oneColWidth}px) {
 					flex-direction: row;
 				}
+
+				@media print {
+					flex-direction: column;
+				}
 			`}
 		>
 			<AnagramHelper />
@@ -130,6 +134,10 @@ const Layout = ({
 						> * {
 							overflow: auto;
 						}
+					}
+
+					@media print {
+						flex-direction: row;
 					}
 				`}
 			>

--- a/libs/@guardian/react-crossword/src/theme.ts
+++ b/libs/@guardian/react-crossword/src/theme.ts
@@ -4,6 +4,7 @@ import type { Theme } from './@types/crossword';
 export const defaultTheme: Theme = {
 	gridBackgroundColor: palette.neutral[7],
 	gridForegroundColor: palette.neutral[100],
+	gridPrintBackgroundColor: palette.neutral[46],
 	gridGutterSize: 1,
 	gridCellSize: 32,
 


### PR DESCRIPTION
## What are you changing?

Adds basic print styles to crossword component

## Why?

So crossword is visible and legible when printed, doesn't show unnecessary elements and makes best use of available space

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/user-attachments/assets/860409c9-f234-4288-8a8e-14cca33f3111
[after]: https://github.com/user-attachments/assets/0ac52d81-3af0-4e19-975d-19f8b71c1a69