### PR TITLE
react-crossword A11y improvements

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Cell.tsx
+++ b/libs/@guardian/react-crossword/src/components/Cell.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { isUndefined } from '@guardian/libs';
 import { textSans12 } from '@guardian/source/foundations';
 import type { FormEvent, KeyboardEvent, SVGProps } from 'react';
 import { useEffect, useRef } from 'react';
@@ -48,9 +49,10 @@ const CellComponent = ({
 	const theme = useTheme();
 	const { getId } = useData();
 	const cellRef = useRef<null | SVGGElement>(null);
-	const cellDescription = data.description
-		? (isIncorrect ? 'Incorrect letter. ' : '') + data.description
-		: '';
+	const cellDescription =
+		isUndefined(data.description) && !isIncorrect
+			? undefined
+			: `${isIncorrect ? 'Incorrect Letter. ' : ''} ${data.description ?? ''}`;
 
 	const backgroundColor = isBlackCell
 		? 'transparent'
@@ -137,7 +139,6 @@ const CellComponent = ({
 							id={getId(`cell-input-${data.x}-${data.y}`)}
 							onInput={handleInput ?? noop}
 							tabIndex={isCurrentCell ? 0 : -1}
-							aria-label="Crossword cell"
 							aria-description={cellDescription}
 							css={css`
 								width: 100%;

--- a/libs/@guardian/react-crossword/src/components/Crossword.tsx
+++ b/libs/@guardian/react-crossword/src/components/Crossword.tsx
@@ -65,7 +65,6 @@ export const Crossword = ({
 	return (
 		<ContextProvider theme={theme} data={data} userProgress={progress}>
 			<div
-				role="application"
 				data-link-name="Crosswords"
 				css={css`
 					*,

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -461,6 +461,7 @@ export const Grid = () => {
 			viewBox={`0 0 ${maxWidth} ${maxHeight}`}
 			tabIndex={-1}
 			role={'grid'}
+			aria-label={'Crossword Grid'}
 			onKeyDown={navigateGrid}
 			onFocus={handleGridFocus}
 			onBlur={handleGridBlur}


### PR DESCRIPTION
## What are you changing?

- Reduce the verbosity of the aria labels on the grid cells
- Remove the application role from the parent div as it is making the crossword not very visible to screen readers

## Why?

- We have received feedback from a user that the labels are too verbose and make the crossword very difficult to use. The  information that was previously being read out can in fact be inferred by the position on the grid and the previous navigation context.

**previously** 
Every cell had information about what clue it was part of and how many letters there were in the word
Every Cell -> `Letter 2 of 4-across: Life is in a mess (5 letters). Also, letter 1 of 5-down Life is always in a mess (2 letters).`

**now** 
Only the cells at the start of a word have info about the clue and length. This gives the context for the surrounding letters. This should reduce the overload of information read out.
First Cell -> `4-across: Life is in a mess (5 letters).`
