### PR TITLE
Remove usage of Array.at() - it is not supported in older browser versions

### DIFF
--- a/.changeset/tricky-masks-agree.md
+++ b/.changeset/tricky-masks-agree.md
@@ -1,0 +1,5 @@
+---
+'@guardian/react-crossword': patch
+---
+
+remove usage of Array.at() - it is not supported in older browser versions.

--- a/libs/@guardian/react-crossword/src/utils/getCellsWithProgressForGroup.ts
+++ b/libs/@guardian/react-crossword/src/utils/getCellsWithProgressForGroup.ts
@@ -54,7 +54,7 @@ export const getCellsWithProgressForEntry = ({
 		if (cell) {
 			cellsWithProgress.push({
 				...cell,
-				progress: progress.at(x)?.[y] ?? '',
+				progress: progress[x]?.[y] ?? '',
 				separator: getSeparatorFromEntry(entry, i),
 			});
 		}


### PR DESCRIPTION
remove usage of Array.at() - it is not supported in older browser versions
