### PR TITLE
Encode returnAddress url for Support page

### DIFF
--- a/.changeset/large-ads-pick.md
+++ b/.changeset/large-ads-pick.md
@@ -2,4 +2,5 @@
 '@guardian/libs': patch
 ---
 
-Add encodeUriComponent to url in Support sign up page
+- Use encodeUriComponent to encode url for Support sign up page
+- Update privacy message for Consent or Pay

--- a/.changeset/large-ads-pick.md
+++ b/.changeset/large-ads-pick.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': patch
+---
+
+Add encodeUriComponent to url in Support sign up page

--- a/libs/@guardian/libs/src/consent-management-platform/isConsentOrPay.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/isConsentOrPay.ts
@@ -18,6 +18,6 @@ export const isConsentOrPayCountry = (countryCode: CountryCode) => {
 
 export const getSupportSignUpPage = (): string => {
 	return isGuardianDomain()
-		? `https://support.theguardian.com/guardian-ad-lite?returnAddress=${window.location.href}`
-		: `https://support.code.dev-theguardian.com/guardian-ad-lite?returnAddress=${window.location.href}`;
+		? `https://support.theguardian.com/guardian-ad-lite?returnAddress=${encodeURIComponent(window.location.href)}`
+		: `https://support.code.dev-theguardian.com/guardian-ad-lite?returnAddress=${encodeURIComponent(window.location.href)}`;
 };

--- a/libs/@guardian/libs/src/consent-management-platform/lib/sourcepointConfig.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/lib/sourcepointConfig.ts
@@ -11,7 +11,7 @@ export const PROPERTY_HREF_SUBDOMAIN = 'http://subdomain.theguardian.com';
 export const PROPERTY_HREF_MAIN = 'https://test.theguardian.com';
 
 export const PRIVACY_MANAGER_TCFV2 = 106842;
-export const PRIVACY_MANAGER_TCFV2_CONSENT_OR_PAY = 1251121;
+export const PRIVACY_MANAGER_TCFV2_CONSENT_OR_PAY = 1263449;
 export const PRIVACY_MANAGER_AUSTRALIA = 1178486;
 
 export const ENDPOINT = isGuardianDomain()


### PR DESCRIPTION
## What are you changing?

- Encoding returnAddress url for Support Page
- Updating Consent or Pay privacy messages

## Why?

- This is affecting other query parameters on the support page.
- We're pointing to an old privacy message.
