### PR TITLE
fix order of operation for the arrow key events

### DIFF
--- a/.changeset/strong-memes-arrive.md
+++ b/.changeset/strong-memes-arrive.md
@@ -1,0 +1,5 @@
+---
+'@guardian/react-crossword': patch
+---
+
+fix for moving down with arrow keys

--- a/libs/@guardian/react-crossword/src/components/Grid.tsx
+++ b/libs/@guardian/react-crossword/src/components/Grid.tsx
@@ -347,8 +347,8 @@ export const Grid = () => {
 					moveCurrentCell({ delta: { x: 0, y: -1 } });
 					break;
 				case 'ArrowDown':
-					moveCurrentCell({ delta: { x: 0, y: 1 } });
 					updateWorkingDirection({ direction: 'down' });
+					moveCurrentCell({ delta: { x: 0, y: 1 } });
 					break;
 				case 'ArrowLeft':
 					updateWorkingDirection({ direction: 'across' });


### PR DESCRIPTION
## What are you changing?

- The order of operations was different for the down key as the other keys. It seems to work fine with the current implementation but should be consistent.
