### PR TITLE
Identity Auth Frontend | Add `https://r.thegulocal.com` for DEV stage

### DIFF
--- a/.changeset/loud-spiders-wonder.md
+++ b/.changeset/loud-spiders-wonder.md
@@ -1,0 +1,5 @@
+---
+'@guardian/identity-auth-frontend': minor
+---
+
+Add `https://r.thegulocal.com/` and `https://m.thegulocal.com/` as a valid origin for `getRedirectUri` when the stage is `DEV` to allow DCR/frontend local development with okta/oauth tokens

--- a/libs/@guardian/identity-auth-frontend/src/index.ts
+++ b/libs/@guardian/identity-auth-frontend/src/index.ts
@@ -55,6 +55,12 @@ const getRedirectUri = (stage: Stage, origin: string) => {
 			return 'https://m.code.dev-theguardian.com/';
 		case 'DEV':
 		default:
+			if (origin === 'https://r.thegulocal.com') {
+				return 'https://r.thegulocal.com/';
+			}
+			if (origin === 'https://m.thegulocal.com') {
+				return 'https://m.thegulocal.com/';
+			}
 			return 'http://localhost:3030/';
 	}
 };


### PR DESCRIPTION
## What are you changing?

- Adds `https://r.thegulocal.com` as a valid origin for `getRedirectUri` when the stage is `DEV`
- Adds `https://m.thegulocal.com` as a valid origin for `getRedirectUri` when the stage is `DEV`

## Why?

- This allows [DCR](https://github.com/guardian/dotcom-rendering/tree/main/dotcom-rendering) (when running on `https://r.thegulocal.com` by following [these instructions](https://github.com/guardian/dotcom-rendering/blob/f425a8bc726778551b30a2e54367872cd81aa7f1/dotcom-rendering/docs/contributing/detailed-setup-guide.md#running-alongside-identity)) to get Okta/OAuth tokens when the developer is signed in on `https://profile.code.dev-theguardian.com` domain
- This also allows [Frontend](https://github.com/guardian/frontend) (when running on `https://m.thegulocal.com` by following [these instructions](https://github.com/guardian/frontend/blob/main/nginx/README.md)) to get Okta/OAuth tokens when the developer is signed in on `https://profile.code.dev-theguardian.com` domain

## Tested

- In DCR with canary and new instructions in [this pr](https://github.com/guardian/dotcom-rendering/pull/13426).

## Related PRs

Identity Platform: https://github.com/guardian/identity-platform/pull/802
Dotcom Rendering: https://github.com/guardian/dotcom-rendering/pull/13426
CSNX (This PR): https://github.com/guardian/csnx/pull/1964
Frontend: https://github.com/guardian/frontend/pull/27791