### PR TITLE
Move sticky clue to bottom of grid when out of view

### DIFF
--- a/libs/@guardian/react-crossword/src/components/StickyClue.tsx
+++ b/libs/@guardian/react-crossword/src/components/StickyClue.tsx
@@ -2,7 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
 import { textSans12 } from '@guardian/source/foundations';
-import { memo } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { useCurrentClue } from '../context/CurrentClue';
 import { useData } from '../context/Data';
 import { useTheme } from '../context/Theme';
@@ -12,6 +12,8 @@ type StickyClueProps = {
 };
 
 export const StickyClueComponent = ({ additionalCss }: StickyClueProps) => {
+	const stickyClueRef = useRef<HTMLDivElement>(null);
+	const [stickyClueBottom, setStickyClueBottom] = useState(false);
 	const { entries } = useData();
 	const { currentEntryId } = useCurrentClue();
 	const theme = useTheme();
@@ -19,44 +21,80 @@ export const StickyClueComponent = ({ additionalCss }: StickyClueProps) => {
 		? entries.get(currentEntryId)
 		: undefined;
 
-	const stickyClue = css`
+	useEffect(() => {
+		const stickyClueElement = stickyClueRef.current;
+		if (!stickyClueElement) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				if (entry) {
+					setStickyClueBottom(entry.intersectionRatio < 1);
+				}
+			},
+			{ threshold: [1] },
+		);
+
+		observer.observe(stickyClueRef.current);
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [stickyClueRef]);
+
+	const placeholder = css`
+		position: absolute;
 		top: 0;
-		position: sticky;
+		min-height: calc(0.75rem * 3.5);
+		width: 100%;
+	`;
+
+	const stickyClue = css`
+		position: absolute;
 		display: flex;
-		z-index: 1;
+		top: 0;
 		min-height: 3.5em;
 		align-items: start;
 		${textSans12};
 		background: ${theme.stickyClueBackgroundColour};
+		${stickyClueBottom &&
+		css`
+			top: auto;
+			bottom: 0;
+		`};
 		@media print {
 			display: none;
 		}
 	`;
 
 	return (
-		<div aria-hidden="true" css={[additionalCss, stickyClue]}>
-			{entry && (
-				<>
-					<span
-						aria-hidden="true"
-						css={css`
-							flex: 0 0 auto;
-							font-weight: bold;
-							padding-right: 0.625em;
-							text-transform: capitalize;
-						`}
-					>
-						{entry.id.split('-').join(' ')}
-					</span>
-					<span
-						aria-hidden="true"
-						dangerouslySetInnerHTML={{
-							__html: entry.clue,
-						}}
-					></span>
-				</>
-			)}
-		</div>
+		<>
+			<div css={placeholder} ref={stickyClueRef}></div>
+			<div aria-hidden="true" css={[stickyClue, additionalCss]}>
+				{entry && (
+					<>
+						<span
+							aria-hidden="true"
+							css={css`
+								flex: 0 0 auto;
+								font-weight: bold;
+								padding-right: 0.625em;
+								text-transform: capitalize;
+							`}
+						>
+							{entry.id.split('-').join(' ')}
+						</span>
+						<span
+							aria-hidden="true"
+							dangerouslySetInnerHTML={{
+								__html: entry.clue,
+							}}
+						></span>
+					</>
+				)}
+			</div>
+		</>
 	);
 };
 

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -75,15 +75,25 @@ const Layout = ({
 					}
 				`}
 			>
-				<StickyClue
-					additionalCss={css`
-						max-width: ${gridWidth}px;
+				<div
+					css={css`
+						position: relative;
+						padding: calc(0.75rem * 3.5) 0;
 						@container (min-width: ${oneColWidth}px) {
-							display: none;
+							padding: 0;
 						}
 					`}
-				/>
-				<Grid />
+				>
+					<StickyClue
+						additionalCss={css`
+							max-width: ${gridWidth}px;
+							@container (min-width: ${oneColWidth}px) {
+								display: none;
+							}
+						`}
+					/>
+					<Grid />
+				</div>
 				<div
 					css={css`
 						margin-top: ${space[1]}px;


### PR DESCRIPTION
## What are you changing?

Moves sticky clue from top of crossword grid to the bottom when scrolled out of view

## Why?

So that currently selected clue remains visible. The existing implementation using `position: sticky` does not work well on mobile browsers when the virtual keyboard is shown as [the visual viewport is shrunk, but the actual viewport where the sticky element has been applied remains the same size so can be scrolled out of view](https://github.com/w3c/csswg-drafts/issues/7475).

> [!NOTE]
> From further testing it seems that [intersection observers](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) also face the same issue so on mobile devices the switch from top to bottom happens much later than expected. We may need to use a scroll event listener and the [Visual Viewport API](https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API) instead to work around this.
