### PR TITLE
Add 'getErrorMessage' implementation

### DIFF
--- a/libs/@guardian/libs/src/getErrorMessage/README.md
+++ b/libs/@guardian/libs/src/getErrorMessage/README.md
@@ -1,0 +1,29 @@
+# getErrorMessage
+
+Returns: `string`
+
+Tries to extract an error message from the argument without throwing a new error, in light of the fact that when you `catch` a value in JavaScript, you don't know what type it has.
+
+## Reference
+
+The current implementation is based on Kent C. Dodd's article, [Get a catch block error message with TypeScript](https://kentcdodds.com/blog/get-a-catch-block-error-message-with-typescript).
+
+## Example
+
+```js
+import { getErrorMessage } from '@guardian/libs';
+
+// Example 1 (handling an Error that's been thrown)
+try {
+	throw new Error('This is an error message');
+} catch (e) {
+	console.error(getErrorMessage(e)); // Expected log output: "This is an error message"
+}
+
+// Example 2 (handling a different kind of value that's been thrown for some reason)
+try {
+	throw 2;
+} catch (e) {
+	console.error(getErrorMessage(e)); // Expected log output: "2"
+}
+```

--- a/libs/@guardian/libs/src/getErrorMessage/getErrorMessage.test.ts
+++ b/libs/@guardian/libs/src/getErrorMessage/getErrorMessage.test.ts
@@ -1,0 +1,51 @@
+import { getErrorMessage } from './getErrorMessage';
+
+function throwCatchAndReturnErrorMessage(error: unknown): string {
+	try {
+		throw error;
+	} catch (e) {
+		return getErrorMessage(e);
+	}
+}
+
+describe('getErrorMessage', () => {
+	it('should return the error message from an Error object', () => {
+		const error = new Error('This is an error');
+		expect(getErrorMessage(error)).toBe('This is an error');
+
+		expect(throwCatchAndReturnErrorMessage(error)).toBe('This is an error');
+	});
+
+	it('should return the message from an object with a message property', () => {
+		const error = { message: 'This is a custom error message' };
+		expect(getErrorMessage(error)).toBe('This is a custom error message');
+	});
+
+	it('should handle non-error objects by stringifying them', () => {
+		const error = { foo: 'bar' };
+		expect(getErrorMessage(error)).toBe('{"foo":"bar"}');
+	});
+
+	it('should handle circular references somewhat gracefully', () => {
+		const circularObj = {};
+		// @ts-expect-error -- we haven't specified a type for circularObj but we want to test circular references
+		circularObj.self = circularObj;
+		expect(getErrorMessage(circularObj)).toBe('[object Object]');
+	});
+
+	it("should handle the various things you can (but almost certainly shouldn't) throw in JavaScript", () => {
+		expect(throwCatchAndReturnErrorMessage('string error')).toBe(
+			'string error',
+		);
+		expect(throwCatchAndReturnErrorMessage(42)).toBe('42');
+		expect(throwCatchAndReturnErrorMessage(true)).toBe('true');
+		expect(throwCatchAndReturnErrorMessage(null)).toBe('null');
+		expect(throwCatchAndReturnErrorMessage(undefined)).toBe('');
+		expect(throwCatchAndReturnErrorMessage(Symbol('A'))).toBe('');
+		expect(throwCatchAndReturnErrorMessage({})).toBe('{}');
+		expect(throwCatchAndReturnErrorMessage([])).toBe('[]');
+
+		const date = new Date();
+		expect(throwCatchAndReturnErrorMessage(date)).toBe(JSON.stringify(date));
+	});
+});

--- a/libs/@guardian/libs/src/getErrorMessage/getErrorMessage.ts
+++ b/libs/@guardian/libs/src/getErrorMessage/getErrorMessage.ts
@@ -1,0 +1,33 @@
+type ErrorWithMessage = {
+	message: string;
+};
+
+function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		'message' in error &&
+		typeof (error as Record<string, unknown>).message === 'string'
+	);
+}
+
+function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
+	if (isErrorWithMessage(maybeError)) {
+		return maybeError;
+	}
+
+	try {
+		if (typeof maybeError === 'string') {
+			return new Error(maybeError);
+		}
+		return new Error(JSON.stringify(maybeError));
+	} catch {
+		// fallback in case there's an error stringifying the maybeError
+		// like with circular references for example.
+		return new Error(String(maybeError));
+	}
+}
+
+export function getErrorMessage(error: unknown): string {
+	return toErrorWithMessage(error).message;
+}


### PR DESCRIPTION
## What are you changing?

Add a `getErrorMessage` helper function to `@guardian/libs`

-

## Why?

In a try/catch block it's common to want to extract a message from the thrown value, e.g. in order to log it. But TypeScript treats the value of `e` in `catch (e)` as `unknown`. Which it is! You can `throw` all sorts of things in JavaScript. In order to meaningfully and safely stringify the various values that might get thrown, there are a few different steps you need to take.

Given that a) there's a common and -- I _think_ -- well-defined use-case_ here, and b) the implementation is non-trivial, it seems like a good candidate for a `@guardian/libs` helper function.

There's [a good post about this](https://kentcdodds.com/blog/get-a-catch-block-error-message-with-typescript) by Kent C. Dodds, which includes an implementation. I've largely copied that implementation here, and added some tests.

-

## Additional details

### Usage in PROD

I've added this function to two projects in PROD so far, and I'd like to add it to a couple more, so in this sense it passes the 'rule of three' for abstraction.

* [Newswires](https://github.com/guardian/newswires/blob/8238e3f753f5d646690caebf9cbe910d76878dae/shared/getErrorMessage.ts)
* [crosswordv2](https://github.com/guardian/crosswordv2/blob/a43c00cc6af1ffb87e841d077d42a3151aaf4da0/client/src/getErrorMessage.ts)

### Encouraging correct use

In the crosswordv2 case, we're often logging messages that we're extracting from Zod errors. The calling code looks pretty similar to how you _might_ extract a message from an error, i.e. `console.error(error.message)`. However, you _wouldn't_ want to pass a Zod error to the `getErrorMessage` function I'm adding here. For one thing, Zod errors typically aren't thrown, so if you're handling one you should generally know what you have, and can handle it more context-appropriately. I've added some funky TypeScript to the crosswordv2 implementation to discourage passing `ZodError` values, but we can't add that to the libs implementation without introducing Zod as a dependency, which wouldn't be good.

Does it seem like a risk to reviewers, that if this helper function is available then people might accidentally pass values to it that would be better handled in other ways?