### PR TITLE
Add newsletter types bullet list style

### DIFF
--- a/.changeset/silver-hands-walk.md
+++ b/.changeset/silver-hands-walk.md
@@ -1,0 +1,5 @@
+---
+'@guardian/newsletter-types': minor
+---
+
+add bullet list style to newsletters api

--- a/libs/@guardian/newsletter-types/src/@types/newsletters-api.ts
+++ b/libs/@guardian/newsletter-types/src/@types/newsletters-api.ts
@@ -43,6 +43,7 @@ export type NewsletterEmailRenderingOptions = {
 	darkHeadlineBackground?: boolean;
 	displayNewsletterName?: boolean;
 	paletteOverride?: PillarName;
+	bulletListStyle?: 'lined' | 'bulleted';
 };
 
 export type NewsletterApiData = {


### PR DESCRIPTION
## What are you changing?

Adds bullet list style to support being able to switch between a list of bullet points or a lined list style within the newsletters tool / email rendering

## Why?

- Since changing to the Kronos template for newletters like first thing, they are rendering with a lined list where the editors would prefer a bullet point list
