### PR TITLE
Re release packages as latest

### DIFF
--- a/libs/@guardian/core-web-vitals/CHANGELOG.md
+++ b/libs/@guardian/core-web-vitals/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/core-web-vitals
 
+## 10.0.1
+
+### Patch Changes
+
+- latest release - fix for accidental canary release
+
 ## 10.0.0
 
 ### Major Changes

--- a/libs/@guardian/core-web-vitals/package.json
+++ b/libs/@guardian/core-web-vitals/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/core-web-vitals",
-	"version": "10.0.0",
+	"version": "10.0.1",
 	"private": false,
 	"description": "Methods to help with the implementation of Google's Core Web Vitals",
 	"sideEffects": false,
@@ -26,7 +26,7 @@
 	},
 	"devDependencies": {
 		"@guardian/eslint-config": "workspace:*",
-		"@guardian/libs": "21.0.0",
+		"@guardian/libs": "21.0.1",
 		"@types/jest": "29.5.8",
 		"eslint": "9.19.0",
 		"jest": "29.7.0",

--- a/libs/@guardian/identity-auth-frontend/CHANGELOG.md
+++ b/libs/@guardian/identity-auth-frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/identity-auth-frontend
 
+## 8.0.1
+
+### Patch Changes
+
+- latest release - fix for accidental canary release
+
 ## 8.0.0
 
 ### Major Changes

--- a/libs/@guardian/identity-auth-frontend/package.json
+++ b/libs/@guardian/identity-auth-frontend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/identity-auth-frontend",
-	"version": "8.0.0",
+	"version": "8.0.1",
 	"private": false,
 	"description": "",
 	"license": "Apache-2.0",
@@ -27,8 +27,8 @@
 	},
 	"devDependencies": {
 		"@guardian/eslint-config": "workspace:*",
-		"@guardian/identity-auth": "6.0.0",
-		"@guardian/libs": "21.0.0",
+		"@guardian/identity-auth": "6.0.1",
+		"@guardian/libs": "21.0.1",
 		"@types/jest": "29.5.8",
 		"eslint": "9.19.0",
 		"jest": "29.7.0",

--- a/libs/@guardian/identity-auth/CHANGELOG.md
+++ b/libs/@guardian/identity-auth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/identity-auth
 
+## 6.0.1
+
+### Patch Changes
+
+- latest release - fix for accidental canary release
+
 ## 6.0.0
 
 ### Major Changes

--- a/libs/@guardian/identity-auth/package.json
+++ b/libs/@guardian/identity-auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/identity-auth",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"private": false,
 	"description": "",
 	"license": "Apache-2.0",
@@ -27,7 +27,7 @@
 	},
 	"devDependencies": {
 		"@guardian/eslint-config": "workspace:*",
-		"@guardian/libs": "21.0.0",
+		"@guardian/libs": "21.0.1",
 		"@types/jest": "29.5.8",
 		"eslint": "9.19.0",
 		"jest": "29.7.0",

--- a/libs/@guardian/libs/CHANGELOG.md
+++ b/libs/@guardian/libs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/libs
 
+## 21.0.1
+
+### Patch Changes
+
+- latest release - fix for accidental canary release
+
 ## 21.0.0
 
 ### Major Changes

--- a/libs/@guardian/libs/package.json
+++ b/libs/@guardian/libs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/libs",
-	"version": "21.0.0",
+	"version": "21.0.1",
 	"private": false,
 	"description": "A collection of JavaScript libraries and TypeScript types for Guardian projects",
 	"sideEffects": false,

--- a/libs/@guardian/react-crossword/package.json
+++ b/libs/@guardian/react-crossword/package.json
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@emotion/react": "11.11.3",
 		"@guardian/eslint-config": "workspace:*",
-		"@guardian/libs": "21.0.0",
+		"@guardian/libs": "21.0.1",
 		"@guardian/source": "8.0.2",
 		"@storybook/addon-a11y": "8.5.1",
 		"@storybook/addon-essentials": "8.5.1",

--- a/libs/@guardian/source-development-kitchen/CHANGELOG.md
+++ b/libs/@guardian/source-development-kitchen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @guardian/source-development-kitchen
 
+## 15.0.1
+
+### Patch Changes
+
+- latest release - fix for accidental canary release
+
 ## 15.0.0
 
 ### Major Changes

--- a/libs/@guardian/source-development-kitchen/package.json
+++ b/libs/@guardian/source-development-kitchen/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/source-development-kitchen",
-	"version": "15.0.0",
+	"version": "15.0.1",
 	"sideEffects": false,
 	"type": "module",
 	"exports": {
@@ -28,7 +28,7 @@
 	"devDependencies": {
 		"@emotion/react": "11.11.3",
 		"@guardian/eslint-config": "workspace:*",
-		"@guardian/libs": "21.0.0",
+		"@guardian/libs": "21.0.1",
 		"@guardian/source": "8.0.2",
 		"@storybook/addon-a11y": "8.5.1",
 		"@storybook/addon-essentials": "8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,7 +252,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config
       '@guardian/libs':
-        specifier: 21.0.0
+        specifier: 21.0.1
         version: link:../libs
       '@types/jest':
         specifier: 29.5.8
@@ -340,7 +340,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config
       '@guardian/libs':
-        specifier: 21.0.0
+        specifier: 21.0.1
         version: link:../libs
       '@types/jest':
         specifier: 29.5.8
@@ -379,10 +379,10 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config
       '@guardian/identity-auth':
-        specifier: 6.0.0
+        specifier: 6.0.1
         version: link:../identity-auth
       '@guardian/libs':
-        specifier: 21.0.0
+        specifier: 21.0.1
         version: link:../libs
       '@types/jest':
         specifier: 29.5.8
@@ -521,7 +521,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config
       '@guardian/libs':
-        specifier: 21.0.0
+        specifier: 21.0.1
         version: link:../libs
       '@guardian/source':
         specifier: 8.0.2
@@ -723,7 +723,7 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config
       '@guardian/libs':
-        specifier: 21.0.0
+        specifier: 21.0.1
         version: link:../libs
       '@guardian/source':
         specifier: 8.0.2


### PR DESCRIPTION
## Why?

- Accidentally merged a canary PR with main before the packages could be released for real 
 There is a race condition where if a branch with the canary tag merges with main before the release then the new versions can be released as canaries. https://github.com/guardian/csnx/pull/1823#issuecomment-2663308959