### PR TITLE
remove sticky clue in favour of simpler focused clue above and below the grid.

### DIFF
--- a/libs/@guardian/react-crossword/src/@types/Layout.ts
+++ b/libs/@guardian/react-crossword/src/@types/Layout.ts
@@ -2,8 +2,8 @@ import type { ComponentType } from 'react';
 import type { AnagramHelper } from '../components/AnagramHelper';
 import type { Clues } from '../components/Clues';
 import type { Controls } from '../components/Controls';
-import type { Grid } from '../components/Grid';
 import type { FocusedClue } from '../components/FocusedClue';
+import type { Grid } from '../components/Grid';
 
 export type LayoutProps = {
 	Grid: typeof Grid;

--- a/libs/@guardian/react-crossword/src/@types/Layout.ts
+++ b/libs/@guardian/react-crossword/src/@types/Layout.ts
@@ -3,13 +3,13 @@ import type { AnagramHelper } from '../components/AnagramHelper';
 import type { Clues } from '../components/Clues';
 import type { Controls } from '../components/Controls';
 import type { Grid } from '../components/Grid';
-import type { StickyClue } from '../components/StickyClue';
+import type { FocusedClue } from '../components/FocusedClue';
 
 export type LayoutProps = {
 	Grid: typeof Grid;
 	Controls: typeof Controls;
 	AnagramHelper: typeof AnagramHelper;
-	StickyClue: typeof StickyClue;
+	FocusedClue: typeof FocusedClue;
 	Clues: typeof Clues;
 	SavedMessage: ComponentType;
 	gridWidth: number;

--- a/libs/@guardian/react-crossword/src/@types/crossword.ts
+++ b/libs/@guardian/react-crossword/src/@types/crossword.ts
@@ -92,8 +92,8 @@ export type Theme = {
 	/** The text colour of shuffled letter that are not yet on the grid */
 	anagramHelperCandidateTextColor: string;
 
-	/** The background colour for the sticky clue */
-	stickyClueBackgroundColour: string;
+	/** The background colour for the focused clue */
+	focusedClueBackgroundColour: string;
 };
 
 export type Dimensions = {

--- a/libs/@guardian/react-crossword/src/components/Crossword.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.stories.tsx
@@ -87,14 +87,14 @@ export const CustomLayoutRaw: StoryFn = () => {
 		Clues,
 		Grid,
 		Controls,
-		StickyClue,
+		FocusedClue,
 		SavedMessage,
 		gridWidth,
 	}: LayoutProps) => {
 		return (
 			<>
 				<p>gridWidth: {gridWidth}</p>
-				<StickyClue />
+				<FocusedClue />
 				<Grid />
 				<Controls />
 				<SavedMessage />
@@ -132,7 +132,7 @@ export const CustomisedLayout: StoryFn = () => {
 		Grid,
 		Controls,
 		SavedMessage,
-		StickyClue,
+		FocusedClue,
 		gridWidth,
 	}: LayoutProps) => {
 		return (
@@ -141,7 +141,7 @@ export const CustomisedLayout: StoryFn = () => {
 					<Clues direction="across" Header={CluesHeader} />
 				</div>
 				<div style={{ flexBasis: gridWidth, minWidth: '15em' }}>
-					<StickyClue />
+					<FocusedClue />
 					<Grid />
 					<Controls />
 					<div

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -11,7 +11,7 @@ import { AnagramHelper } from './AnagramHelper';
 import { Clues } from './Clues';
 import { Controls } from './Controls';
 import { Grid } from './Grid';
-import { StickyClue } from './StickyClue';
+import { FocusedClue } from './FocusedClue';
 
 export type CrosswordProps = {
 	data: CAPICrossword;
@@ -36,7 +36,7 @@ const layoutComponents: Omit<LayoutProps, 'gridWidth'> = {
 	Grid,
 	Controls,
 	AnagramHelper,
-	StickyClue,
+	StickyClue: FocusedClue,
 	Clues,
 	SavedMessage,
 };

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -10,8 +10,8 @@ import { defaultTheme } from '../theme';
 import { AnagramHelper } from './AnagramHelper';
 import { Clues } from './Clues';
 import { Controls } from './Controls';
-import { Grid } from './Grid';
 import { FocusedClue } from './FocusedClue';
+import { Grid } from './Grid';
 
 export type CrosswordProps = {
 	data: CAPICrossword;

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -36,7 +36,7 @@ const layoutComponents: Omit<LayoutProps, 'gridWidth'> = {
 	Grid,
 	Controls,
 	AnagramHelper,
-	StickyClue: FocusedClue,
+	FocusedClue,
 	Clues,
 	SavedMessage,
 };

--- a/libs/@guardian/react-crossword/src/components/FocusedClue.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/FocusedClue.stories.tsx
@@ -3,10 +3,10 @@ import { type StoryObj } from '@storybook/react';
 import { groupedClues as data } from '../../stories/formats/grouped-clues';
 import { ContextProvider } from '../context/ContextProvider';
 import { defaultTheme } from '../theme';
-import { StickyClue } from './StickyClue';
+import { FocusedClue } from './FocusedClue';
 
-const meta: Meta<typeof StickyClue> = {
-	component: StickyClue,
+const meta: Meta<typeof FocusedClue> = {
+	component: FocusedClue,
 	title: 'Components/StickyClue',
 	decorators: [
 		(Story) => (
@@ -23,7 +23,7 @@ const meta: Meta<typeof StickyClue> = {
 
 export default meta;
 
-type Story = StoryObj<typeof StickyClue>;
+type Story = StoryObj<typeof FocusedClue>;
 
 export const Across: Story = {};
 

--- a/libs/@guardian/react-crossword/src/components/FocusedClue.tsx
+++ b/libs/@guardian/react-crossword/src/components/FocusedClue.tsx
@@ -11,7 +11,7 @@ type StickyClueProps = {
 	additionalCss?: SerializedStyles;
 };
 
-export const StickyClueComponent = ({ additionalCss }: StickyClueProps) => {
+export const FocusedClueComponent = ({ additionalCss }: StickyClueProps) => {
 	const { entries } = useData();
 	const { currentEntryId } = useCurrentClue();
 	const theme = useTheme();
@@ -21,13 +21,10 @@ export const StickyClueComponent = ({ additionalCss }: StickyClueProps) => {
 
 	const stickyClue = css`
 		top: 0;
-		position: sticky;
 		display: flex;
-		z-index: 1;
-		min-height: 3.5em;
-		align-items: start;
+		min-height: 2.75em;
 		${textSans12};
-		background: ${theme.stickyClueBackgroundColour};
+		background: ${theme.focusedClueBackgroundColour};
 		@media print {
 			display: none;
 		}
@@ -60,4 +57,4 @@ export const StickyClueComponent = ({ additionalCss }: StickyClueProps) => {
 	);
 };
 
-export const StickyClue = memo(StickyClueComponent);
+export const FocusedClue = memo(FocusedClueComponent);

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -4,7 +4,7 @@ import { textSans12, textSans14 } from '@guardian/source/foundations';
 import type { ReactNode } from 'react';
 import { memo } from 'react';
 import type { LayoutProps } from '../@types/Layout';
-import { StickyClue } from '../components/StickyClue';
+import { FocusedClue } from '../components/FocusedClue';
 import { useTheme } from '../context/Theme';
 
 const CluesHeader = memo(({ children }: { children: ReactNode }) => {
@@ -54,7 +54,6 @@ const Layout = ({
 				gap: ${space[4]}px;
 				max-width: ${gridWidth + clueMaxWidth * 2}px;
 				height: 100%;
-				overflow: auto;
 
 				@container (min-width: ${oneColWidth}px) {
 					flex-direction: row;
@@ -75,7 +74,7 @@ const Layout = ({
 					}
 				`}
 			>
-				<StickyClue
+				<FocusedClue
 					additionalCss={css`
 						max-width: ${gridWidth}px;
 						@container (min-width: ${oneColWidth}px) {
@@ -84,6 +83,14 @@ const Layout = ({
 					`}
 				/>
 				<Grid />
+				<FocusedClue
+					additionalCss={css`
+						max-width: ${gridWidth}px;
+						@container (min-width: ${oneColWidth}px) {
+							display: none;
+						}
+					`}
+				/>
 				<div
 					css={css`
 						margin-top: ${space[1]}px;

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -54,6 +54,7 @@ const Layout = ({
 				gap: ${space[4]}px;
 				max-width: ${gridWidth + clueMaxWidth * 2}px;
 				height: 100%;
+				overflow: auto;
 
 				@container (min-width: ${oneColWidth}px) {
 					flex-direction: row;

--- a/libs/@guardian/react-crossword/src/theme.ts
+++ b/libs/@guardian/react-crossword/src/theme.ts
@@ -26,5 +26,5 @@ export const defaultTheme: Theme = {
 	anagramHelperBackgroundColor: palette.neutral[97],
 	anagramHelperCandidateTextColor: palette.neutral[60],
 
-	stickyClueBackgroundColour: palette.neutral[100],
+	focusedClueBackgroundColour: palette.neutral[100],
 };


### PR DESCRIPTION
This allows the same ability to see the clue above and below the grid without the need for the listeners to calculate if the clue is in focus or not. Does not need platform specific logic. 

See https://github.com/guardian/csnx/pull/1951


## What are you changing?

<img width="392" alt="Screenshot 2025-02-17 at 12 37 29" src="https://github.com/user-attachments/assets/e7d11f8c-cb3e-4b75-8a37-33e8de9c7680" />
