### PR TITLE
gitchore: Bump @guardian/ophan-tracker-js to 2.5.0 and widen depdende…

### DIFF
--- a/.changeset/long-years-train.md
+++ b/.changeset/long-years-train.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': patch
+---
+
+Bump `@guardian/ophan-tracker-js` to `^2.5.0`

--- a/libs/@guardian/libs/package.json
+++ b/libs/@guardian/libs/package.json
@@ -28,7 +28,7 @@
 		"verify-dist": "wireit"
 	},
 	"dependencies": {
-		"@guardian/ophan-tracker-js": "2.2.10"
+		"@guardian/ophan-tracker-js": "^2.5.0"
 	},
 	"devDependencies": {
 		"@guardian/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,8 +423,8 @@ importers:
   libs/@guardian/libs:
     dependencies:
       '@guardian/ophan-tracker-js':
-        specifier: 2.2.10
-        version: 2.2.10
+        specifier: 2.5.0
+        version: 2.5.0
     devDependencies:
       '@guardian/eslint-config':
         specifier: workspace:*
@@ -2563,8 +2563,8 @@ packages:
       '@eslint/core': 0.10.0
       levn: 0.4.1
 
-  /@guardian/ophan-tracker-js@2.2.10:
-    resolution: {integrity: sha512-WqE5bPagZ7AYUc2Fb0xDgNfhmdS9wK1IJcUjTD6CrlPim67SiRragw4fy+CP2OwShkfiWFmb9l/TgQLbuvUlIQ==}
+  /@guardian/ophan-tracker-js@2.5.0:
+    resolution: {integrity: sha512-SPXjzQ6wpLLcv02Gv1mNcjXIdNxzIV1h/kpkdLdxR6w4TovVoJyXI4/JJpG4MuXxap9fqbTJeDA6kwHhVFo3Lw==}
     engines: {node: '>=16'}
     dependencies:
       '@guardian/tsconfig': 1.0.0


### PR DESCRIPTION
## What are you changing?

Bumps `@guardian/ophan-tracker-js` and specifies a wider version range. 


## Why?


As per https://docs.renovatebot.com/dependency-pinning/#so-whats-best libraries like `@guardian/libs` shouldn't specify an exact version of a dependency as it creates a blocker where downstream consumers of `@guardian/libs` are almost forced to use the same version of the dependency unless they want to end up with multiple versions in their `node_modules` folder.

In my case I wanted to use `@guardian/ophan-tracker-js` which adds a new `DETECT` action, but as `@guardian/libs` specifically requested `@guardian/ophan-tracker-js=v2.2.10` my Typescript compilation would fail due to incompatible types between the version of Ophan that DCR uses and the one that `@guardian/libs` uses.

By specifiying a caret (^) version of `@guardian/ophan-tracker-js` it allows downstream users of `@guardian/libs` to install whatever version of `@guardian/ophan-tracker-js` they need so long as its still the same major version range.
