### PR TITLE
add css snippet to restore styling for html tags in crossword clues

### DIFF
--- a/.changeset/funky-days-design.md
+++ b/.changeset/funky-days-design.md
@@ -1,0 +1,5 @@
+---
+'@guardian/react-crossword': minor
+---
+
+Readd clue styling

--- a/libs/@guardian/react-crossword/src/components/AnagramHelper.tsx
+++ b/libs/@guardian/react-crossword/src/components/AnagramHelper.tsx
@@ -8,6 +8,7 @@ import { useProgress } from '../context/Progress';
 import { useShowAnagramHelper } from '../context/ShowAnagramHelper';
 import { useTheme } from '../context/Theme';
 import { biasedShuffle } from '../utils/biasedShuffle';
+import { restoreClueFormattingStyles } from '../utils/clueFormattingStyles';
 import { getCellsWithProgressForGroup } from '../utils/getCellsWithProgressForGroup';
 import { CrosswordButton } from './CrosswordButton';
 import { SolutionDisplay } from './SolutionDisplay';
@@ -215,6 +216,7 @@ export const AnagramHelper = () => {
 							aria-hidden="true"
 							css={css`
 								text-align: center;
+								${restoreClueFormattingStyles}
 							`}
 							dangerouslySetInnerHTML={{
 								__html: entry.clue,

--- a/libs/@guardian/react-crossword/src/components/Clue.stories.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clue.stories.tsx
@@ -57,3 +57,23 @@ export const ActiveAndComplete: Story = {
 		isComplete: true,
 	},
 };
+
+export const Styled: Story = {
+	args: {
+		entry: {
+			id: '1-across',
+			number: 1,
+			humanNumber: '1',
+			clue: 'Plain <b>Bold</b> <i>Italic</i> <b><i>BoldItalic</i></b> <sub>Subscript</sub> <sup>Superscript</sup> <span>Span</span> (4)',
+			direction: 'across',
+			length: 4,
+			group: ['1-across'],
+			position: {
+				x: 0,
+				y: 1,
+			},
+			separatorLocations: {},
+			solution: 'CAKE',
+		},
+	},
+};

--- a/libs/@guardian/react-crossword/src/components/Clue.tsx
+++ b/libs/@guardian/react-crossword/src/components/Clue.tsx
@@ -6,6 +6,7 @@ import type { HTMLAttributes } from 'react';
 import { memo, useEffect, useRef } from 'react';
 import type { CAPIEntry } from '../@types/CAPI';
 import { useTheme } from '../context/Theme';
+import { restoreClueFormattingStyles } from '../utils/clueFormattingStyles';
 
 const punctuateString = (string: string) => {
 	const trimmed = string.trim();
@@ -121,6 +122,7 @@ const ClueComponent = ({
 				aria-hidden="true"
 				css={css`
 					display: table-cell;
+					${restoreClueFormattingStyles}
 				`}
 				dangerouslySetInnerHTML={{
 					__html: entry.clue,

--- a/libs/@guardian/react-crossword/src/components/FocusedClue.tsx
+++ b/libs/@guardian/react-crossword/src/components/FocusedClue.tsx
@@ -6,6 +6,7 @@ import { memo } from 'react';
 import { useCurrentClue } from '../context/CurrentClue';
 import { useData } from '../context/Data';
 import { useTheme } from '../context/Theme';
+import { restoreClueFormattingStyles } from '../utils/clueFormattingStyles';
 
 type StickyClueProps = {
 	additionalCss?: SerializedStyles;
@@ -47,6 +48,7 @@ export const FocusedClueComponent = ({ additionalCss }: StickyClueProps) => {
 					</span>
 					<span
 						aria-hidden="true"
+						css={restoreClueFormattingStyles}
 						dangerouslySetInnerHTML={{
 							__html: entry.clue,
 						}}

--- a/libs/@guardian/react-crossword/src/utils/clueFormattingStyles.ts
+++ b/libs/@guardian/react-crossword/src/utils/clueFormattingStyles.ts
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react';
+
+// CSS reset removes clue formatting styles.
+export const restoreClueFormattingStyles = css`
+	& > sub {
+		vertical-align: sub;
+	}
+	& > sup {
+		vertical-align: super;
+	}
+	& > b {
+		font-weight: bold;
+	}
+	& > i {
+		font-style: italic;
+	}
+`;


### PR DESCRIPTION
## What are you changing?

Add a little css snippet to re-add basic HTML styling for tags used to markup crossword clues. I believe the basic HTML styles are overridden by a CSS reset.

## Why?

Formatted clues appear with the intended formatting
