### PR TITLE
Adds new OphanComponentType

### DIFF
--- a/.changeset/weak-cats-relate.md
+++ b/.changeset/weak-cats-relate.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Adds new ACQUISITION_GUTTER OphanComponentTypes

--- a/.changeset/weak-cats-relate.md
+++ b/.changeset/weak-cats-relate.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+'@guardian/libs': patch
 ---
 
 Adds new ACQUISITION_GUTTER OphanComponentTypes

--- a/libs/@guardian/libs/src/ophan/@types/index.ts
+++ b/libs/@guardian/libs/src/ophan/@types/index.ts
@@ -97,7 +97,9 @@ export type OphanComponentType =
 	| 'APP_FEATURE'
 	| 'CARD'
 	| 'CAROUSEL'
-	| 'CONTAINER';
+	| 'CONTAINER'
+	| 'MENU'
+	| 'ACQUISITIONS_GUTTER';
 
 export type OphanComponent = {
 	componentType: OphanComponentType;

--- a/libs/@guardian/libs/src/ophan/@types/index.ts
+++ b/libs/@guardian/libs/src/ophan/@types/index.ts
@@ -98,7 +98,6 @@ export type OphanComponentType =
 	| 'CARD'
 	| 'CAROUSEL'
 	| 'CONTAINER'
-	| 'MENU'
 	| 'ACQUISITIONS_GUTTER';
 
 export type OphanComponent = {


### PR DESCRIPTION
## What are you changing?

Having recently added and tooled a new acquisitions component in the Sticky Liveblog Ask (renamed Gutter Liveblog Ask), we now need to track the data separately.  It was using the ACQUISITIONS_OTHER generic OphanComponentType and we would like to use a dedicated OphanComponentType.

## Why?

This will allow us to report more easily, add monitoring and alerts in Grafana so that we can be notified if acquisitions drop below a threashold which could indicate a problem.

## Related PRs:

[ophan PR 6849](https://github.com/guardian/ophan/pull/6849)
[ophan-data-lake PR 8229](https://github.com/guardian/ophan-data-lake/pull/8229)
