### PR TITLE
Source | Update lifestyle 800 colour

### DIFF
--- a/.changeset/clear-papers-tease.md
+++ b/.changeset/clear-papers-tease.md
@@ -1,0 +1,7 @@
+---
+'@guardian/source': major
+---
+
+Update lifestyle 800 colour
+
+This change improves contrast against the neutral.46 colour, ensuring compliance with WCAG accessibility standards for text and background colour contrast.

--- a/libs/@guardian/source/src/design-tokens/tokens.json
+++ b/libs/@guardian/source/src/design-tokens/tokens.json
@@ -237,7 +237,7 @@
 				"$value": "#FEC8D3"
 			},
 			"800": {
-				"$value": "#FEEEF7"
+				"$value": "#FEF1F8"
 			}
 		},
 		"labs": {

--- a/libs/@guardian/source/src/foundations/__generated__/palette.ts
+++ b/libs/@guardian/source/src/foundations/__generated__/palette.ts
@@ -56,7 +56,7 @@ export const palette = {
 		'450': '#F37ABC',
 		'500': '#FFABDB',
 		'600': '#FEC8D3',
-		'800': '#FEEEF7',
+		'800': '#FEF1F8',
 	},
 	neutral: {
 		'0': '#000000',

--- a/libs/@guardian/source/src/foundations/__generated__/variables.css
+++ b/libs/@guardian/source/src/foundations/__generated__/variables.css
@@ -57,7 +57,7 @@
 	--source-palette-lifestyle-450: #f37abc;
 	--source-palette-lifestyle-500: #ffabdb;
 	--source-palette-lifestyle-600: #fec8d3;
-	--source-palette-lifestyle-800: #feeef7;
+	--source-palette-lifestyle-800: #fef1f8;
 	--source-palette-neutral-0: #000000;
 	--source-palette-neutral-7: #121212;
 	--source-palette-neutral-10: #1a1a1a;

--- a/libs/@guardian/source/src/foundations/tokens.test.ts
+++ b/libs/@guardian/source/src/foundations/tokens.test.ts
@@ -100,7 +100,7 @@ describe('Palette tokens', () => {
 				'450': '#F37ABC',
 				'500': '#FFABDB',
 				'600': '#FEC8D3',
-				'800': '#FEEEF7',
+				'800': '#FEF1F8',
 			},
 			neutral: {
 				'0': '#000000',


### PR DESCRIPTION
## What are you changing?

- Update lifestyle 800 colour from `#FEEEF7` to `#FEF1F8`

## Why?

- This change improves contrast against the neutral.46 colour, ensuring compliance with WCAG accessibility standards for text and background colour contrast.

**Context**: https://github.com/guardian/design-system-guild/issues/39
