### PR TITLE
Export getErrorMessage helper function

### DIFF
--- a/.changeset/sixty-stars-watch.md
+++ b/.changeset/sixty-stars-watch.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+Export the getErrorMessage function

--- a/libs/@guardian/libs/README.md
+++ b/libs/@guardian/libs/README.md
@@ -30,7 +30,7 @@ Codified editorial design and information architecture.
 
 Get the user’s current location.
 
-### [Switches](./src/getSwitches)
+### [Switches](./src/switches)
 
 Get the active switches on theguardian.com.
 
@@ -85,6 +85,10 @@ Robust API over `localStorage` and `sessionStorage`.
 ### [`timeAgo`](./src/timeAgo)
 
 Format absolute dates as time-ago strings.
+
+### [`getErrorMessage`](./src/getErrorMessage)
+
+Utility for extracting a useful error message from Errors (or other values) that can be thrown in JavaScript.
 
 ## Installation
 

--- a/libs/@guardian/libs/src/index.test.ts
+++ b/libs/@guardian/libs/src/index.test.ts
@@ -15,6 +15,7 @@ describe('The package', () => {
 			'getConsentFor',
 			'getCookie',
 			'getCountryByCountryCode',
+			'getErrorMessage',
 			'getLocale',
 			'getMeasures',
 			'getSwitches',

--- a/libs/@guardian/libs/src/index.ts
+++ b/libs/@guardian/libs/src/index.ts
@@ -4,11 +4,17 @@ export * from './deprecated-exports';
 
 export { ArticleElementRole } from './ArticleElementRole/ArticleElementRole';
 
+export {
+	cmp,
+	getConsentFor,
+	onConsent,
+	onConsentChange,
+} from './consent-management-platform';
 export type {
-	OnConsentChangeCallback,
 	CMP,
-	ConsentState,
 	ConsentFramework,
+	ConsentState,
+	OnConsentChangeCallback,
 	VendorName,
 } from './consent-management-platform/types';
 export type {
@@ -16,12 +22,6 @@ export type {
 	TCFv2ConsentState,
 } from './consent-management-platform/types/tcfv2';
 export type { USNATConsentState } from './consent-management-platform/types/usnat';
-export {
-	cmp,
-	getConsentFor,
-	onConsentChange,
-	onConsent,
-} from './consent-management-platform';
 
 export { getCookie } from './cookies/getCookie';
 export { removeCookie } from './cookies/removeCookie';
@@ -55,12 +55,12 @@ export { loadScript } from './loadScript/loadScript';
 
 export { getLocale } from './locale/getLocale';
 
+export type { Subscription } from './logger/@types/logger';
 export { debug } from './logger/debug';
 export { log } from './logger/logger';
-export type { Subscription } from './logger/@types/logger';
 
-export { startPerformanceMeasure } from './performance/startPerformanceMeasure';
 export { getMeasures } from './performance/getMeasures';
+export { startPerformanceMeasure } from './performance/startPerformanceMeasure';
 
 export type {
 	OphanABEvent,
@@ -77,3 +77,5 @@ export { storage } from './storage/storage';
 
 export type { Switches } from './switches/@types/Switches';
 export { getSwitches } from './switches/getSwitches';
+
+export { getErrorMessage } from './getErrorMessage/getErrorMessage';


### PR DESCRIPTION
## What are you changing?

I added a `getErrorMessage` function in #2165, but didn't export it. I created this following the model of https://github.com/guardian/csnx/pull/392

-

## Why?

Not much point in adding the function but not exporting it!

-
