### PR TITLE
Support Ophan data- attributes in Source

### DIFF
--- a/.changeset/lucky-nails-swim.md
+++ b/.changeset/lucky-nails-swim.md
@@ -1,0 +1,5 @@
+---
+"@guardian/source": minor
+---
+
+Support Ophan data- attributes in Source components

--- a/libs/@guardian/source/src/react-components/@types/Props.ts
+++ b/libs/@guardian/source/src/react-components/@types/Props.ts
@@ -16,4 +16,19 @@ export interface Props {
 	 * at any point.
 	 */
 	css?: never;
+	/**
+	 * **Rendered Components – Ophan**
+	 *
+	 * The Ophan client automatically tracks components on the page
+	 * that have the `data-component` attribute.
+	 * To avoid race conditions, it is best to add this attribute only
+	 * to server-rendered HTML.
+	 *
+	 * Add `data-component="component-name"` to the element you want
+	 * to track.
+	 *
+	 * The page views table will then contain `component-name` when the
+	 * element is present on the page.
+	 */
+	'data-component'?: string;
 }

--- a/libs/@guardian/source/src/react-components/button/@types/SharedButtonProps.ts
+++ b/libs/@guardian/source/src/react-components/button/@types/SharedButtonProps.ts
@@ -61,4 +61,24 @@ export interface SharedButtonProps extends Props {
 	 *
 	 */
 	theme?: Partial<ThemeButton>;
+	/**
+	 * **Component Clicks – Ophan**
+	 *
+	 * The Ophan client automatically tracks click interactions
+	 * on components that have the `data-link-name` attribute.
+	 * To avoid race conditions, it is best to add this attribute only
+	 * to server-rendered HTML.
+	 *
+	 * Some elements are not trackable, e.g. `div`, `span`.
+	 * Refer to the Ophan documentation for more information.
+	 * https://github.com/guardian/ophan/blob/0f365862682cd97cc50cf381299e0f4875e2996c/tracker-js/src/click-path-capture.js
+	 *
+	 * Add `data-component="component-name"` to the element you want
+	 * to track. Then `add data-link-name="link-name"` to the anchor for which
+	 * clicks will be tracked.
+	 *
+	 * The page views table will then contain `link-name` when the
+	 * link is clicked.
+	 */
+	'data-link-name'?: string;
 }

--- a/libs/@guardian/source/src/react-components/link/@types/SharedLinkProps.ts
+++ b/libs/@guardian/source/src/react-components/link/@types/SharedLinkProps.ts
@@ -38,4 +38,24 @@ export interface SharedLinkProps extends Props {
 	 *
 	 */
 	theme?: Partial<ThemeLink>;
+	/**
+	 * **Component Clicks – Ophan**
+	 *
+	 * The Ophan client automatically tracks click interactions
+	 * on components that have the `data-link-name` attribute.
+	 * To avoid race conditions, it is best to add this attribute only
+	 * to server-rendered HTML.
+	 *
+	 * Some elements are not trackable, e.g. `div`, `span`.
+	 * Refer to the Ophan documentation for more information.
+	 * https://github.com/guardian/ophan/blob/0f365862682cd97cc50cf381299e0f4875e2996c/tracker-js/src/click-path-capture.js
+	 *
+	 * Add `data-component="component-name"` to the element you want
+	 * to track. Then `add data-link-name="link-name"` to the anchor for which
+	 * clicks will be tracked.
+	 *
+	 * The page views table will then contain `link-name` when the
+	 * link is clicked.
+	 */
+	'data-link-name'?: string;
 }


### PR DESCRIPTION
## What are you changing?

- Add support for the data-link-name  attribute in Source Buttons and Link components
- Add support for the data-component attribute in all Source components 

## Why?

We use Ophan to track clicks on and renders of many of our components in our applications. This change adds first class support of Ophan tracking to Source components. Passing values for these new props to the components allows Ophan's Tracker JS to identify and track these components. These props are optional – nothing happens if the props are omitted.
