### PR TITLE
Add Storybook component testing

### DIFF
--- a/libs/@guardian/stand/package.json
+++ b/libs/@guardian/stand/package.json
@@ -45,6 +45,7 @@
 		"@storybook/addon-links": "8.6.4",
 		"@storybook/react": "8.6.4",
 		"@storybook/react-vite": "8.6.4",
+		"@storybook/test": "8.6.4",
 		"@types/jest": "29.5.8",
 		"@types/react": "18.2.79",
 		"eslint": "9.19.0",
@@ -58,10 +59,10 @@
 		"wireit": "0.14.12"
 	},
 	"peerDependencies": {
-		"tslib": "^2.6.2",
-		"typescript": "~5.5.2",
 		"@emotion/react": "^11.11.4",
-		"react": "^18.2.0"
+		"react": "^18.2.0",
+		"tslib": "^2.6.2",
+		"typescript": "~5.5.2"
 	},
 	"peerDependenciesMeta": {
 		"typescript": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -841,6 +841,9 @@ importers:
       '@storybook/react-vite':
         specifier: 8.6.4
         version: 8.6.4(@storybook/test@8.6.4)(react-dom@18.2.0)(react@18.2.0)(rollup@4.45.1)(storybook@8.6.4)(typescript@5.5.2)(vite@6.3.5)
+      '@storybook/test':
+        specifier: 8.6.4
+        version: 8.6.4(storybook@8.6.4)
       '@types/jest':
         specifier: 29.5.8
         version: 29.5.8


### PR DESCRIPTION
## What are you changing?

- Adds some `play` functions to test interactive functions within Storybook

## Why?

- We are assessing which direction to go with our tests for the Byline component, doing the testing within storybook would be useful as we already have stories and it doesn't introduce much extra setup
