### PR TITLE
Include admiral in the list of vendor IDs in the consent management platform

### DIFF
--- a/.changeset/gentle-rooms-rhyme.md
+++ b/.changeset/gentle-rooms-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Add admiral to list of VendorIDs in consent management platform

--- a/libs/@guardian/libs/src/consent-management-platform/vendors.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/vendors.ts
@@ -51,9 +51,14 @@ export const AusVendorIDs = {
 	redplanet: ['not-tcfv2-vendor'],
 } satisfies VendorIDType;
 
+export const UsVendorIDs = {
+	admiral: ['not-tcfv2-vendor'],
+} satisfies VendorIDType;
+
 export const VendorIDs = {
 	...TCFV2VendorIDs,
 	...AusVendorIDs,
+	...UsVendorIDs,
 } as const;
 
 export type VendorName = keyof typeof VendorIDs;


### PR DESCRIPTION
## What are you changing?

Adds Admiral to vendor ID list in the consent management platform within `@guardian/libs`

Admiral is not on the [IAB Europe TCF vendor list](https://iabeurope.eu/vendor-list-tcf/) and will only run in the US so we are including it with a dummy ID rather than a Sourcepoint ID, in a separate section for the US

## Why?

We are implementing Admiral's Ad Blocker detection in `@guardian/commercial` as a third party script, so we need to understand whether we have consent in order to run this script.

[Admiral Tech Review Document](https://docs.google.com/document/d/1zpgfswAgroU5CDSDe1xyEhMxZLMDNYRaBGffTFsYnNs/edit?usp=sharing)
