### PR TITLE
Remove isCorpABTest flag

### DIFF
--- a/.changeset/lovely-turtles-rescue.md
+++ b/.changeset/lovely-turtles-rescue.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': major
+---
+
+Remove Consent or Pay Flag that hides CorP logic

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -114,14 +114,13 @@ export const init = (
 
 	setCurrentFramework(framework);
 
-	const isCorpABTest: boolean = window.location.search.includes('CORP_FLAG');
 	// To ensure users who are not part of Consent or Pay country or AB Test
-	if (!isCorpABTest || !isConsentOrPayCountry(countryCode)) {
+	if (!isConsentOrPayCountry(countryCode)) {
 		useNonAdvertisedList = false;
 	}
 
 	setIsConsentOrPay(
-		isConsentOrPayCountry(countryCode) && !useNonAdvertisedList && isCorpABTest,
+		isConsentOrPayCountry(countryCode) && !useNonAdvertisedList,
 	);
 
 	// invoke callbacks before we receive Sourcepoint
@@ -242,8 +241,7 @@ export const init = (
 							choiceTypeID === SourcePointChoiceTypes.RejectAll &&
 							message_type === 'gdpr' &&
 							isConsentOrPayCountry(countryCode) &&
-							!useNonAdvertisedList &&
-							isCorpABTest
+							!useNonAdvertisedList
 						) {
 							window.location.href = getSupportSignUpPage();
 						}
@@ -309,7 +307,6 @@ export const init = (
 					excludePage: isExcludedFromCMP(pageSection),
 					isCorP: isConsentOrPayCountry(countryCode),
 					isUserSignedIn,
-					isCorpABTest,
 				},
 			};
 			break;

--- a/libs/@guardian/libs/src/consent-management-platform/types/window.d.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/types/window.d.ts
@@ -52,7 +52,6 @@ declare global {
 						excludePage: boolean;
 						isCorP: boolean;
 						isUserSignedIn: boolean;
-						isCorpABTest: boolean;
 					};
 				};
 				usnat?: {


### PR DESCRIPTION
## What are you changing?

- Remove isCorpABTest feature flag 

## Why?

- To roll out Consent or Pay to all consumers.
