### PR TITLE
Update Wireit to latest version

### DIFF
--- a/apps/github-pages/package.json
+++ b/apps/github-pages/package.json
@@ -16,7 +16,7 @@
 		"astro": "5.6.1",
 		"svelte": "5.25.3",
 		"typescript": "5.5.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"wireit": {
 		"build": {

--- a/apps/storybooks/package.json
+++ b/apps/storybooks/package.json
@@ -20,7 +20,7 @@
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"storybook": "8.6.4",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"wireit": {
 		"dev": {

--- a/libs/@guardian/ab-core/package.json
+++ b/libs/@guardian/ab-core/package.json
@@ -35,7 +35,7 @@
 		"ts-jest": "29.3.0",
 		"tslib": "2.6.2",
 		"typescript": "5.5.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"tslib": "^2.6.2",

--- a/libs/@guardian/ab-react/package.json
+++ b/libs/@guardian/ab-react/package.json
@@ -41,7 +41,7 @@
 		"ts-jest": "29.3.0",
 		"tslib": "2.6.2",
 		"typescript": "5.5.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"@guardian/ab-core": "^8.0.0",

--- a/libs/@guardian/browserslist-config/package.json
+++ b/libs/@guardian/browserslist-config/package.json
@@ -19,7 +19,7 @@
 		"browserslist": "4.23.0",
 		"eslint": "9.19.0",
 		"tslib": "2.6.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"browserslist": "^4.22.2",

--- a/libs/@guardian/core-web-vitals/package.json
+++ b/libs/@guardian/core-web-vitals/package.json
@@ -36,7 +36,7 @@
 		"tslib": "2.6.2",
 		"typescript": "5.5.2",
 		"web-vitals": "4.2.1",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"@guardian/libs": "^22.0.0",

--- a/libs/@guardian/eslint-config/package.json
+++ b/libs/@guardian/eslint-config/package.json
@@ -25,7 +25,7 @@
 	},
 	"devDependencies": {
 		"eslint": "9.19.0",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"eslint": "^9.19.0"

--- a/libs/@guardian/identity-auth-frontend/package.json
+++ b/libs/@guardian/identity-auth-frontend/package.json
@@ -38,7 +38,7 @@
 		"ts-jest": "29.3.0",
 		"tslib": "2.6.2",
 		"typescript": "5.5.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"@guardian/identity-auth": "^7.0.0",

--- a/libs/@guardian/identity-auth/package.json
+++ b/libs/@guardian/identity-auth/package.json
@@ -37,7 +37,7 @@
 		"ts-jest": "29.3.0",
 		"tslib": "2.6.2",
 		"typescript": "5.5.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"@guardian/libs": "^22.0.0",

--- a/libs/@guardian/libs/package.json
+++ b/libs/@guardian/libs/package.json
@@ -43,7 +43,7 @@
 		"tsx": "4.19.0",
 		"typescript": "5.5.2",
 		"wcag-contrast": "3.0.0",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"tslib": "^2.6.2",

--- a/libs/@guardian/newsletter-types/package.json
+++ b/libs/@guardian/newsletter-types/package.json
@@ -25,7 +25,7 @@
 		"rollup": "4.40.0",
 		"tslib": "2.6.2",
 		"typescript": "5.5.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"tslib": "^2.6.2",

--- a/libs/@guardian/prettier/package.json
+++ b/libs/@guardian/prettier/package.json
@@ -16,7 +16,7 @@
 		"eslint": "9.19.0",
 		"prettier": "3.2.2",
 		"tslib": "2.6.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"prettier": "^3.2.2",

--- a/libs/@guardian/react-crossword/package.json
+++ b/libs/@guardian/react-crossword/package.json
@@ -55,7 +55,7 @@
 		"ts-jest": "29.3.0",
 		"tslib": "2.6.2",
 		"typescript": "5.5.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.11.4",

--- a/libs/@guardian/source-development-kitchen/package.json
+++ b/libs/@guardian/source-development-kitchen/package.json
@@ -48,7 +48,7 @@
 		"ts-jest": "29.3.0",
 		"tslib": "2.6.2",
 		"typescript": "5.5.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.11.4",

--- a/libs/@guardian/source/package.json
+++ b/libs/@guardian/source/package.json
@@ -76,7 +76,7 @@
 		"tslib": "2.6.2",
 		"tsx": "4.19.0",
 		"typescript": "5.5.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"sort-package-json": "3.0.0",
 		"syncpack": "13.0.0",
 		"typescript": "5.5.2",
-		"wireit": "0.14.8"
+		"wireit": "0.14.12"
 	},
 	"packageManager": "pnpm@8.14.0",
 	"pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 5.5.2
         version: 5.5.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   apps/github-pages:
     devDependencies:
@@ -63,8 +63,8 @@ importers:
         specifier: 5.5.2
         version: 5.5.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   apps/storybooks:
     devDependencies:
@@ -108,8 +108,8 @@ importers:
         specifier: 8.6.4
         version: 8.6.4(prettier@3.3.3)
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   configs/rollup:
     devDependencies:
@@ -171,8 +171,8 @@ importers:
         specifier: 5.5.2
         version: 5.5.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/ab-react:
     devDependencies:
@@ -222,8 +222,8 @@ importers:
         specifier: 5.5.2
         version: 5.5.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/browserslist-config:
     devDependencies:
@@ -243,8 +243,8 @@ importers:
         specifier: 2.6.2
         version: 2.6.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/core-web-vitals:
     devDependencies:
@@ -282,8 +282,8 @@ importers:
         specifier: 4.2.1
         version: 4.2.1
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/eslint-config:
     dependencies:
@@ -331,8 +331,8 @@ importers:
         specifier: 9.19.0
         version: 9.19.0
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/identity-auth:
     devDependencies:
@@ -370,8 +370,8 @@ importers:
         specifier: 5.5.2
         version: 5.5.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/identity-auth-frontend:
     devDependencies:
@@ -412,8 +412,8 @@ importers:
         specifier: 5.5.2
         version: 5.5.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/libs:
     devDependencies:
@@ -463,8 +463,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/newsletter-types:
     devDependencies:
@@ -484,8 +484,8 @@ importers:
         specifier: 5.5.2
         version: 5.5.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/prettier:
     devDependencies:
@@ -502,8 +502,8 @@ importers:
         specifier: 2.6.2
         version: 2.6.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/react-crossword:
     dependencies:
@@ -587,8 +587,8 @@ importers:
         specifier: 5.5.2
         version: 5.5.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/source:
     dependencies:
@@ -711,8 +711,8 @@ importers:
         specifier: 5.5.2
         version: 5.5.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/source-development-kitchen:
     devDependencies:
@@ -783,8 +783,8 @@ importers:
         specifier: 5.5.2
         version: 5.5.2
       wireit:
-        specifier: 0.14.8
-        version: 0.14.8
+        specifier: 0.14.12
+        version: 0.14.12
 
   libs/@guardian/tsconfig: {}
 
@@ -8537,10 +8537,6 @@ packages:
     resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
     dev: true
 
-  /jsonc-parser@3.2.0:
-    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
-    dev: true
-
   /jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
     dev: true
@@ -12306,15 +12302,15 @@ packages:
       string-width: 7.2.0
     dev: true
 
-  /wireit@0.14.8:
-    resolution: {integrity: sha512-pxRAjRGft/38fOE6CNm6np0spVaXFZIIlF0MF+J6P0zLqWb7CDcNITDxHM7zRe12pIMM0opq4upaOa10IKQ91Q==}
+  /wireit@0.14.12:
+    resolution: {integrity: sha512-gNSd+nZmMo6cuICezYXRIayu6TSOeCSCDzjSF0q6g8FKDsRbdqrONrSZYzdk/uBISmRcv4vZtsno6GyGvdXwGA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
       brace-expansion: 4.0.0
       chokidar: 3.6.0
       fast-glob: 3.3.2
-      jsonc-parser: 3.2.0
+      jsonc-parser: 3.3.1
       proper-lockfile: 4.1.2
     dev: true
 


### PR DESCRIPTION
## What are you changing?

Updates Wireit to `0.14.12`

## Why?

Wireit was using a legacy GitHub caching API which was shutdown on 15 April, causing our builds to fail. The latest version has been updated to use the v2 caching API.

https://github.com/google/wireit/issues/1297

