### PR TITLE
Add newsletter types question block heading field

### DIFF
--- a/.changeset/chubby-queens-melt.md
+++ b/.changeset/chubby-queens-melt.md
@@ -1,0 +1,5 @@
+---
+'@guardian/newsletter-types': minor
+---
+
+Adds question block subheading for newsletter types

--- a/libs/@guardian/newsletter-types/src/@types/newsletters-api.ts
+++ b/libs/@guardian/newsletter-types/src/@types/newsletters-api.ts
@@ -19,6 +19,7 @@ export type AutomatedFrontSection = {
 
 export type NewsletterEmailRenderingOptions = {
 	linkListSubheading?: string[] | undefined;
+	questionBlockSubheading?: string[] | undefined;
 	podcastSubheading?: string[] | undefined;
 	darkThemeSubheading?: string[] | undefined;
 	readMoreSections?:


### PR DESCRIPTION
## What are you changing?

Add question block subheading field for newsletters api to support question block component replacement in email-rendering
-

## Why?

- First Edition newsletter no longer rendered with a custom template - now uses standard template, requiring this to be configurable 
