### PR TITLE
Create `stand` lib to house byline component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -510,6 +510,34 @@ install: check-node-version
 @guardian/source-development-kitchen\:verify-dist: env
 	@corepack pnpm --filter @guardian/source-development-kitchen verify-dist
 
+.PHONY: @guardian/stand\:build
+@guardian/stand\:build: env
+	@corepack pnpm --filter @guardian/stand build
+
+.PHONY: @guardian/stand\:dev
+@guardian/stand\:dev: env
+	@corepack pnpm --filter @guardian/stand dev
+
+.PHONY: @guardian/stand\:fix
+@guardian/stand\:fix: env
+	@corepack pnpm --filter @guardian/stand fix
+
+.PHONY: @guardian/stand\:lint
+@guardian/stand\:lint: env
+	@corepack pnpm --filter @guardian/stand lint
+
+.PHONY: @guardian/stand\:test
+@guardian/stand\:test: env
+	@corepack pnpm --filter @guardian/stand test
+
+.PHONY: @guardian/stand\:tsc
+@guardian/stand\:tsc: env
+	@corepack pnpm --filter @guardian/stand tsc
+
+.PHONY: @guardian/stand\:verify-dist
+@guardian/stand\:verify-dist: env
+	@corepack pnpm --filter @guardian/stand verify-dist
+
 .PHONY: github-pages\:build
 github-pages\:build: env
 	@corepack pnpm --filter github-pages build

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following packages live in `libs/@guardian/*` and are published to NPM:
 - [@guardian/react-crossword](libs/@guardian/react-crossword)
 - [@guardian/source](libs/@guardian/source)
 - [@guardian/source-development-kitchen](libs/@guardian/source-development-kitchen)
+- [@guardian/stand](libs/@guardian/stand)
 - [@guardian/tsconfig](libs/@guardian/tsconfig)
 
 <!-- END PUBLISHED_PACKAGES -->
@@ -199,6 +200,16 @@ Project-specific tasks are defined as `scripts` in their `package.json`, and can
 - `make @guardian/source-development-kitchen:test`
 - `make @guardian/source-development-kitchen:tsc`
 - `make @guardian/source-development-kitchen:verify-dist`
+
+#### @guardian/stand
+
+- `make @guardian/stand:build`
+- `make @guardian/stand:dev`
+- `make @guardian/stand:fix`
+- `make @guardian/stand:lint`
+- `make @guardian/stand:test`
+- `make @guardian/stand:tsc`
+- `make @guardian/stand:verify-dist`
 
 #### github-pages
 

--- a/libs/@guardian/stand/eslint.config.js
+++ b/libs/@guardian/stand/eslint.config.js
@@ -1,0 +1,13 @@
+import guardian from '@guardian/eslint-config';
+
+export default [
+	...guardian.configs.recommended,
+	...guardian.configs.jest,
+	{
+		ignores: [
+			'dist',
+			'jest.dist.*', // depends on build output, so don't lint it
+			'.wireit',
+		],
+	},
+];

--- a/libs/@guardian/stand/jest.config.js
+++ b/libs/@guardian/stand/jest.config.js
@@ -1,0 +1,9 @@
+import { config as baseConfig } from '../../../configs/jest.config.js';
+
+/** @typedef {import("jest").Config} Config  */
+const config = {
+	...baseConfig,
+	displayName: '@guardian/stand',
+};
+
+export default config;

--- a/libs/@guardian/stand/jest.dist.setup.js
+++ b/libs/@guardian/stand/jest.dist.setup.js
@@ -1,0 +1,6 @@
+// Mock `./src/index` with whatever `package.json` points at in dist.
+// This means we can run the unit tests against `dist` instead.
+
+import * as dist from '.';
+
+jest.mock('./src/index', () => dist);

--- a/libs/@guardian/stand/package.json
+++ b/libs/@guardian/stand/package.json
@@ -1,0 +1,143 @@
+{
+	"name": "@guardian/stand",
+	"version": "0.0.0",
+	"private": false,
+	"description": "",
+	"license": "Apache-2.0",
+	"sideEffects": false,
+	"type": "module",
+	"exports": {
+		"types": "./dist/index.d.ts",
+		"import": "./dist/index.js",
+		"require": "./dist/index.cjs"
+	},
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "wireit",
+		"dev": "jest --watch",
+		"fix": "wireit",
+		"lint": "wireit",
+		"test": "wireit",
+		"tsc": "wireit",
+		"verify-dist": "wireit"
+	},
+	"devDependencies": {
+		"@guardian/eslint-config": "workspace:*",
+		"@types/jest": "29.5.8",
+		"eslint": "9.19.0",
+		"jest": "29.7.0",
+		"rollup": "4.45.1",
+		"ts-jest": "29.4.0",
+		"tslib": "2.6.2",
+		"typescript": "5.5.2",
+		"wireit": "0.14.12"
+	},
+	"peerDependencies": {
+		"tslib": "^2.6.2",
+		"typescript": "~5.5.2"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"wireit": {
+		"__deps__": {
+			"dependencies": [
+				"../libs:build"
+			]
+		},
+		"build": {
+			"command": "rollup -c",
+			"dependencies": [
+				"__deps__"
+			],
+			"files": [
+				"src/**",
+				"package.json",
+				"tsconfig.json",
+				"rollup.config.js",
+				"../../../configs/rollup/rollup.config.js"
+			],
+			"output": [
+				"dist"
+			]
+		},
+		"fix": {
+			"command": "eslint --cache --color . --fix",
+			"dependencies": [
+				"__deps__"
+			],
+			"files": [
+				"**",
+				"!(dist)/**",
+				"!.eslintcache"
+			],
+			"clean": false,
+			"output": [
+				"."
+			]
+		},
+		"lint": {
+			"command": "eslint --cache --color .",
+			"dependencies": [
+				"__deps__"
+			],
+			"files": [
+				"**",
+				"!(dist)/**",
+				"!.eslintcache"
+			],
+			"output": []
+		},
+		"test": {
+			"command": "jest",
+			"dependencies": [
+				"__deps__"
+			],
+			"files": [
+				"**",
+				"../../../configs/jest.*",
+				"!(dist)/**",
+				"!.eslintcache"
+			],
+			"output": []
+		},
+		"tsc": {
+			"command": "tsc --pretty",
+			"dependencies": [
+				"__deps__"
+			],
+			"files": [
+				"**",
+				"tsconfig.json",
+				"../tsconfig/tsconfig.json",
+				"../../../@types/**",
+				"../../../tsconfig.base.json",
+				"!(dist)/**",
+				"!.eslintcache"
+			],
+			"output": []
+		},
+		"verify-dist": {
+			"command": "jest --setupFilesAfterEnv ./jest.dist.setup.js",
+			"dependencies": [
+				"build"
+			],
+			"files": [
+				"**",
+				"../../../configs/jest.*",
+				"!(dist)/**",
+				"!.eslintcache"
+			],
+			"output": []
+		}
+	}
+}

--- a/libs/@guardian/stand/rollup.config.js
+++ b/libs/@guardian/stand/rollup.config.js
@@ -1,0 +1,1 @@
+export * as default from '../../../configs/rollup/rollup.config.js';

--- a/libs/@guardian/stand/src/index.test.ts
+++ b/libs/@guardian/stand/src/index.test.ts
@@ -1,0 +1,5 @@
+import { byline } from '.';
+
+test('test export byline', () => {
+	expect(byline()).toEqual('byline');
+});

--- a/libs/@guardian/stand/src/index.ts
+++ b/libs/@guardian/stand/src/index.ts
@@ -1,0 +1,3 @@
+export function byline() {
+	return 'byline';
+}

--- a/libs/@guardian/stand/tsconfig.json
+++ b/libs/@guardian/stand/tsconfig.json
@@ -1,0 +1,5 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"include": ["**/*"],
+	"exclude": ["node_modules", "dist", ".wireit", "jest.dist.setup.js"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,6 +793,36 @@ importers:
         specifier: 0.14.12
         version: 0.14.12
 
+  libs/@guardian/stand:
+    devDependencies:
+      '@guardian/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@types/jest':
+        specifier: 29.5.8
+        version: 29.5.8
+      eslint:
+        specifier: 9.19.0
+        version: 9.19.0
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@22.10.0)
+      rollup:
+        specifier: 4.45.1
+        version: 4.45.1
+      ts-jest:
+        specifier: 29.4.0
+        version: 29.4.0(@babel/core@7.28.0)(esbuild@0.25.4)(jest@29.7.0)(typescript@5.5.2)
+      tslib:
+        specifier: 2.6.2
+        version: 2.6.2
+      typescript:
+        specifier: 5.5.2
+        version: 5.5.2
+      wireit:
+        specifier: 0.14.12
+        version: 0.14.12
+
   libs/@guardian/tsconfig: {}
 
   scripts:
@@ -4294,12 +4324,8 @@ packages:
   /@types/doctrine@0.0.9:
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
-  /@types/estree@1.0.7:
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
-
   /@types/estree@1.0.8:
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-    dev: true
 
   /@types/fontkit@2.0.8:
     resolution: {integrity: sha512-wN+8bYxIpJf+5oZdrdtaX04qUuWHcKxcDEgRS9Qm9ZClSHjzEn13SxUC+5eRM+4yXIeTYk8mTzLAWGF64847ew==}
@@ -5188,16 +5214,10 @@ packages:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  /brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-    dependencies:
-      balanced-match: 1.0.2
-
   /brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
   /brace-expansion@4.0.0:
     resolution: {integrity: sha512-l/mOwLWs7BQIgOKrL46dIAbyCKvPV7YJPDspkuc88rHsZRlg3hptUGdU7Trv0VFP4d3xnSGBQrKu5ZvGB7UeIw==}
@@ -6646,12 +6666,12 @@ packages:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.1
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0
+      debug: 4.4.1
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -9181,7 +9201,7 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}


### PR DESCRIPTION
## What are you changing?

- Adding a new package to house our byline component, which is the anchor tenant for future shared journalism tools components. It currently lives in flexible frontend -> https://github.com/guardian/flexible-content/pull/5652

## Why?

- This doesn't belong in Source, but it should be exported somewhere so multiple apps can consume the components. Adding it to csnx gives us lots of existing tooling to help with this and standardise it.
