### PR TITLE
Add print background colour and cell border for Firefox

### DIFF
--- a/libs/@guardian/react-crossword/src/components/Cell.tsx
+++ b/libs/@guardian/react-crossword/src/components/Cell.tsx
@@ -68,6 +68,7 @@ const CellComponent = ({
 			fill: ${isBlackCell
 				? theme.gridPrintBackgroundColor
 				: theme.gridForegroundColor};
+			stroke: ${theme.gridPrintBackgroundColor};
 		}
 	`;
 

--- a/libs/@guardian/react-crossword/src/components/Cell.tsx
+++ b/libs/@guardian/react-crossword/src/components/Cell.tsx
@@ -65,7 +65,9 @@ const CellComponent = ({
 	const cellStyles = css`
 		fill: ${backgroundColor};
 		@media print {
-			fill: ${isBlackCell ? 'transparent' : theme.gridForegroundColor};
+			fill: ${isBlackCell
+				? theme.gridPrintBackgroundColor
+				: theme.gridForegroundColor};
 		}
 	`;
 


### PR DESCRIPTION
## What are you changing?

- Add a print-only background colour to each cell
- Add a print-only stroke colour to each cell 

## Why?

By default, Firefox doesn't support printing background colours. This behaviour must be [enabled using a setting in the print dialog](https://superuser.com/questions/1113516/is-it-possible-to-view-a-page-in-firefox-using-print-media-type). 

We can get around it using the `fill` property, which is currently set to `transparent` for the black cells. We can use the `stroke` property to set the border colour between cells.

## Screenshots

**Before**

<img width="366" alt="Screenshot 2025-03-05 at 17 57 25" src="https://github.com/user-attachments/assets/6f2cbb76-0499-4014-b1db-28037ce658d7" />

**After**
<img width="368" alt="Screenshot 2025-03-05 at 21 25 29" src="https://github.com/user-attachments/assets/dcbb2320-a1b1-4afb-bd6c-afdbdf6b6f1d" />

