### PR TITLE
include the recommended and jsx-runtime configs into their own config objects

### DIFF
--- a/.changeset/blue-points-occur.md
+++ b/.changeset/blue-points-occur.md
@@ -1,0 +1,5 @@
+---
+'@guardian/eslint-config': major
+---
+
+Bugfix to re-enable recommended react rules

--- a/libs/@guardian/eslint-config/configs/react.js
+++ b/libs/@guardian/eslint-config/configs/react.js
@@ -3,19 +3,26 @@ import react from 'eslint-plugin-react';
 import hooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 
+const files = ['**/*.{js,ts,jsx,mjsx,tsx,mtsx}'];
+
 export default [
 	{
+		files,
+		...react.configs.flat.recommended,
+	},
+	{
+		files,
+		...react.configs.flat['jsx-runtime'],
+	},
+	{
 		name: '@guardian/react',
-		files: ['**/*.{js,ts,jsx,mjsx,tsx,mtsx}'],
+		files,
 		languageOptions: {
-			...react.configs.flat.recommended.languageOptions,
 			globals: {
 				...globals.serviceworker,
 				...globals.browser,
 			},
 		},
-		...react.configs.flat.recommended,
-		...react.configs.flat['jsx-runtime'],
 		plugins: {
 			react,
 			'react-hooks': hooks,


### PR DESCRIPTION
## What are you changing?

Split out the shared configs from `eslint-plugin-react` into their own config objects to make sure they are correctly included in the array for downstream projects.

## Why?

The spread operator `...` only performs **shallow** merges of objects with overlapping keys. For example, if `react.configs.flat['jsx-runtime']` defines a `rules` key, its value will override the `rules` from `react.configs.flat.recommended`. Of course that's of little consequence, as both are overridden by the `rules` object that is defined directly in the object literal. This has meant that, as far as I can tell, the rules provided by the `eslint-plugin-react`'s recommended config set are not included in projects relying on the `react` object exported by `@guardian/eslint-config`. (spotted by the keen eyes of @bryophyta in https://github.com/guardian/newswires/pull/263#discussion_r2049154334)

You could carefully make sure that each shared config is spread into all the subkeys that it might override, but then you'll have problems at the next level of nesting. Much better will be to make use of eslint's config merging behaviour, and spread each of these config objects into their own, separate object.
