### PR TITLE
trigger event when the cmp banner is closed

### DIFF
--- a/.changeset/sparkly-dryers-drop.md
+++ b/.changeset/sparkly-dryers-drop.md
@@ -1,0 +1,5 @@
+---
+'@guardian/libs': minor
+---
+
+trigger event when cmp banner is closed

--- a/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
+++ b/libs/@guardian/libs/src/consent-management-platform/sourcepoint.ts
@@ -264,6 +264,7 @@ export const init = (
 						choiceTypeID === SourcePointChoiceTypes.RejectAll ||
 						choiceTypeID === SourcePointChoiceTypes.Dismiss
 					) {
+						document.dispatchEvent(new Event('cmp:banner-close'));
 						setTimeout(invokeCallbacks, 0);
 					}
 				},


### PR DESCRIPTION
## What are you changing?

Trigger an event to notify subscribers that the cmp banner was closed


## Why?

The Commercial team required an event to ensure mobile sticky ad is not displayed at the same time as the cmp banner
