### PR TITLE
Update vendor id for Twitter

### DIFF
--- a/libs/@guardian/libs/src/consent-management-platform/vendors.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/vendors.ts
@@ -35,7 +35,7 @@ export const TCFV2VendorIDs = {
 	remarketing: ['5ed0eb688a76503f1016578f'],
 	sentry: ['5f0f39014effda6e8bbd2006'],
 	teads: ['5eab3d5ab8e05c2bbe33f399'],
-	twitter: ['5e71760b69966540e4554f01'],
+	twitter: ['5fab0c31a22863611c5f8764'],
 	'youtube-player': ['5e7ac3fae30e7d1bc1ebf5e8'],
 } satisfies VendorIDType;
 


### PR DESCRIPTION
## What are you changing?

- Updating to a new vendor list.

## Why?

- The twitter vendor list id was updated in the Sourcepoint vendor list.
