### PR TITLE
Improve ticker animation

### DIFF
--- a/.changeset/true-frogs-reply.md
+++ b/.changeset/true-frogs-reply.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-development-kitchen': patch
+---
+
+Improve ticker animation

--- a/libs/@guardian/source-development-kitchen/src/react-components/ticker/useTicker.ts
+++ b/libs/@guardian/source-development-kitchen/src/react-components/ticker/useTicker.ts
@@ -1,23 +1,39 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+const AnimationDurationMilliseconds = 5000;
 
 export const useTicker = (total: number, readyToAnimate: boolean): number => {
 	const [runningTotal, setRunningTotal] = useState<number>(0);
+	const animationFrameRef = useRef<number | null>(null);
 
 	useEffect(() => {
-		if (readyToAnimate && runningTotal < total) {
-			window.requestAnimationFrame(() => {
-				setRunningTotal((prevRunningTotal) => {
-					const newRunningTotal = prevRunningTotal + Math.floor(total / 100);
-
-					if (newRunningTotal > total || newRunningTotal < 1) {
-						return total;
-					}
-
-					return newRunningTotal;
-				});
-			});
+		if (!readyToAnimate) {
+			setRunningTotal(0);
+			return;
 		}
-	}, [readyToAnimate, runningTotal, total]);
+
+		const startTime = performance.now();
+
+		const animate = (currentTime: number) => {
+			const elapsedTime = currentTime - startTime;
+			const progress = Math.min(elapsedTime / AnimationDurationMilliseconds, 1);
+			const currentTotal = Math.floor(progress * total);
+
+			setRunningTotal(currentTotal);
+
+			if (progress < 1) {
+				animationFrameRef.current = requestAnimationFrame(animate);
+			}
+		};
+
+		animationFrameRef.current = requestAnimationFrame(animate);
+
+		return () => {
+			if (animationFrameRef.current) {
+				cancelAnimationFrame(animationFrameRef.current);
+			}
+		};
+	}, [total, readyToAnimate]);
 
 	return runningTotal;
 };


### PR DESCRIPTION
## What are you changing?
The animation of the ticker.

## Why?
On some devices the animation can be very slow/jerky.
The new implementation smoothes it out by setting a fixed animation duration, and using `requestAnimationFrame` to base the ticker increments around the browser's rendering cycle.
