### PR TITLE
Revert "Temporarily switch to Sourcepoint geolocation for US and ROW (except Australia)"

### DIFF
--- a/.changeset/tricky-cows-attend.md
+++ b/.changeset/tricky-cows-attend.md
@@ -1,0 +1,7 @@
+---
+'@guardian/libs': minor
+---
+
+Revert sourcepoint geolocation test.
+
+We'll continue this test next week, possibly via a canary or beta build.

--- a/libs/@guardian/libs/src/consent-management-platform/index.test.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/index.test.ts
@@ -87,9 +87,7 @@ describe('hotfix cmp.init', () => {
 		);
 	});
 
-	// The country code no longer determines the framework used for the Sourcepoint test.
-	// Instead, the framework is determined by the Sourcepoint config.
-	xit.each([
+	it.each([
 		['GB', 'tcfv2'],
 		['AU', 'aus'],
 		['US', 'usnat'],

--- a/libs/@guardian/libs/src/consent-management-platform/onConsentChange.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/onConsentChange.ts
@@ -114,23 +114,16 @@ export const invokeCallbacks = (): void => {
 	if (callbacksToInvoke.length === 0) {
 		return;
 	}
+	void getConsentState().then((state) => {
+		if (
+			awaitingUserInteractionInTCFv2(state) ||
+			awaitingUserInteractionInUSNAT(state)
+		) {
+			return;
+		}
 
-	// We are checking if the current framework is set before calling getConsentState
-	// as the framework is only set after Sourcepoint config has loaded.
-	// This was prevously set once we determined the country code which
-	// occured at the beginning of the sourcepoint.ts file
-	if (getCurrentFramework() !== undefined) {
-		void getConsentState().then((state) => {
-			if (
-				awaitingUserInteractionInTCFv2(state) ||
-				awaitingUserInteractionInUSNAT(state)
-			) {
-				return;
-			}
-
-			callbacksToInvoke.forEach((callback) => invokeCallback(callback, state));
-		});
-	}
+		callbacksToInvoke.forEach((callback) => invokeCallback(callback, state));
+	});
 };
 
 export const onConsentChange: OnConsentChange = (callBack, final = false) => {

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.test.js
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.test.js
@@ -44,9 +44,10 @@ describe('Sourcepoint unified', () => {
 				expect(window._sp_.config.gdpr.targetingParams.framework).toEqual(
 					frameworkAndCountryCode.framework,
 				);
-				expect(window._sp_.config.usnat).toBeDefined();
+				expect(window._sp_.config.usnat).toBeUndefined();
+				expect(window.__tcfapi).toBeDefined();
 				expect(window.__uspapi).toBeUndefined();
-				expect(window.__gpp).toBeDefined();
+				expect(window.__gpp).toBeUndefined();
 			} else if (frameworkAndCountryCode.framework == 'usnat') {
 				expect(window._sp_.config.usnat.targetingParams.framework).toEqual(
 					frameworkAndCountryCode.framework,

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -23,7 +23,7 @@ import {
 } from './lib/sourcepointConfig';
 import { mergeVendorList } from './mergeUserConsent';
 import { invokeCallbacks } from './onConsentChange';
-import { loadStubsForGeolocationTest } from './stub';
+import { loadStubsFor } from './stub';
 import type { ConsentFramework } from './types';
 import type { SPUserConsent } from './types/tcfv2';
 
@@ -48,7 +48,7 @@ const getPropertyHref = (
 	}
 
 	if (framework == 'usnat') {
-		return PROPERTY_HREF_MAIN;
+		return 'https://www.theguardian.com';
 	}
 
 	return useNonAdvertisedList ? PROPERTY_HREF_SUBDOMAIN : PROPERTY_HREF_MAIN;
@@ -101,13 +101,15 @@ export const init = (
 	useNonAdvertisedList: boolean,
 	pubData = {},
 ): void => {
-	loadStubsForGeolocationTest(framework);
+	loadStubsFor(framework);
 
 	// make sure nothing else on the page has accidentally
 	// used the `_sp_` name as well
 	if (window._sp_) {
 		throw new Error('Sourcepoint global (window._sp_) is already defined!');
 	}
+
+	setCurrentFramework(framework);
 
 	// To ensure users who are not part of Consent or Pay country or AB Test
 	if (!isConsentOrPayCountry(countryCode)) {
@@ -165,35 +167,9 @@ export const init = (
 			// ccpa or gdpr object added below
 
 			events: {
-				onConsentReady: (message_type, consentUUID, euconsent, info) => {
+				onConsentReady: (message_type, consentUUID, euconsent) => {
 					log('cmp', `onConsentReady ${message_type}`);
-
-					// If the Sourcepoint vendor list applies to the user, we set the current framework.
-					// This event callback is called for each Sourcepoint framework set i.e. both gdpr and usnat.
-					if (info.applies) {
-						let spFramework: ConsentFramework | undefined;
-
-						switch (message_type) {
-							case 'gdpr':
-								spFramework = 'tcfv2';
-								break;
-							case 'usnat':
-								spFramework = 'usnat';
-								break;
-							case 'ccpa':
-								spFramework = 'aus';
-								break;
-							default:
-								spFramework = undefined;
-								break;
-						}
-
-						if (spFramework !== undefined) {
-							setCurrentFramework(spFramework);
-						}
-					}
-
-					if (info.applies && message_type != frameworkMessageType) {
+					if (message_type != frameworkMessageType) {
 						sendJurisdictionMismatchToOphan(
 							JSON.stringify({
 								sp: message_type,
@@ -204,8 +180,10 @@ export const init = (
 
 						log(
 							'cmp',
-							`onConsentReady Data mismatch ;sp:${message_type};fastly:${frameworkMessageType};`,
+							`onMessageReceiveData Data mismatch ;sp:${message_type};fastly:${frameworkMessageType};`,
 						);
+
+						return;
 					}
 
 					log('cmp', `consentUUID ${consentUUID}`);
@@ -315,29 +293,32 @@ export const init = (
 	// to the _sp_ object. wrapperMessagingWithoutDetection.js uses the presence of these keys to attach
 	// __tcfapi or __uspapi to the window object respectively. If both of these functions appear on the window,
 	// advertisers seem to assume that __tcfapi is the one to use, breaking CCPA consent.
-	// USNAT and CCPA can't be loaded at the same time.
-	// We use the country code to determine Austrialian users and set only ccpa for aus.
-	if (framework == 'aus') {
-		window._sp_.config.ccpa = {
-			targetingParams: {
-				framework,
-			},
-		};
-	} else {
-		// Set both for gdpr and usnat
-		window._sp_.config.usnat = {
-			targetingParams: {
-				framework,
-			},
-		};
-		window._sp_.config.gdpr = {
-			targetingParams: {
-				framework,
-				excludePage: isExcludedFromCMP(pageSection),
-				isCorP: isConsentOrPayCountry(countryCode),
-				isUserSignedIn,
-			},
-		};
+	// https://documentation.sourcepoint.com/implementation/web-implementation/multi-campaign-web-implementation#implementation-code-snippet-overview
+	switch (framework) {
+		case 'tcfv2':
+			window._sp_.config.gdpr = {
+				targetingParams: {
+					framework,
+					excludePage: isExcludedFromCMP(pageSection),
+					isCorP: isConsentOrPayCountry(countryCode),
+					isUserSignedIn,
+				},
+			};
+			break;
+		case 'usnat':
+			window._sp_.config.usnat = {
+				targetingParams: {
+					framework,
+				},
+			};
+			break;
+		case 'aus':
+			window._sp_.config.ccpa = {
+				targetingParams: {
+					framework,
+				},
+			};
+			break;
 	}
 
 	// TODO use libs function loadScript,

--- a/libs/@guardian/libs/src/consent-management-platform/stub.test.js
+++ b/libs/@guardian/libs/src/consent-management-platform/stub.test.js
@@ -1,8 +1,4 @@
-import {
-	loadAllStubs,
-	loadStubsFor,
-	loadStubsForGeolocationTest,
-} from './stub.ts';
+import { loadAllStubs, loadStubsFor } from './stub.ts';
 
 describe('stub', () => {
 	describe('loadStubsFor', () => {
@@ -50,40 +46,6 @@ describe('stub', () => {
 			loadAllStubs();
 			expect(window.__gpp).toBeDefined();
 			expect(window.__uspapi).toBeDefined();
-		});
-	});
-
-	describe('loadStubsForGeolocationTest', () => {
-		beforeEach(() => {
-			// Clear the window object before each test
-			window.__tcfapi = undefined;
-			window.__uspapi = undefined;
-			window.__gpp = undefined;
-		});
-
-		it('should load the correct stub for the tcfv2', () => {
-			expect(window.__tcfapi).toBeUndefined();
-			expect(window.__gpp).toBeUndefined();
-			expect(window.__uspapi).toBeUndefined();
-			loadStubsForGeolocationTest('tcfv2');
-			expect(window.__gpp).toBeDefined();
-		});
-
-		it('should load the correct stub for the usnat', () => {
-			expect(window.__tcfapi).toBeUndefined();
-			expect(window.__gpp).toBeUndefined();
-			expect(window.__uspapi).toBeUndefined();
-			loadStubsForGeolocationTest('usnat');
-			expect(window.__gpp).toBeDefined();
-		});
-		it('should load the correct stub for the aus', () => {
-			expect(window.__tcfapi).toBeUndefined();
-			expect(window.__gpp).toBeUndefined();
-			expect(window.__uspapi).toBeUndefined();
-			loadStubsForGeolocationTest('aus');
-			expect(window.__uspapi).toBeDefined();
-			expect(window.__tcfapi).toBeUndefined();
-			expect(window.__gpp).toBeUndefined();
 		});
 	});
 });

--- a/libs/@guardian/libs/src/consent-management-platform/stub.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/stub.ts
@@ -31,19 +31,3 @@ export const loadAllStubs = (): void => {
 	stub_gpp_usnat();
 	stub_uspapi_ccpa();
 };
-
-/**
- * Load  stubs for the geolocation test.
- *
- */
-export const loadStubsForGeolocationTest = (
-	framework: ConsentFramework,
-): void => {
-	if (framework === 'aus') {
-		stub_uspapi_ccpa();
-		return;
-	}
-
-	stub_tcfv2();
-	stub_gpp_usnat();
-};

--- a/libs/@guardian/libs/src/consent-management-platform/types/window.d.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/types/window.d.ts
@@ -71,9 +71,6 @@ declare global {
 						message_type: string,
 						consentUUID: string,
 						euconsent: string,
-						info: {
-							applies: boolean;
-						},
 					) => void;
 					onMessageReady: (message_type: string) => void;
 					onMessageChoiceSelect: OnMessageChoiceSelect;


### PR DESCRIPTION
Reverts guardian/csnx#2109

Temporarily revert the Sourcepoint Geolocation test. We'll likely resume this test next week but for now its blocking other users of @guardian/libs from making changes.

We don't want the Geolocation change to accidentally be deployed by a dependency update before we're ready.