### PR TITLE
Crossword accessibility improvements

### DIFF
--- a/.changeset/open-areas-pay.md
+++ b/.changeset/open-areas-pay.md
@@ -1,0 +1,5 @@
+---
+'@guardian/react-crossword': major
+---
+
+improve accessibility of crossword

--- a/libs/@guardian/react-crossword/src/@types/crossword.ts
+++ b/libs/@guardian/react-crossword/src/@types/crossword.ts
@@ -93,8 +93,8 @@ export type Theme = {
 
 	/** Background colour of the anagram helper */
 	anagramHelperBackgroundColor: string;
-	/** Text colour of shuffled letter that are not yet on the grid */
-	anagramHelperCandidateTextColor: string;
+	/** Background colour of shuffled letters that are on the grid */
+	anagramHelperProgressBackgroundColor: string;
 
 	/** Background colour for the focused clue */
 	focusedClueBackgroundColor: string;

--- a/libs/@guardian/react-crossword/src/components/AnagramHelper.tsx
+++ b/libs/@guardian/react-crossword/src/components/AnagramHelper.tsx
@@ -63,6 +63,13 @@ export const AnagramHelper = () => {
 		reset();
 	}, [reset]);
 
+	useEffect(() => {
+		if (showAnagramHelper) {
+			// TODO: Source doesn't support ref forwarding
+			document.getElementById('anagram-helper-input')?.focus();
+		}
+	}, [showAnagramHelper]);
+
 	if (!showAnagramHelper) {
 		return null;
 	}
@@ -131,6 +138,7 @@ export const AnagramHelper = () => {
 								value={letters}
 								maxLength={cellsWithProgress.length}
 								autoFocus={true}
+								id="anagram-helper-input"
 							/>
 						</div>
 						<CrosswordButton

--- a/libs/@guardian/react-crossword/src/components/Clue.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clue.tsx
@@ -91,7 +91,7 @@ const ClueComponent = ({
 						? theme.connectedBackgroundColor
 						: 'transparent'};
 				cursor: ${isConnected ? 'default' : 'pointer'};
-				opacity: ${isComplete ? 0.5 : 1};
+				opacity: ${isComplete ? 0.7 : 1};
 
 				padding: 0.5em 0;
 				color: ${isSelected ? theme.selectedTextColor : theme.textColor};

--- a/libs/@guardian/react-crossword/src/components/Clue.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clue.tsx
@@ -91,7 +91,7 @@ const ClueComponent = ({
 						? theme.connectedBackgroundColor
 						: 'transparent'};
 				cursor: ${isConnected ? 'default' : 'pointer'};
-				opacity: ${isComplete ? 0.7 : 1};
+				opacity: ${isComplete ? 0.6 : 1};
 
 				padding: 0.5em 0;
 				color: ${isSelected ? theme.selectedTextColor : theme.textColor};

--- a/libs/@guardian/react-crossword/src/components/Controls.tsx
+++ b/libs/@guardian/react-crossword/src/components/Controls.tsx
@@ -135,7 +135,7 @@ const CheckClue = memo((props: ButtonProps) => {
 			aria-live="off"
 			onClick={check}
 			data-link-name="Check this"
-			aria-label={`Remove incorrect letters from ${currentEntryId ? currentEntryId.split('-').join(' ') : 'word'}`}
+			aria-label={`Check and remove incorrect letters from ${currentEntryId ? currentEntryId.split('-').join(' ') : 'word'}`}
 			{...props}
 		>
 			Check Word
@@ -229,7 +229,7 @@ const CheckGrid = memo((props: ButtonProps) => {
 			onClick={check}
 			data-link-name="Check all"
 			{...props}
-			aria-label="Check and Remove all incorrect letters"
+			aria-label="Check and remove all incorrect letters"
 		>
 			Check All
 		</CrosswordButton>

--- a/libs/@guardian/react-crossword/src/components/Controls.tsx
+++ b/libs/@guardian/react-crossword/src/components/Controls.tsx
@@ -228,6 +228,7 @@ const CheckGrid = memo((props: ButtonProps) => {
 		<CrosswordButton
 			onClick={check}
 			data-link-name="Check all"
+			requireConfirmation={true}
 			{...props}
 			aria-label="Check and remove all incorrect letters"
 		>

--- a/libs/@guardian/react-crossword/src/components/CrosswordButton.tsx
+++ b/libs/@guardian/react-crossword/src/components/CrosswordButton.tsx
@@ -35,7 +35,7 @@ const ButtonComponent = ({
 	};
 
 	return (
-		<SourceButton onClick={handleClick} size="xsmall" {...props}>
+		<SourceButton onClick={handleClick} size="small" {...props}>
 			{isConfirming && 'Confirm '}
 			{children}
 		</SourceButton>

--- a/libs/@guardian/react-crossword/src/components/FocusedClue.tsx
+++ b/libs/@guardian/react-crossword/src/components/FocusedClue.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { isUndefined } from '@guardian/libs';
-import { textSans12 } from '@guardian/source/foundations';
+import { textSans14 } from '@guardian/source/foundations';
 import { memo } from 'react';
 import { useCurrentClue } from '../context/CurrentClue';
 import { useData } from '../context/Data';
@@ -22,8 +22,8 @@ export const FocusedClueComponent = ({ additionalCss }: StickyClueProps) => {
 	const stickyClue = css`
 		top: 0;
 		display: flex;
-		min-height: 2.75em;
-		${textSans12};
+		min-height: 2em;
+		${textSans14};
 		background: ${theme.focusedClueBackgroundColor};
 		@media print {
 			display: none;

--- a/libs/@guardian/react-crossword/src/components/SolutionDisplay.tsx
+++ b/libs/@guardian/react-crossword/src/components/SolutionDisplay.tsx
@@ -57,7 +57,9 @@ export const SolutionDisplayCell = ({
 			css={css`
 				${textSans12};
 				font-size: ${theme.gridCellSize * 0.6}px;
-				background-color: ${theme.gridForegroundColor};
+				background-color: ${cellWithProgress.progress
+					? theme.anagramHelperProgressBackgroundColor
+					: theme.gridForegroundColor};
 				border: 1px solid ${theme.gridBackgroundColor};
 				border-right: ${cellWithProgress.separator === ','
 					? `3px solid ${theme.gridBackgroundColor}`
@@ -67,9 +69,7 @@ export const SolutionDisplayCell = ({
 				text-align: center;
 				align-content: center;
 				position: relative;
-				color: ${cellWithProgress.progress
-					? theme.textColor
-					: theme.anagramHelperCandidateTextColor};
+				color: ${theme.textColor};
 			`}
 		>
 			{cellWithProgress.separator === '-' && (

--- a/libs/@guardian/react-crossword/src/theme.ts
+++ b/libs/@guardian/react-crossword/src/theme.ts
@@ -26,7 +26,7 @@ export const defaultTheme: Theme = {
 	clueMaxWidth: 480,
 
 	anagramHelperBackgroundColor: palette.neutral[97],
-	anagramHelperCandidateTextColor: palette.neutral[60],
+	anagramHelperProgressBackgroundColor: palette.neutral[86],
 
 	focusedClueBackgroundColor: palette.neutral[100],
 };


### PR DESCRIPTION
## What are you changing?

- increase text contrast of completed clues (bump opacity 0.5 -> 0.6)
- increase anagram helper text contrast (replace light text colour with light background colour)
- make check word aria-label consistent with check all ("check all and remove incorrect letters")
- increase size of control buttons (xsmall -> small)
- increase text size of focussed clue (12px -> 14px)
- add a requires confirmation check to check all button – consistent with Reveal All and Clear All
- force focus on text input when anagram helper opens – `autofocus` doesn't appear to work when the player is consumed in DCR

## Why?

Follows feedback from users

Fixes #2018 #2023 #2024 #2016 #2014 

## Screenshots

**Completed clues contrast**

| Before      | After      |
| ----------- | ---------- |
| ![clues-before][] | ![clues-after][] |
| ![clues-before-contrast-check][] | ![clues-after-contrast-check][] |

[clues-before]: https://github.com/user-attachments/assets/936b1ba6-2874-451e-b922-6466b6565ffc
[clues-after]: https://github.com/user-attachments/assets/329dd980-2e69-40cc-8a8a-4c68a0835fb7

[clues-before-contrast-check]: https://github.com/user-attachments/assets/ffb84681-f56c-4848-af58-41b4b77b06d4
[clues-after-contrast-check]: https://github.com/user-attachments/assets/1ad2ea9c-4f6e-4288-bd5d-461094a64a3c

**Anagram helper contrast**

| Before      | After      |
| ----------- | ---------- |
| ![anagram-before][] | ![anagram-after][] |
| ![anagram-before-contrast-check][] | ![anagram-after-contrast-check][] |

[anagram-before]: https://github.com/user-attachments/assets/92f01777-6c7b-429e-9b9e-8a07ada1b164
[anagram-after]: https://github.com/user-attachments/assets/342b2b0a-ba21-4e2e-a898-626e4fe11cd9
[anagram-before-contrast-check]: https://github.com/user-attachments/assets/5f4d9bbe-0be0-408a-8c1c-85e13513c891
[anagram-after-contrast-check]: https://github.com/user-attachments/assets/3e48bc3a-5547-48f3-b18c-e1a2907615ec

**Controls button size**

| Before      | After      |
| ----------- | ---------- |
| ![controls-before][] | ![controls-after][] |

[controls-before]: https://github.com/user-attachments/assets/5e24173c-9d7d-412b-b0bc-9f84d8b91928
[controls-after]: https://github.com/user-attachments/assets/de7dd7f5-add1-4dfa-8748-b1d83286ed9a

**Focussed clue text size**

| Before      | After      |
| ----------- | ---------- |
| ![focussed-clue-before][] | ![focussed-clue-after][] |

[focussed-clue-before]: https://github.com/user-attachments/assets/5004fc84-65d9-4c7c-9a33-a75190e9da02
[focussed-clue-after]: https://github.com/user-attachments/assets/e45820f7-31c2-4f03-9942-ba83276ce76b
