### PR TITLE
Make goal copy in ticker configurable

### DIFF
--- a/.changeset/fast-wombats-post.md
+++ b/.changeset/fast-wombats-post.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-development-kitchen': minor
+---
+
+Make the goalCopy in tickerCopy configurable

--- a/.changeset/sweet-wings-smell.md
+++ b/.changeset/sweet-wings-smell.md
@@ -1,5 +1,0 @@
----
-'@guardian/source-development-kitchen': major
----
-
-Make the goalCopy in TickerData configurable

--- a/.changeset/sweet-wings-smell.md
+++ b/.changeset/sweet-wings-smell.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-development-kitchen': major
+---
+
+Make the goalCopy in TickerData configurable

--- a/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.stories.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.stories.tsx
@@ -24,11 +24,12 @@ const Template: StoryFn<typeof Ticker> = (args: TickerSettings) => (
 export const HalfwayContributed: StoryFn<typeof Ticker> = Template.bind({});
 HalfwayContributed.args = {
 	currencySymbol: '£',
-	copy: {},
+	copy: {
+		goalCopy: 'goal',
+	},
 	tickerData: {
 		total: 50000,
 		goal: 100000,
-		goalCopy: 'goal',
 	},
 	tickerStylingSettings,
 	size: 'small',
@@ -39,11 +40,11 @@ SmallDonationsSoFar.args = {
 	currencySymbol: '£',
 	copy: {
 		headline: 'Help us reach our end-of-year goal',
+		goalCopy: 'goal',
 	},
 	tickerData: {
 		total: 99,
 		goal: 100000,
-		goalCopy: 'goal',
 	},
 	tickerStylingSettings,
 	size: 'small',
@@ -54,11 +55,11 @@ ContributionGoalMet.args = {
 	currencySymbol: '£',
 	copy: {
 		headline: 'Help us reach our end-of-year goal',
+		goalCopy: 'goal',
 	},
 	tickerData: {
 		total: 10000000,
 		goal: 1000000,
-		goalCopy: 'goal',
 	},
 	tickerStylingSettings,
 	size: 'small',

--- a/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.stories.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.stories.tsx
@@ -28,6 +28,7 @@ HalfwayContributed.args = {
 	tickerData: {
 		total: 50000,
 		goal: 100000,
+		goalCopy: 'goal',
 	},
 	tickerStylingSettings,
 	size: 'small',
@@ -42,6 +43,7 @@ SmallDonationsSoFar.args = {
 	tickerData: {
 		total: 99,
 		goal: 100000,
+		goalCopy: 'goal',
 	},
 	tickerStylingSettings,
 	size: 'small',
@@ -56,6 +58,7 @@ ContributionGoalMet.args = {
 	tickerData: {
 		total: 10000000,
 		goal: 1000000,
+		goalCopy: 'goal',
 	},
 	tickerStylingSettings,
 	size: 'small',

--- a/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
@@ -18,6 +18,7 @@ interface TickerCopy {
 export interface TickerData {
 	total: number;
 	goal: number;
+	goalCopy?: string;
 }
 
 export interface TickerStylingSettings {
@@ -186,7 +187,7 @@ export const Ticker = ({
 								{runningTotal.toLocaleString()}
 							</span>{' '}
 							of {currencySymbol}
-							{tickerData.goal.toLocaleString()} goal
+							{tickerData.goal.toLocaleString()} {tickerData.goalCopy ?? 'goal'}
 						</div>
 					</div>
 				</div>

--- a/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
+++ b/libs/@guardian/source-development-kitchen/src/react-components/ticker/Ticker.tsx
@@ -13,12 +13,12 @@ import { useTicker } from './useTicker';
 
 interface TickerCopy {
 	headline?: string;
+	goalCopy?: string;
 }
 
 export interface TickerData {
 	total: number;
 	goal: number;
-	goalCopy?: string;
 }
 
 export interface TickerStylingSettings {
@@ -187,7 +187,7 @@ export const Ticker = ({
 								{runningTotal.toLocaleString()}
 							</span>{' '}
 							of {currencySymbol}
-							{tickerData.goal.toLocaleString()} {tickerData.goalCopy ?? 'goal'}
+							{tickerData.goal.toLocaleString()} {copy.goalCopy ?? 'goal'}
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## What are you changing?

The PR is to make  the goal copy in ticker  configurable ie the word "goal" after 50,000 on this ticker

<img width="462" alt="image" src="https://github.com/user-attachments/assets/86b7d348-c82c-4d4f-a548-098869dc78b4" />



## Why?

 This is to change word "goal" after 50,000 on this ticker to "readers" to show that it's for supporter count

