### PR TITLE
Support scrolling clue into view when selected

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Clue.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clue.tsx
@@ -52,6 +52,7 @@ type Props = {
 	isSelected?: boolean;
 	isComplete?: boolean;
 	isValid?: boolean;
+	containerRef?: React.RefObject<HTMLDivElement>;
 	selectClue: (entry: CAPIEntry) => void;
 } & HTMLAttributes<HTMLDivElement>;
 
@@ -61,6 +62,7 @@ const ClueComponent = ({
 	isSelected,
 	isComplete,
 	isValid,
+	containerRef,
 	selectClue,
 	...props
 }: Props) => {
@@ -68,11 +70,17 @@ const ClueComponent = ({
 	const clueRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
-		const currentRef = clueRef.current;
-		if (currentRef && isSelected) {
-			currentRef.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+		const clue = clueRef.current;
+		const clueContainer = containerRef?.current;
+
+		if (!clue || !clueContainer) {
+			return;
 		}
-	}, [isSelected]);
+
+		if (isSelected && clueContainer.scrollHeight > clueContainer.clientHeight) {
+			clue.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+		}
+	}, [isSelected, containerRef]);
 
 	return (
 		<div

--- a/libs/@guardian/react-crossword/src/components/Clue.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clue.tsx
@@ -52,7 +52,7 @@ type Props = {
 	isSelected?: boolean;
 	isComplete?: boolean;
 	isValid?: boolean;
-	containerRef?: React.RefObject<HTMLDivElement>;
+	scrollToSelected?: boolean;
 	selectClue: (entry: CAPIEntry) => void;
 } & HTMLAttributes<HTMLDivElement>;
 
@@ -62,7 +62,7 @@ const ClueComponent = ({
 	isSelected,
 	isComplete,
 	isValid,
-	containerRef,
+	scrollToSelected,
 	selectClue,
 	...props
 }: Props) => {
@@ -71,16 +71,15 @@ const ClueComponent = ({
 
 	useEffect(() => {
 		const clue = clueRef.current;
-		const clueContainer = containerRef?.current;
 
-		if (!clue || !clueContainer) {
+		if (!clue) {
 			return;
 		}
 
-		if (isSelected && clueContainer.scrollHeight > clueContainer.clientHeight) {
+		if (isSelected && scrollToSelected) {
 			clue.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 		}
-	}, [isSelected, containerRef]);
+	}, [isSelected, scrollToSelected]);
 
 	return (
 		<div

--- a/libs/@guardian/react-crossword/src/components/Clue.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clue.tsx
@@ -3,7 +3,7 @@ import { isString } from '@guardian/libs';
 import { visuallyHidden } from '@guardian/source/foundations';
 import { SvgTickRound } from '@guardian/source/react-components';
 import type { HTMLAttributes } from 'react';
-import { memo } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import type { CAPIEntry } from '../@types/CAPI';
 import { useTheme } from '../context/Theme';
 
@@ -65,6 +65,14 @@ const ClueComponent = ({
 	...props
 }: Props) => {
 	const theme = useTheme();
+	const clueRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const currentRef = clueRef.current;
+		if (currentRef && isSelected) {
+			currentRef.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+		}
+	}, [isSelected]);
 
 	return (
 		<div
@@ -88,6 +96,7 @@ const ClueComponent = ({
 				}
 			`}
 			onClick={() => selectClue(entry)}
+			ref={clueRef}
 			{...props}
 		>
 			<span

--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -12,6 +12,7 @@ import { Clue } from './Clue';
 
 type Props = {
 	direction: Direction;
+	scrollToSelected?: boolean;
 	/** Use this to provide a custom header component for the list of clues. If
 	 * undefined, the word 'across' or 'down' will be displayed, unstyled. */
 	Header?: ComponentType<{
@@ -20,7 +21,6 @@ type Props = {
 		 * a11y... */
 		children: ReactNode;
 	}>;
-	containerRef?: React.RefObject<HTMLDivElement>;
 };
 
 const Label = memo(({ direction }: { direction: Direction }) => {
@@ -39,7 +39,7 @@ const Label = memo(({ direction }: { direction: Direction }) => {
 	);
 });
 
-export const Clues = ({ direction, Header, containerRef }: Props) => {
+export const Clues = ({ direction, scrollToSelected, Header }: Props) => {
 	const { entries, getId, cells } = useData();
 	const { progress } = useProgress();
 	const { currentEntryId, setCurrentEntryId } = useCurrentClue();
@@ -209,7 +209,7 @@ export const Clues = ({ direction, Header, containerRef }: Props) => {
 								isSelected={isSelected}
 								isComplete={complete}
 								isValid={isValid}
-								containerRef={containerRef}
+								scrollToSelected={scrollToSelected}
 								key={entry.id}
 								id={getId(entry.id)}
 								tabIndex={-1}

--- a/libs/@guardian/react-crossword/src/components/Clues.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clues.tsx
@@ -20,6 +20,7 @@ type Props = {
 		 * a11y... */
 		children: ReactNode;
 	}>;
+	containerRef?: React.RefObject<HTMLDivElement>;
 };
 
 const Label = memo(({ direction }: { direction: Direction }) => {
@@ -38,7 +39,7 @@ const Label = memo(({ direction }: { direction: Direction }) => {
 	);
 });
 
-export const Clues = ({ direction, Header }: Props) => {
+export const Clues = ({ direction, Header, containerRef }: Props) => {
 	const { entries, getId, cells } = useData();
 	const { progress } = useProgress();
 	const { currentEntryId, setCurrentEntryId } = useCurrentClue();
@@ -208,6 +209,7 @@ export const Clues = ({ direction, Header }: Props) => {
 								isSelected={isSelected}
 								isComplete={complete}
 								isValid={isValid}
+								containerRef={containerRef}
 								key={entry.id}
 								id={getId(entry.id)}
 								tabIndex={-1}

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -131,17 +131,14 @@ const Layout = ({
 					}
 
 					@container (min-width: ${oneColWidth}px) {
-						overflow: auto;
-					}
+						max-height: ${gridWidth}px;
+						overflow-y: scroll;
 
 					@container (min-width: ${twoColWidth}px) {
 						flex-direction: row;
 						overflow: auto;
 						min-height: 100%;
-
-						> * {
-							overflow: auto;
-						}
+						max-height: none;
 					}
 
 					@media print {

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -133,6 +133,7 @@ const Layout = ({
 					@container (min-width: ${oneColWidth}px) {
 						max-height: ${gridWidth}px;
 						overflow-y: scroll;
+					}
 
 					@container (min-width: ${twoColWidth}px) {
 						flex-direction: row;

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { headlineBold17, space } from '@guardian/source/foundations';
 import { textSans12, textSans14 } from '@guardian/source/foundations';
 import type { ReactNode } from 'react';
-import { memo } from 'react';
+import { memo, useRef } from 'react';
 import type { LayoutProps } from '../@types/Layout';
 import { FocusedClue } from '../components/FocusedClue';
 import { useTheme } from '../context/Theme';
@@ -40,6 +40,7 @@ const Layout = ({
 }: LayoutProps) => {
 	const { textColor, clueMinWidth, clueMaxWidth } = useTheme();
 	const theme = useTheme();
+	const clueContainerRef = useRef<HTMLDivElement>(null);
 
 	const gridWidth = Math.max(actualGridWidth, 300);
 	const oneColWidth = gridWidth + clueMinWidth;
@@ -117,6 +118,7 @@ const Layout = ({
 			</div>
 
 			<div
+				ref={clueContainerRef}
 				css={css`
 					flex: 1;
 					display: flex;
@@ -147,8 +149,16 @@ const Layout = ({
 					}
 				`}
 			>
-				<Clues direction="across" Header={CluesHeader} />
-				<Clues direction="down" Header={CluesHeader} />
+				<Clues
+					direction="across"
+					Header={CluesHeader}
+					containerRef={clueContainerRef}
+				/>
+				<Clues
+					direction="down"
+					Header={CluesHeader}
+					containerRef={clueContainerRef}
+				/>
 			</div>
 		</div>
 	);

--- a/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
+++ b/libs/@guardian/react-crossword/src/layouts/ScreenLayout.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { headlineBold17, space } from '@guardian/source/foundations';
 import { textSans12, textSans14 } from '@guardian/source/foundations';
 import type { ReactNode } from 'react';
-import { memo, useRef } from 'react';
+import { memo } from 'react';
 import type { LayoutProps } from '../@types/Layout';
 import { FocusedClue } from '../components/FocusedClue';
 import { useTheme } from '../context/Theme';
@@ -40,7 +40,6 @@ const Layout = ({
 }: LayoutProps) => {
 	const { textColor, clueMinWidth, clueMaxWidth } = useTheme();
 	const theme = useTheme();
-	const clueContainerRef = useRef<HTMLDivElement>(null);
 
 	const gridWidth = Math.max(actualGridWidth, 300);
 	const oneColWidth = gridWidth + clueMinWidth;
@@ -118,7 +117,6 @@ const Layout = ({
 			</div>
 
 			<div
-				ref={clueContainerRef}
 				css={css`
 					flex: 1;
 					display: flex;
@@ -133,15 +131,17 @@ const Layout = ({
 					}
 
 					@container (min-width: ${oneColWidth}px) {
-						max-height: ${gridWidth}px;
-						overflow-y: scroll;
+						overflow: auto;
 					}
 
 					@container (min-width: ${twoColWidth}px) {
 						flex-direction: row;
 						overflow: auto;
 						min-height: 100%;
-						max-height: none;
+
+						> * {
+							overflow: auto;
+						}
 					}
 
 					@media print {
@@ -149,16 +149,8 @@ const Layout = ({
 					}
 				`}
 			>
-				<Clues
-					direction="across"
-					Header={CluesHeader}
-					containerRef={clueContainerRef}
-				/>
-				<Clues
-					direction="down"
-					Header={CluesHeader}
-					containerRef={clueContainerRef}
-				/>
+				<Clues direction="across" Header={CluesHeader} />
+				<Clues direction="down" Header={CluesHeader} />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## What are you changing?

Adds `scrollToSelected` prop to `Clue` component to automatically scroll clue into view when selected

## Why?

On DCR we want to allow the clue list to be scrolled independently of the rest of the page on tablet sized viewports so readers can see all of the clues whilst keeping the crossword grid in view. As part of this, the clue list should automatically scroll to the relevant clue when a cell is selected on the grid.