### PR TITLE
Switch to sp geolocation

### DIFF
--- a/.changeset/stupid-moons-look.md
+++ b/.changeset/stupid-moons-look.md
@@ -3,3 +3,7 @@
 ---
 
 Temporarily use Sourcepoint geo location to log mismatch
+
+- Load all stubs (tcfv2, usnat, ccpa) regardless of location except for Australia
+- Loading all jurisdiction config objects to allow Sourcepoint to choose depending on their geolocation except for Australia
+- Australia will use our current geolocation as SP's framework doesn't allow us to load both ccpa and usnat config objects.

--- a/.changeset/stupid-moons-look.md
+++ b/.changeset/stupid-moons-look.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': major
+---
+
+Temporarily use Sourcepoint geo location to log mismatch

--- a/libs/@guardian/libs/src/consent-management-platform/lib/sourcepointConfig.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/lib/sourcepointConfig.ts
@@ -3,12 +3,14 @@ import { isGuardianDomain } from './domain';
 export const ACCOUNT_ID = 1257;
 export const PRIVACY_MANAGER_USNAT = 1068329;
 
-export const PROPERTY_ID_MAIN = 7417;
+// export const PROPERTY_ID_MAIN = 7417;
+export const PROPERTY_ID_MAIN = 9398;
 export const PROPERTY_ID_SUBDOMAIN = 38161;
 export const PROPERTY_ID_AUSTRALIA = 13348;
 
 export const PROPERTY_HREF_SUBDOMAIN = 'https://subdomain.theguardian.com';
-export const PROPERTY_HREF_MAIN = 'https://test.theguardian.com';
+// export const PROPERTY_HREF_MAIN = 'https://test.theguardian.com';
+export const PROPERTY_HREF_MAIN = 'https://ui-dev';
 
 export const PRIVACY_MANAGER_TCFV2 = 106842;
 export const PRIVACY_MANAGER_TCFV2_CONSENT_OR_PAY = 1263449;

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.test.js
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.test.js
@@ -44,16 +44,15 @@ describe('Sourcepoint unified', () => {
 				expect(window._sp_.config.gdpr.targetingParams.framework).toEqual(
 					frameworkAndCountryCode.framework,
 				);
-				expect(window._sp_.config.usnat).toBeUndefined();
-				expect(window.__tcfapi).toBeDefined();
-				expect(window.__uspapi).toBeUndefined();
-				expect(window.__gpp).toBeUndefined();
+				expect(window._sp_.config.usnat).toBeDefined();
+				expect(window.__uspapi).toBeDefined();
+				expect(window.__gpp).toBeDefined();
 			} else if (frameworkAndCountryCode.framework == 'usnat') {
 				expect(window._sp_.config.usnat.targetingParams.framework).toEqual(
 					frameworkAndCountryCode.framework,
 				);
 				expect(window._sp_.config.gdpr).toBeUndefined;
-				expect(window.__uspapi).toBeUndefined();
+				expect(window.__uspapi).toBeDefined();
 				expect(window.__tcfapi).toBeUndefined();
 				expect(window.__gpp).toBeDefined();
 			} else if (frameworkAndCountryCode.framework == 'aus') {
@@ -63,7 +62,7 @@ describe('Sourcepoint unified', () => {
 				expect(window._sp_.config.gdpr).toBeUndefined;
 				expect(window.__uspapi).toBeDefined();
 				expect(window.__tcfapi).toBeUndefined();
-				expect(window.__gpp).toBeUndefined();
+				expect(window.__gpp).toBeDefined();
 			}
 		},
 	);

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.test.js
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.test.js
@@ -45,14 +45,14 @@ describe('Sourcepoint unified', () => {
 					frameworkAndCountryCode.framework,
 				);
 				expect(window._sp_.config.usnat).toBeDefined();
-				expect(window.__uspapi).toBeDefined();
+				expect(window.__uspapi).toBeUndefined();
 				expect(window.__gpp).toBeDefined();
 			} else if (frameworkAndCountryCode.framework == 'usnat') {
 				expect(window._sp_.config.usnat.targetingParams.framework).toEqual(
 					frameworkAndCountryCode.framework,
 				);
 				expect(window._sp_.config.gdpr).toBeUndefined;
-				expect(window.__uspapi).toBeDefined();
+				expect(window.__uspapi).toBeUndefined();
 				expect(window.__tcfapi).toBeUndefined();
 				expect(window.__gpp).toBeDefined();
 			} else if (frameworkAndCountryCode.framework == 'aus') {
@@ -62,7 +62,7 @@ describe('Sourcepoint unified', () => {
 				expect(window._sp_.config.gdpr).toBeUndefined;
 				expect(window.__uspapi).toBeDefined();
 				expect(window.__tcfapi).toBeUndefined();
-				expect(window.__gpp).toBeDefined();
+				expect(window.__gpp).toBeUndefined();
 			}
 		},
 	);

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -156,6 +156,7 @@ export const init = (
 			accountId: ACCOUNT_ID,
 			propertyId: getPropertyId(framework, useNonAdvertisedList),
 			propertyHref: getPropertyHref(framework, useNonAdvertisedList),
+			campaignEnv: 'stage',
 			joinHref: true,
 			isSPA: true,
 			targetingParams: {

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -48,7 +48,7 @@ const getPropertyHref = (
 	}
 
 	if (framework == 'usnat') {
-		return 'https://www.theguardian.com';
+		return PROPERTY_HREF_MAIN;
 	}
 
 	return useNonAdvertisedList ? PROPERTY_HREF_SUBDOMAIN : PROPERTY_HREF_MAIN;

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -23,7 +23,7 @@ import {
 } from './lib/sourcepointConfig';
 import { mergeVendorList } from './mergeUserConsent';
 import { invokeCallbacks } from './onConsentChange';
-import { loadAllStubs } from './stub';
+import { loadStubsForGeolocationTest } from './stub';
 import type { ConsentFramework } from './types';
 import type { SPUserConsent } from './types/tcfv2';
 
@@ -101,7 +101,7 @@ export const init = (
 	useNonAdvertisedList: boolean,
 	pubData = {},
 ): void => {
-	loadAllStubs();
+	loadStubsForGeolocationTest(framework);
 
 	// make sure nothing else on the page has accidentally
 	// used the `_sp_` name as well

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -23,7 +23,7 @@ import {
 } from './lib/sourcepointConfig';
 import { mergeVendorList } from './mergeUserConsent';
 import { invokeCallbacks } from './onConsentChange';
-import { loadStubsFor } from './stub';
+import { loadAllStubs } from './stub';
 import type { ConsentFramework } from './types';
 import type { SPUserConsent } from './types/tcfv2';
 
@@ -101,7 +101,7 @@ export const init = (
 	useNonAdvertisedList: boolean,
 	pubData = {},
 ): void => {
-	loadStubsFor(framework);
+	loadAllStubs();
 
 	// make sure nothing else on the page has accidentally
 	// used the `_sp_` name as well
@@ -289,36 +289,29 @@ export const init = (
 		);
 	}
 
-	// NOTE - Contrary to the SourcePoint documentation, it's important that we add EITHER gdpr OR ccpa
-	// to the _sp_ object. wrapperMessagingWithoutDetection.js uses the presence of these keys to attach
-	// __tcfapi or __uspapi to the window object respectively. If both of these functions appear on the window,
-	// advertisers seem to assume that __tcfapi is the one to use, breaking CCPA consent.
-	// https://documentation.sourcepoint.com/implementation/web-implementation/multi-campaign-web-implementation#implementation-code-snippet-overview
-	switch (framework) {
-		case 'tcfv2':
-			window._sp_.config.gdpr = {
-				targetingParams: {
-					framework,
-					excludePage: isExcludedFromCMP(pageSection),
-					isCorP: isConsentOrPayCountry(countryCode),
-					isUserSignedIn,
-				},
-			};
-			break;
-		case 'usnat':
-			window._sp_.config.usnat = {
-				targetingParams: {
-					framework,
-				},
-			};
-			break;
-		case 'aus':
-			window._sp_.config.ccpa = {
-				targetingParams: {
-					framework,
-				},
-			};
-			break;
+	// USNAT and CCPA can't be loaded at the same time.
+	// We use the country code to determine Austrialian users and set only ccpa for aus.
+	if (framework == 'aus') {
+		window._sp_.config.ccpa = {
+			targetingParams: {
+				framework,
+			},
+		};
+	} else {
+		// Set both for gdpr and usnat
+		window._sp_.config.gdpr = {
+			targetingParams: {
+				framework,
+				excludePage: isExcludedFromCMP(pageSection),
+				isCorP: isConsentOrPayCountry(countryCode),
+				isUserSignedIn,
+			},
+		};
+		window._sp_.config.usnat = {
+			targetingParams: {
+				framework,
+			},
+		};
 	}
 
 	// TODO use libs function loadScript,

--- a/libs/@guardian/libs/src/consent-management-platform/stub.test.js
+++ b/libs/@guardian/libs/src/consent-management-platform/stub.test.js
@@ -1,4 +1,8 @@
-import { loadAllStubs, loadStubsFor } from './stub.ts';
+import {
+	loadAllStubs,
+	loadStubsFor,
+	loadStubsForGeolocationTest,
+} from './stub.ts';
 
 describe('stub', () => {
 	describe('loadStubsFor', () => {
@@ -46,6 +50,40 @@ describe('stub', () => {
 			loadAllStubs();
 			expect(window.__gpp).toBeDefined();
 			expect(window.__uspapi).toBeDefined();
+		});
+	});
+
+	describe('loadStubsForGeolocationTest', () => {
+		beforeEach(() => {
+			// Clear the window object before each test
+			window.__tcfapi = undefined;
+			window.__uspapi = undefined;
+			window.__gpp = undefined;
+		});
+
+		it('should load the correct stub for the tcfv2', () => {
+			expect(window.__tcfapi).toBeUndefined();
+			expect(window.__gpp).toBeUndefined();
+			expect(window.__uspapi).toBeUndefined();
+			loadStubsForGeolocationTest('tcfv2');
+			expect(window.__gpp).toBeDefined();
+		});
+
+		it('should load the correct stub for the usnat', () => {
+			expect(window.__tcfapi).toBeUndefined();
+			expect(window.__gpp).toBeUndefined();
+			expect(window.__uspapi).toBeUndefined();
+			loadStubsForGeolocationTest('usnat');
+			expect(window.__gpp).toBeDefined();
+		});
+		it('should load the correct stub for the aus', () => {
+			expect(window.__tcfapi).toBeUndefined();
+			expect(window.__gpp).toBeUndefined();
+			expect(window.__uspapi).toBeUndefined();
+			loadStubsForGeolocationTest('aus');
+			expect(window.__uspapi).toBeDefined();
+			expect(window.__tcfapi).toBeUndefined();
+			expect(window.__gpp).toBeUndefined();
 		});
 	});
 });

--- a/libs/@guardian/libs/src/consent-management-platform/stub.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/stub.ts
@@ -31,3 +31,19 @@ export const loadAllStubs = (): void => {
 	stub_gpp_usnat();
 	stub_uspapi_ccpa();
 };
+
+/**
+ * Load all stubs for the consent management platform.
+ *
+ */
+export const loadStubsForGeolocationTest = (
+	framework: ConsentFramework,
+): void => {
+	if (framework === 'aus') {
+		stub_uspapi_ccpa();
+		return;
+	}
+
+	stub_tcfv2();
+	stub_gpp_usnat();
+};


### PR DESCRIPTION
## What are you changing?

- Temporarily load all stubs (tcfv2, usnat, ccpa) regardless of location
- Loading all jurisdiction config objects to allow Sourcepoint to choose depending on their geolocation
- Sending jurisdiction mismatch to Ophan using CONSENT_GEOLOCATION_MISMATCH


## Why?

- Temporarily switching to Sourcepoint's geolocation to log geolocation/jurisdiction mismatches during a time period


This is a redo of a previously rolled back commit: https://github.com/guardian/csnx/pull/2032
