### PR TITLE
Crossword check word: darken strikethrough

### DIFF
--- a/libs/@guardian/react-crossword/src/theme.ts
+++ b/libs/@guardian/react-crossword/src/theme.ts
@@ -7,7 +7,7 @@ export const defaultTheme: Theme = {
 	gridPrintBackgroundColor: palette.neutral[46],
 	gridGutterSize: 1,
 	gridCellSize: 32,
-	gridCellStrikeThrough: palette.neutral[73],
+	gridCellStrikeThrough: palette.neutral[46],
 
 	textColor: palette.neutral[7],
 	focusColor: palette.focus[400],


### PR DESCRIPTION
## What are you changing?

Clicking "Check word" on the crossword will cross out incorrect letters. 

Make the strikethrough darker to make it easier to see.

`#BABABA` the previous colour [performs poorly for WCAG 2.1 AA colour contrast](https://www.whocanuse.com/?bg=ffffff&fg=bababa&fs=16&fw=b). 

`#707070` on `#ffffff` [performs better](https://www.whocanuse.com/?bg=ffffff&fg=707070&fs=16&fw=b).
`#707070` on `#ffe500` [performs less well](https://www.whocanuse.com/?bg=ffe500&fg=707070&fs=16&fw=b) but is still an improvement.

## Why?

- [Some](https://www.theguardian.com/crosswords/quick/17099#comment-170771341) [users](https://www.theguardian.com/crosswords/quick/17102#comment-170816113) struggle to see the thin light grey line

## Screenshots

**Before**

<img width="503" alt="Screenshot 2025-03-05 at 16 30 46" src="https://github.com/user-attachments/assets/2fdc8813-09e2-466e-9d1a-f3abdbe77757" />

**After**

<img width="507" alt="Screenshot 2025-03-05 at 17 13 44" src="https://github.com/user-attachments/assets/9ee9f13e-4c44-49e3-b7b3-e7be2e26e21f" />
