### PR TITLE
Remove isCorpABTest Flag 

### DIFF
--- a/.changeset/calm-lamps-dream.md
+++ b/.changeset/calm-lamps-dream.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Remove Consent or Pay Flag that hides CorP logic

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -114,14 +114,13 @@ export const init = (
 
 	setCurrentFramework(framework);
 
-	const isCorpABTest: boolean = window.location.search.includes('CORP_FLAG');
 	// To ensure users who are not part of Consent or Pay country or AB Test
-	if (!isCorpABTest || !isConsentOrPayCountry(countryCode)) {
+	if (!isConsentOrPayCountry(countryCode)) {
 		useNonAdvertisedList = false;
 	}
 
 	setIsConsentOrPay(
-		isConsentOrPayCountry(countryCode) && !useNonAdvertisedList && isCorpABTest,
+		isConsentOrPayCountry(countryCode) && !useNonAdvertisedList,
 	);
 
 	// invoke callbacks before we receive Sourcepoint
@@ -241,8 +240,7 @@ export const init = (
 							choiceTypeID === SourcePointChoiceTypes.RejectAll &&
 							message_type === 'gdpr' &&
 							isConsentOrPayCountry(countryCode) &&
-							!useNonAdvertisedList &&
-							isCorpABTest
+							!useNonAdvertisedList
 						) {
 							window.location.href = getSupportSignUpPage();
 						}
@@ -308,7 +306,6 @@ export const init = (
 					excludePage: isExcludedFromCMP(pageSection),
 					isCorP: isConsentOrPayCountry(countryCode),
 					isUserSignedIn,
-					isCorpABTest,
 				},
 			};
 			break;

--- a/libs/@guardian/libs/src/consent-management-platform/types/window.d.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/types/window.d.ts
@@ -51,7 +51,6 @@ declare global {
 						excludePage: boolean;
 						isCorP: boolean;
 						isUserSignedIn: boolean;
-						isCorpABTest: boolean;
 					};
 				};
 				usnat?: {


### PR DESCRIPTION
## What are you changing?

- Remove isCorpABTest feature flag 

## Why?

- To roll out Consent or Pay to all consumers.
