### PR TITLE
Enable Jest/ts-jest ESM support in preperation for typescript v6+

### DIFF
--- a/configs/jest.config.js
+++ b/configs/jest.config.js
@@ -1,3 +1,7 @@
+import { createDefaultEsmPreset } from 'ts-jest';
+
+const presetConfig = createDefaultEsmPreset();
+
 /** @typedef {import("jest").Config} Config  */
 export const config = {
 	clearMocks: true,
@@ -6,8 +10,6 @@ export const config = {
 	transformIgnorePatterns: [
 		'node_modules/.pnpm/(?!@guardian|use-local-storage-state)',
 	],
-	transform: {
-		'^.+\\.[tj]sx?$': ['ts-jest'],
-	},
 	coveragePathIgnorePatterns: ['/__generated__/'],
+	...presetConfig,
 };

--- a/coverage/package.json
+++ b/coverage/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"start": "jest"
+		"start": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest"
 	},
 	"dependencies": {
 		"jest": "30.4.2"

--- a/libs/@guardian/ab-core/jest.dist.setup.js
+++ b/libs/@guardian/ab-core/jest.dist.setup.js
@@ -1,5 +1,6 @@
 // Mock `./src/index` with whatever `package.json` points at in dist.
 // This means we can run the unit tests against `dist` instead.
+import { jest } from '@jest/globals';
 
 import * as dist from '.';
 

--- a/libs/@guardian/ab-core/package.json
+++ b/libs/@guardian/ab-core/package.json
@@ -31,12 +31,13 @@
 	},
 	"devDependencies": {
 		"@guardian/eslint-config": "workspace:*",
+		"@jest/globals": "30.4.1",
 		"@types/jest": "30.0.0",
 		"eslint": "9.39.1",
 		"jest": "30.4.2",
 		"jest-environment-jsdom": "30.4.1",
 		"rollup": "4.60.0",
-		"ts-jest": "29.4.0",
+		"ts-jest": "29.4.10",
 		"tslib": "2.8.1",
 		"typescript": "5.9.3",
 		"wireit": "0.14.12"
@@ -89,7 +90,7 @@
 			"output": []
 		},
 		"test": {
-			"command": "jest",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
 			"files": [
 				"**",
 				"../../../configs/jest.*",
@@ -112,7 +113,7 @@
 			"output": []
 		},
 		"verify-dist": {
-			"command": "jest --setupFilesAfterEnv ./jest.dist.setup.js",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --setupFilesAfterEnv ./jest.dist.setup.js",
 			"dependencies": [
 				"build"
 			],

--- a/libs/@guardian/ab-react/jest.dist.setup.js
+++ b/libs/@guardian/ab-react/jest.dist.setup.js
@@ -1,5 +1,6 @@
 // Mock `./src/index` with whatever `package.json` points at in dist.
 // This means we can run the unit tests against `dist` instead.
+import { jest } from '@jest/globals';
 
 import * as dist from '.';
 

--- a/libs/@guardian/ab-react/package.json
+++ b/libs/@guardian/ab-react/package.json
@@ -32,6 +32,7 @@
 	"devDependencies": {
 		"@guardian/ab-core": "9.0.0",
 		"@guardian/eslint-config": "workspace:*",
+		"@jest/globals": "30.4.1",
 		"@testing-library/react": "16.3.0",
 		"@types/jest": "30.0.0",
 		"@types/react": "18.2.79",
@@ -42,7 +43,7 @@
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"rollup": "4.60.0",
-		"ts-jest": "29.4.0",
+		"ts-jest": "29.4.10",
 		"tslib": "2.8.1",
 		"typescript": "5.9.3",
 		"wireit": "0.14.12"
@@ -116,7 +117,7 @@
 			"output": []
 		},
 		"test": {
-			"command": "jest",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
 			"dependencies": [
 				"__deps__"
 			],
@@ -145,7 +146,7 @@
 			"output": []
 		},
 		"verify-dist": {
-			"command": "jest --setupFilesAfterEnv ./jest.dist.setup.js",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --setupFilesAfterEnv ./jest.dist.setup.js",
 			"dependencies": [
 				"build"
 			],

--- a/libs/@guardian/ab-react/src/context.test.tsx
+++ b/libs/@guardian/ab-react/src/context.test.tsx
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import { ABProvider, useAB } from './context';
 

--- a/libs/@guardian/consent-manager/jest.dist.setup.js
+++ b/libs/@guardian/consent-manager/jest.dist.setup.js
@@ -1,11 +1,12 @@
 // Mock `./src/index` with whatever `package.json` points at in dist.
 // This means we can run the unit tests against `dist` instead.
+import { jest } from '@jest/globals';
 
-import * as dist from '.';
-
-jest.mock('./src/index', () => dist);
-jest.mock('./src/cmp', () => require('./dist/cmp'));
-jest.mock('./src/disable', () => require('./dist/disable'));
-jest.mock('./src/getCurrentFramework', () =>
-	require('./dist/getCurrentFramework'),
+jest.unstable_mockModule('./src/index', () => import('.'));
+jest.unstable_mockModule('./src/cmp', () => import('./dist/cmp.js'));
+jest.unstable_mockModule('./src/disable', () => import('./dist/disable.js'));
+jest.unstable_mockModule(
+	'./src/getCurrentFramework',
+	() => import('./dist/getCurrentFramework.js'),
 );
+jest.unstable_mockModule('./src/export', () => import('./dist/export.js'));

--- a/libs/@guardian/consent-manager/package.json
+++ b/libs/@guardian/consent-manager/package.json
@@ -37,6 +37,7 @@
 	},
 	"devDependencies": {
 		"@guardian/eslint-config": "workspace:*",
+		"@jest/globals": "30.4.1",
 		"@playwright/test": "1.60.0",
 		"@types/jest": "30.0.0",
 		"@types/wcag-contrast": "3.0.3",
@@ -46,7 +47,7 @@
 		"jest-fetch-mock": "3.0.3",
 		"mockdate": "3.0.5",
 		"rollup": "4.60.0",
-		"ts-jest": "29.4.0",
+		"ts-jest": "29.4.10",
 		"tslib": "2.8.1",
 		"tsx": "4.22.1",
 		"typescript": "5.9.3",
@@ -133,7 +134,7 @@
 			]
 		},
 		"test": {
-			"command": "jest",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
 			"files": [
 				"**",
 				"../../../configs/jest.*",
@@ -159,7 +160,7 @@
 			"output": []
 		},
 		"verify-dist": {
-			"command": "jest --setupFilesAfterEnv ./jest.dist.setup.js",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --setupFilesAfterEnv ./jest.dist.setup.js",
 			"dependencies": [
 				"build"
 			],

--- a/libs/@guardian/consent-manager/src/aus/api.test.js
+++ b/libs/@guardian/consent-manager/src/aus/api.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { getGlobalEnterpriseConsents } from './api.ts';
 
 jest.mock('../sourcepoint', () => ({

--- a/libs/@guardian/consent-manager/src/aus/getConsentState.test.js
+++ b/libs/@guardian/consent-manager/src/aus/getConsentState.test.js
@@ -1,8 +1,12 @@
+import { jest } from '@jest/globals';
 import { PRIVACY_CHOICE_ID_AUSTRALIA } from '../lib/sourcepointConfig.ts';
-import { getGlobalEnterpriseConsents } from './api.ts';
-import { getConsentState } from './getConsentState.ts';
 
-jest.mock('./api');
+jest.unstable_mockModule('./api', () => ({
+	getGlobalEnterpriseConsents: jest.fn(),
+}));
+
+const { getGlobalEnterpriseConsents } = await import('./api.ts');
+const { getConsentState } = await import('./getConsentState.ts');
 
 const mockGlobalEnterpriseData = {
 	applies: true,

--- a/libs/@guardian/consent-manager/src/export.test.ts
+++ b/libs/@guardian/consent-manager/src/export.test.ts
@@ -1,4 +1,5 @@
 import type { CountryCode } from '@guardian/libs';
+import { jest } from '@jest/globals';
 import { CMP as actualCMP } from './cmp';
 import { disable, enable } from './disable';
 import { cmp } from './export';
@@ -152,7 +153,7 @@ describe('hotfix cmp.init', () => {
 		expect(getCurrentFramework()).toEqual(framework);
 	});
 
-	it('uses window.guCmpHotFix instances if they exist', () => {
+	it('uses window.guCmpHotFix instances if they exist', async () => {
 		const mockCmp: typeCMP = {
 			init: () => undefined,
 			willShowPrivacyMessage: () => new Promise(() => true),
@@ -174,17 +175,12 @@ describe('hotfix cmp.init', () => {
 		window.guCmpHotFix.cmp = mockCmp;
 
 		jest.resetModules();
-		import('./export')
-			.then((module) => {
-				expect(module.cmp).toEqual(mockCmp);
+		const module = await import('./export');
+		expect(module.cmp).toEqual(mockCmp);
 
-				window.guCmpHotFix = {};
-				jest.resetModules();
-				void import('./export');
-			})
-			.catch((error) => {
-				console.error(error);
-			});
+		window.guCmpHotFix = {};
+		jest.resetModules();
+		await import('./export');
 	});
 });
 // *************** END commercial.dcr.js hotfix ***************

--- a/libs/@guardian/consent-manager/src/export.ts
+++ b/libs/@guardian/consent-manager/src/export.ts
@@ -1,7 +1,7 @@
 import { log } from '@guardian/libs';
 import { countries } from '@guardian/libs';
 import type { CountryCode } from '@guardian/libs';
-import { version } from '../package.json';
+import packageJson from '../package.json' with { type: 'json' };
 import { CMP as UnifiedCMP } from './cmp';
 import { disable, enable, isDisabled } from './disable';
 import { getConsentDetailsForOphan as clientGetConsentDetailsForOphan } from './getConsentDetailsForOphan';
@@ -48,9 +48,9 @@ const init: InitCMP = ({
 	}
 
 	if (window.guCmpHotFix.initialised) {
-		if (window.guCmpHotFix.cmp?.version !== version) {
+		if (window.guCmpHotFix.cmp?.version !== packageJson.version) {
 			console.warn('Two different versions of the CMP are running:', [
-				version,
+				packageJson.version,
 				window.guCmpHotFix.cmp?.version,
 			]);
 		}
@@ -157,7 +157,7 @@ export const cmp: CMP = isServerSide
 			willShowPrivacyMessageSync,
 			hasInitialised,
 			showPrivacyManager,
-			version: version,
+			version: packageJson.version,
 
 			// special helper methods for disabling CMP
 			__isDisabled: isDisabled,

--- a/libs/@guardian/consent-manager/src/getConsentDetailsForOphan.test.ts
+++ b/libs/@guardian/consent-manager/src/getConsentDetailsForOphan.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { getConsentDetailsForOphan } from './getConsentDetailsForOphan';
 import type { ConsentState } from './types';
 import type { TCFv2ConsentState } from './types/tcfv2';

--- a/libs/@guardian/consent-manager/src/getConsentFor.test.js
+++ b/libs/@guardian/consent-manager/src/getConsentFor.test.js
@@ -1,7 +1,6 @@
 // cSpell:ignore doesnotexist
 
-import { getConsentFor } from './getConsentFor.ts';
-import vendors from './vendors.ts';
+import { jest } from '@jest/globals';
 
 const vendorOne = 'd3b07384d113edec49eaa623';
 const vendorAlt = 'c157a79031e1c40f85931829';
@@ -23,13 +22,16 @@ const usnatWithoutConsent = { usnat: { doNotSell: true } };
 const ausWithConsent = { aus: { personalisedAdvertising: true } };
 const ausWithoutConsent = { aus: { personalisedAdvertising: false } };
 
-jest.mock('./vendors', () => ({
+jest.unstable_mockModule('./vendors', () => ({
 	VendorIDs: jest.fn(),
 }));
 
+const vendors = await import('./vendors.ts');
+const { getConsentFor } = await import('./getConsentFor.ts');
+
 it('throws an error if the vendor found ', () => {
 	jest
-		.spyOn(vendors, 'VendorIDs')
+		.mocked(vendors.VendorIDs)
 		.mockReturnValue({ vendorOne: [vendorOne, vendorAlt] });
 	expect(() => {
 		getConsentFor('doesnotexist', tcfv2ConsentFoundTrue);
@@ -49,7 +51,7 @@ test.each([
 	`In %s mode, returns %s, for vendor %s`,
 	(cmpMode, expected, vendor, mock) => {
 		jest
-			.spyOn(vendors, 'VendorIDs')
+			.mocked(vendors.VendorIDs)
 			.mockReturnValue({ vendorOne: [vendorOne, vendorAlt] });
 		expect(() => {
 			getConsentFor(vendor, mock);

--- a/libs/@guardian/consent-manager/src/onConsent.test.ts
+++ b/libs/@guardian/consent-manager/src/onConsent.test.ts
@@ -1,11 +1,15 @@
-import { onConsent } from './onConsent';
-import { onConsentChange } from './onConsentChange';
+import { jest } from '@jest/globals';
 import type { ConsentState, OnConsentChangeCallback } from './types';
 import type { AUSConsentState } from './types/aus';
 import type { TCFv2ConsentState } from './types/tcfv2';
 import type { USNATConsentState } from './types/usnat';
 
-jest.mock('./onConsentChange');
+jest.unstable_mockModule('./onConsentChange', () => ({
+	onConsentChange: jest.fn(),
+}));
+
+const { onConsentChange } = await import('./onConsentChange');
+const { onConsent } = await import('./onConsent');
 
 const tcfv2ConsentState: TCFv2ConsentState = {
 	consents: { 1: true },
@@ -29,9 +33,9 @@ const ausConsentState: AUSConsentState = {
 };
 
 const mockOnConsentChange = (consentState: ConsentState) =>
-	(onConsentChange as jest.Mock).mockImplementation(
-		(cb: OnConsentChangeCallback) => cb(consentState),
-	);
+	jest
+		.mocked(onConsentChange)
+		.mockImplementation((cb: OnConsentChangeCallback) => cb(consentState));
 
 describe('onConsent returns a promise that resolves the initial consent state', () => {
 	test('tcfv2', async () => {

--- a/libs/@guardian/consent-manager/src/onConsentChange.enhanced.test.ts
+++ b/libs/@guardian/consent-manager/src/onConsentChange.enhanced.test.ts
@@ -1,16 +1,27 @@
-import { getConsentState as getAUSConsentState } from './aus/getConsentState';
+import { jest } from '@jest/globals';
 import { setCurrentFramework, unsetFramework } from './getCurrentFramework';
-import { _ } from './onConsentChange';
-import { getConsentState as getTCFv2ConsentState } from './tcfv2/getConsentState';
 import type { ConsentFramework, ConsentState } from './types';
 import type { AUSConsentState } from './types/aus';
 import type { TCFv2ConsentState } from './types/tcfv2';
 import type { USNATConsentState } from './types/usnat';
-import { getConsentState as getUSNATConsentState } from './usnat/getConsentState';
 
-jest.mock('./tcfv2/getConsentState');
-jest.mock('./usnat/getConsentState');
-jest.mock('./aus/getConsentState');
+jest.unstable_mockModule('./tcfv2/getConsentState', () => ({
+	getConsentState: jest.fn(),
+}));
+jest.unstable_mockModule('./usnat/getConsentState', () => ({
+	getConsentState: jest.fn(),
+}));
+jest.unstable_mockModule('./aus/getConsentState', () => ({
+	getConsentState: jest.fn(),
+}));
+
+const { getConsentState: getTCFv2ConsentState } =
+	await import('./tcfv2/getConsentState');
+const { getConsentState: getUSNATConsentState } =
+	await import('./usnat/getConsentState');
+const { getConsentState: getAUSConsentState } =
+	await import('./aus/getConsentState');
+const { _ } = await import('./onConsentChange');
 
 const tcfv2ConsentState: TCFv2ConsentState = {
 	consents: { 1: true },
@@ -54,9 +65,11 @@ const setGpc = (globalPrivacyControl: undefined | boolean) => {
 
 describe('onConsentChange enhances basic consent state', () => {
 	test('tcfv2 can target', async () => {
-		(getTCFv2ConsentState as jest.Mock).mockImplementation(() =>
-			Promise.resolve<TCFv2ConsentState>(tcfv2ConsentState),
-		);
+		jest
+			.mocked(getTCFv2ConsentState)
+			.mockImplementation(() =>
+				Promise.resolve<TCFv2ConsentState>(tcfv2ConsentState),
+			);
 		setAPI('tcfv2');
 		const expectedConsentState: ConsentState = {
 			tcfv2: tcfv2ConsentState,
@@ -71,9 +84,11 @@ describe('onConsentChange enhances basic consent state', () => {
 			...tcfv2ConsentState,
 			consents: { 1: false },
 		};
-		(getTCFv2ConsentState as jest.Mock).mockImplementation(() =>
-			Promise.resolve<TCFv2ConsentState>(basicConsentState),
-		);
+		jest
+			.mocked(getTCFv2ConsentState)
+			.mockImplementation(() =>
+				Promise.resolve<TCFv2ConsentState>(basicConsentState),
+			);
 		setAPI('tcfv2');
 		const expectedConsentState: ConsentState = {
 			tcfv2: basicConsentState,
@@ -84,9 +99,11 @@ describe('onConsentChange enhances basic consent state', () => {
 		expect(consentState).toEqual(expectedConsentState);
 	});
 	test('usnat can target', async () => {
-		(getUSNATConsentState as jest.Mock).mockImplementation(() =>
-			Promise.resolve<USNATConsentState>(usnatConsentState),
-		);
+		jest
+			.mocked(getUSNATConsentState)
+			.mockImplementation(() =>
+				Promise.resolve<USNATConsentState>(usnatConsentState),
+			);
 		setAPI('usnat');
 		const expectedConsentState: ConsentState = {
 			usnat: usnatConsentState,
@@ -97,7 +114,7 @@ describe('onConsentChange enhances basic consent state', () => {
 		expect(consentState).toEqual(expectedConsentState);
 	});
 	test('usnat can NOT target', async () => {
-		(getUSNATConsentState as jest.Mock).mockImplementation(() =>
+		jest.mocked(getUSNATConsentState).mockImplementation(() =>
 			Promise.resolve<USNATConsentState>({
 				doNotSell: true,
 				signalStatus: 'ready',
@@ -113,9 +130,11 @@ describe('onConsentChange enhances basic consent state', () => {
 		expect(consentState).toEqual(expectedConsentState);
 	});
 	test('aus can target', async () => {
-		(getAUSConsentState as jest.Mock).mockImplementation(() =>
-			Promise.resolve<AUSConsentState>(ausConsentState),
-		);
+		jest
+			.mocked(getAUSConsentState)
+			.mockImplementation(() =>
+				Promise.resolve<AUSConsentState>(ausConsentState),
+			);
 		setAPI('aus');
 		const expectedConsentState: ConsentState = {
 			aus: ausConsentState,
@@ -126,7 +145,7 @@ describe('onConsentChange enhances basic consent state', () => {
 		expect(consentState).toEqual(expectedConsentState);
 	});
 	test('aus can NOT target', async () => {
-		(getAUSConsentState as jest.Mock).mockImplementation(() =>
+		jest.mocked(getAUSConsentState).mockImplementation(() =>
 			Promise.resolve<AUSConsentState>({
 				personalisedAdvertising: false,
 				signalStatus: 'ready',
@@ -152,9 +171,11 @@ describe('onConsentChange enhances basic consent state', () => {
 	});
 	test('notices a GPC signal', async () => {
 		setGpc(true);
-		(getUSNATConsentState as jest.Mock).mockImplementation(() =>
-			Promise.resolve<USNATConsentState>(usnatConsentState),
-		);
+		jest
+			.mocked(getUSNATConsentState)
+			.mockImplementation(() =>
+				Promise.resolve<USNATConsentState>(usnatConsentState),
+			);
 		setAPI('usnat');
 		const expectedConsentState: ConsentState = {
 			usnat: usnatConsentState,

--- a/libs/@guardian/consent-manager/src/onConsentChange.test.js
+++ b/libs/@guardian/consent-manager/src/onConsentChange.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import ausData from './aus/__fixtures__/api.getGlobalEnterpriseData.json';
 import { setCurrentFramework } from './getCurrentFramework.ts';
 import { _, invokeCallbacks, onConsentChange } from './onConsentChange.ts';

--- a/libs/@guardian/consent-manager/src/tcfv2/api.test.js
+++ b/libs/@guardian/consent-manager/src/tcfv2/api.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import {
 	getCustomVendorConsents,
 	getTCData,

--- a/libs/@guardian/consent-manager/src/tcfv2/getConsentState.test.js
+++ b/libs/@guardian/consent-manager/src/tcfv2/getConsentState.test.js
@@ -1,9 +1,15 @@
-import customVendorConsents from './__fixtures__/api.getCustomVendorConsents.json';
-import tcData from './__fixtures__/api.getTCData.json';
-import { getCustomVendorConsents, getTCData } from './api.ts';
-import { getConsentState } from './getConsentState.ts';
+import { jest } from '@jest/globals';
+import customVendorConsents from './__fixtures__/api.getCustomVendorConsents.json' with { type: 'json' };
+import tcData from './__fixtures__/api.getTCData.json' with { type: 'json' };
 
-jest.mock('./api');
+jest.unstable_mockModule('./api', () => ({
+	getTCData: jest.fn(),
+	getCustomVendorConsents: jest.fn(),
+}));
+
+const { getTCData, getCustomVendorConsents } = await import('./api.ts');
+const { getConsentState } = await import('./getConsentState.ts');
+
 getTCData.mockReturnValue(Promise.resolve(tcData));
 getCustomVendorConsents.mockReturnValue(Promise.resolve(customVendorConsents));
 

--- a/libs/@guardian/consent-manager/src/usnat/api.test.js
+++ b/libs/@guardian/consent-manager/src/usnat/api.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { getUsnatData } from './api.ts';
 
 it('calls the correct Sourcepoint api with the correct methods', async () => {

--- a/libs/@guardian/consent-manager/src/usnat/getConsentState.test.js
+++ b/libs/@guardian/consent-manager/src/usnat/getConsentState.test.js
@@ -1,9 +1,13 @@
-import usnatDataCanSell from './__fixtures__/api.getUserConsents.canSell.json';
-import usnatDataDoNotSell from './__fixtures__/api.getUserConsents.doNotSell.json';
-import { getUsnatData } from './api.ts';
-import { getConsentState } from './getConsentState.ts';
+import { jest } from '@jest/globals';
+import usnatDataCanSell from './__fixtures__/api.getUserConsents.canSell.json' with { type: 'json' };
+import usnatDataDoNotSell from './__fixtures__/api.getUserConsents.doNotSell.json' with { type: 'json' };
 
-jest.mock('./api');
+jest.unstable_mockModule('./api', () => ({
+	getUsnatData: jest.fn(),
+}));
+
+const { getUsnatData } = await import('./api.ts');
+const { getConsentState } = await import('./getConsentState.ts');
 
 describe('getConsentState', () => {
 	beforeEach(() => {

--- a/libs/@guardian/consent-manager/src/vendorDataManager.test.ts
+++ b/libs/@guardian/consent-manager/src/vendorDataManager.test.ts
@@ -1,36 +1,19 @@
-import { removeCookie } from '@guardian/libs';
-import { storage } from '@guardian/libs';
-import { onConsentChange } from './onConsentChange';
+import { jest } from '@jest/globals';
 import type { ConsentState, OnConsentChangeCallback } from './types';
 import type { TCFv2ConsentState } from './types/tcfv2';
-import { initVendorDataManager } from './vendorDataManager';
-import {
-	deprecatedVendorStorageIds,
-	vendorStorageIds,
-} from './vendorStorageIds';
 
-jest.mock('./onConsentChange');
+jest.unstable_mockModule('./onConsentChange', () => ({
+	onConsentChange: jest.fn(),
+}));
 
-const tcfv2ConsentState: TCFv2ConsentState = {
-	consents: { 1: true },
-	eventStatus: 'tcloaded',
-	vendorConsents: {
-		'5fa51b29a228638b4a1980e4': true, // ipsos
-		'5eff0d77969bfa03746427eb': false, // permutive
-	},
-	addtlConsent: 'xyz',
-	gdprApplies: true,
-	tcString: 'YAAA',
-};
-
-jest.mock('./vendors', () => ({
+jest.unstable_mockModule('./vendors', () => ({
 	VendorIDs: {
 		permutive: ['5eff0d77969bfa03746427eb'],
 		ipsos: ['5fa51b29a228638b4a1980e4'],
 	},
 }));
 
-jest.mock('./vendorStorageIds', () => ({
+jest.unstable_mockModule('./vendorStorageIds', () => ({
 	vendorStorageIds: {
 		permutive: {
 			cookies: ['permutiveCookie1', 'permutiveCookie2'],
@@ -50,12 +33,7 @@ jest.mock('./vendorStorageIds', () => ({
 	},
 }));
 
-const mockOnConsentChange = (consentState: ConsentState) =>
-	(onConsentChange as jest.Mock).mockImplementation(
-		(cb: OnConsentChangeCallback) => cb(consentState),
-	);
-
-jest.mock('@guardian/libs', () => ({
+jest.unstable_mockModule('@guardian/libs', () => ({
 	removeCookie: jest.fn(),
 	storage: {
 		local: {
@@ -66,6 +44,29 @@ jest.mock('@guardian/libs', () => ({
 		},
 	},
 }));
+
+const { onConsentChange } = await import('./onConsentChange');
+const { removeCookie, storage } = await import('@guardian/libs');
+const { initVendorDataManager } = await import('./vendorDataManager');
+const { vendorStorageIds, deprecatedVendorStorageIds } =
+	await import('./vendorStorageIds');
+
+const tcfv2ConsentState: TCFv2ConsentState = {
+	consents: { 1: true },
+	eventStatus: 'tcloaded',
+	vendorConsents: {
+		'5fa51b29a228638b4a1980e4': true, // ipsos
+		'5eff0d77969bfa03746427eb': false, // permutive
+	},
+	addtlConsent: 'xyz',
+	gdprApplies: true,
+	tcString: 'YAAA',
+};
+
+const mockOnConsentChange = (consentState: ConsentState) =>
+	jest
+		.mocked(onConsentChange)
+		.mockImplementation((cb: OnConsentChangeCallback) => cb(consentState));
 
 describe('initVendorDataManager', () => {
 	it('should remove cookies and localStorage data only for vendors that the user has not consented to', () => {

--- a/libs/@guardian/core-web-vitals/jest.dist.setup.js
+++ b/libs/@guardian/core-web-vitals/jest.dist.setup.js
@@ -1,5 +1,6 @@
 // Mock `./src/index` with whatever `package.json` points at in dist.
 // This means we can run the unit tests against `dist` instead.
+import { jest } from '@jest/globals';
 
 import * as dist from '.';
 

--- a/libs/@guardian/core-web-vitals/package.json
+++ b/libs/@guardian/core-web-vitals/package.json
@@ -31,12 +31,13 @@
 	"devDependencies": {
 		"@guardian/eslint-config": "workspace:*",
 		"@guardian/libs": "32.0.0",
+		"@jest/globals": "30.4.1",
 		"@types/jest": "30.0.0",
 		"eslint": "9.39.1",
 		"jest": "30.4.2",
 		"jest-environment-jsdom": "30.4.1",
 		"rollup": "4.60.0",
-		"ts-jest": "29.4.0",
+		"ts-jest": "29.4.10",
 		"tslib": "2.8.1",
 		"typescript": "5.9.3",
 		"web-vitals": "4.2.1",
@@ -106,7 +107,7 @@
 			"output": []
 		},
 		"test": {
-			"command": "jest",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
 			"dependencies": [
 				"__deps__"
 			],
@@ -135,7 +136,7 @@
 			"output": []
 		},
 		"verify-dist": {
-			"command": "jest --setupFilesAfterEnv ./jest.dist.setup.js",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --setupFilesAfterEnv ./jest.dist.setup.js",
 			"dependencies": [
 				"build"
 			],

--- a/libs/@guardian/core-web-vitals/src/index.test.ts
+++ b/libs/@guardian/core-web-vitals/src/index.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import type {
 	CLSMetricWithAttribution,
 	FCPMetric,
@@ -7,9 +8,6 @@ import type {
 	TTFBMetric,
 } from 'web-vitals/attribution';
 import type { CoreWebVitalsPayload } from './@types/CoreWebVitalsPayload';
-import { _, bypassCoreWebVitalsSampling, initCoreWebVitals } from './index';
-
-const { coreWebVitalsPayload, reset } = _;
 
 const defaultCoreWebVitalsPayload = {
 	page_view_id: '123456',
@@ -30,7 +28,7 @@ const defaultCoreWebVitalsPayload = {
 const browserId = defaultCoreWebVitalsPayload.browser_id;
 const pageViewId = defaultCoreWebVitalsPayload.page_view_id;
 
-jest.mock('web-vitals/attribution', () => ({
+jest.unstable_mockModule('web-vitals/attribution', () => ({
 	onCLS: (onReport: (metric: CLSMetricWithAttribution) => void) => {
 		onReport({
 			value: defaultCoreWebVitalsPayload.cls,
@@ -122,7 +120,11 @@ jest.mock('web-vitals/attribution', () => ({
 	},
 }));
 
-const mockBeacon = jest.fn().mockReturnValue(true);
+const { _, bypassCoreWebVitalsSampling, initCoreWebVitals } =
+	await import('./index');
+const { coreWebVitalsPayload, reset } = _;
+
+const mockBeacon = jest.fn<typeof navigator.sendBeacon>().mockReturnValue(true);
 navigator.sendBeacon = mockBeacon;
 
 const mockConsoleWarn = jest

--- a/libs/@guardian/identity-auth-frontend/jest.dist.setup.js
+++ b/libs/@guardian/identity-auth-frontend/jest.dist.setup.js
@@ -1,6 +1,6 @@
 // Mock `./src/index` with whatever `package.json` points at in dist.
 // This means we can run the unit tests against `dist` instead.
-
+import { jest } from '@jest/globals';
 import * as dist from '.';
 
 jest.mock('./src/index', () => dist);

--- a/libs/@guardian/identity-auth-frontend/package.json
+++ b/libs/@guardian/identity-auth-frontend/package.json
@@ -33,13 +33,14 @@
 		"@guardian/eslint-config": "workspace:*",
 		"@guardian/identity-auth": "17.0.0",
 		"@guardian/libs": "32.0.0",
+		"@jest/globals": "30.4.1",
 		"@types/jest": "30.0.0",
 		"eslint": "9.39.1",
 		"jest": "30.4.2",
 		"jest-environment-jsdom": "30.4.1",
 		"jest-fetch-mock": "3.0.3",
 		"rollup": "4.60.0",
-		"ts-jest": "29.4.0",
+		"ts-jest": "29.4.10",
 		"tslib": "2.8.1",
 		"typescript": "5.9.3",
 		"wireit": "0.14.12"
@@ -108,7 +109,7 @@
 			"output": []
 		},
 		"test": {
-			"command": "jest",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
 			"dependencies": [
 				"__deps__"
 			],
@@ -137,7 +138,7 @@
 			"output": []
 		},
 		"verify-dist": {
-			"command": "jest --setupFilesAfterEnv ./jest.dist.setup.js",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --setupFilesAfterEnv ./jest.dist.setup.js",
 			"dependencies": [
 				"build"
 			],

--- a/libs/@guardian/identity-auth-frontend/src/index.test.ts
+++ b/libs/@guardian/identity-auth-frontend/src/index.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { getIdentityAuth } from './index';
 
 jest.mock('@guardian/identity-auth');

--- a/libs/@guardian/identity-auth/jest.dist.setup.js
+++ b/libs/@guardian/identity-auth/jest.dist.setup.js
@@ -1,6 +1,6 @@
 // Mock `./src/index` with whatever `package.json` points at in dist.
 // This means we can run the unit tests against `dist` instead.
-
+import { jest } from '@jest/globals';
 import * as dist from '.';
 
 jest.mock('./src/index', () => dist);

--- a/libs/@guardian/identity-auth/package.json
+++ b/libs/@guardian/identity-auth/package.json
@@ -32,13 +32,14 @@
 	"devDependencies": {
 		"@guardian/eslint-config": "workspace:*",
 		"@guardian/libs": "32.0.0",
+		"@jest/globals": "30.4.1",
 		"@types/jest": "30.0.0",
 		"eslint": "9.39.1",
 		"jest": "30.4.2",
 		"jest-environment-jsdom": "30.4.1",
 		"jest-fetch-mock": "3.0.3",
 		"rollup": "4.60.0",
-		"ts-jest": "29.4.0",
+		"ts-jest": "29.4.10",
 		"tslib": "2.8.1",
 		"typescript": "5.9.3",
 		"wireit": "0.14.12"
@@ -106,7 +107,7 @@
 			"output": []
 		},
 		"test": {
-			"command": "jest",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
 			"dependencies": [
 				"__deps__"
 			],
@@ -135,7 +136,7 @@
 			"output": []
 		},
 		"verify-dist": {
-			"command": "jest --setupFilesAfterEnv ./jest.dist.setup.js",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --setupFilesAfterEnv ./jest.dist.setup.js",
 			"dependencies": [
 				"build"
 			],

--- a/libs/@guardian/identity-auth/src/__tests__/authState.test.ts
+++ b/libs/@guardian/identity-auth/src/__tests__/authState.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import type { AccessToken, IDToken } from '../@types/Token';
 import { AuthStateManager } from '../authState';
 import { Emitter } from '../emitter';

--- a/libs/@guardian/identity-auth/src/__tests__/autoRenew.test.ts
+++ b/libs/@guardian/identity-auth/src/__tests__/autoRenew.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method -- jest mocks */
-
+import { jest } from '@jest/globals';
 import type { IdentityAuthOptions } from '../@types/OAuth';
 import { AuthStateManager } from '../authState';
 import { AutoRenewService } from '../autoRenew';
@@ -87,9 +87,11 @@ describe('IdentityAuth#AutoRenewService', () => {
 			authStateManager,
 		);
 
-		authStateManager.getAuthState = jest.fn().mockReturnValue({
-			isAuthenticated: false,
-		});
+		authStateManager.getAuthState = jest
+			.fn<typeof authStateManager.getAuthState>()
+			.mockReturnValue({
+				isAuthenticated: false,
+			} as ReturnType<typeof authStateManager.getAuthState>);
 
 		autoRenewService.start();
 
@@ -131,14 +133,16 @@ describe('IdentityAuth#AutoRenewService', () => {
 			authStateManager,
 		);
 
-		authStateManager.getAuthState = jest.fn().mockReturnValue({
-			accessToken: {
-				expiresAt: 0,
-			},
-			isAuthenticated: true,
-		});
+		authStateManager.getAuthState = jest
+			.fn<typeof authStateManager.getAuthState>()
+			.mockReturnValue({
+				accessToken: {
+					expiresAt: 0,
+				},
+				isAuthenticated: true,
+			} as ReturnType<typeof authStateManager.getAuthState>);
 
-		emitter.emit = jest.fn();
+		emitter.emit = jest.fn<typeof emitter.emit>();
 
 		autoRenewService.start();
 
@@ -169,14 +173,16 @@ describe('IdentityAuth#AutoRenewService', () => {
 			authStateManager,
 		);
 
-		authStateManager.getAuthState = jest.fn().mockReturnValue({
-			accessToken: {
-				expiresAt: 0,
-			},
-			isAuthenticated: true,
-		});
+		authStateManager.getAuthState = jest
+			.fn<typeof authStateManager.getAuthState>()
+			.mockReturnValue({
+				accessToken: {
+					expiresAt: 0,
+				},
+				isAuthenticated: true,
+			} as ReturnType<typeof authStateManager.getAuthState>);
 
-		emitter.emit = jest.fn();
+		emitter.emit = jest.fn<typeof emitter.emit>();
 
 		autoRenewService.start();
 
@@ -216,18 +222,18 @@ describe('IdentityAuth#AutoRenewService', () => {
 		);
 
 		authStateManager.getAuthState = jest
-			.fn()
+			.fn<typeof authStateManager.getAuthState>()
 			.mockReturnValueOnce({
 				accessToken: {
 					expiresAt: 0,
 				},
 				isAuthenticated: true,
-			})
+			} as ReturnType<typeof authStateManager.getAuthState>)
 			.mockReturnValueOnce({
 				isAuthenticated: false,
-			});
+			} as ReturnType<typeof authStateManager.getAuthState>);
 
-		emitter.emit = jest.fn();
+		emitter.emit = jest.fn<typeof emitter.emit>();
 
 		autoRenewService.start();
 

--- a/libs/@guardian/identity-auth/src/__tests__/cookieRefresh.test.ts
+++ b/libs/@guardian/identity-auth/src/__tests__/cookieRefresh.test.ts
@@ -1,21 +1,24 @@
 /* eslint-disable @typescript-eslint/unbound-method -- jest mocks */
-import * as libs from '@guardian/libs';
-import { cookieRefreshIfRequired } from '../cookieRefresh';
+import { jest } from '@jest/globals';
 
-// jest is really not good with es modules :(
-jest.mock(
-	'@guardian/libs',
-	() =>
-		({
-			__esModule: true,
-			...jest.requireActual('@guardian/libs'),
-		}) as typeof libs,
-);
+jest.unstable_mockModule('@guardian/libs', () => ({
+	getCookie: jest.fn(),
+	storage: {
+		local: {
+			set: jest.fn(),
+			get: jest.fn(),
+			isAvailable: jest.fn(),
+		},
+	},
+}));
 
-const mockedSetLocal = jest.spyOn(libs.storage.local, 'set');
-const mockedGetLocal = jest.spyOn(libs.storage.local, 'get');
-const mockedLocalIsAvailable = jest.spyOn(libs.storage.local, 'isAvailable');
-const mockedGetCookie = jest.spyOn(libs, 'getCookie');
+const libs = await import('@guardian/libs');
+const { cookieRefreshIfRequired } = await import('../cookieRefresh');
+
+const mockedSetLocal = jest.mocked(libs.storage.local.set);
+const mockedGetLocal = jest.mocked(libs.storage.local.get);
+const mockedLocalIsAvailable = jest.mocked(libs.storage.local.isAvailable);
+const mockedGetCookie = jest.mocked(libs.getCookie);
 
 describe('IdentityAuth#CookieRefresh', () => {
 	const { location } = window;

--- a/libs/@guardian/identity-auth/src/__tests__/emitter.test.ts
+++ b/libs/@guardian/identity-auth/src/__tests__/emitter.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { Emitter } from '../emitter';
 
 describe('IdentityAuth#Emitter', () => {

--- a/libs/@guardian/identity-auth/src/__tests__/identityAuth.test.ts
+++ b/libs/@guardian/identity-auth/src/__tests__/identityAuth.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import type { AccessToken, CustomClaims, IDToken } from '../@types/Token';
 import { IdentityAuth } from '../index';
 

--- a/libs/@guardian/identity-auth/src/__tests__/token.test.ts
+++ b/libs/@guardian/identity-auth/src/__tests__/token.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import fetchMock from 'jest-fetch-mock';
 import type {
 	AuthorizeParams,
@@ -45,7 +46,7 @@ describe('IdentityAuth#Token', () => {
 	});
 
 	it('should perform auth code flow in iframe and return OAuthAuthorizeResponse', async () => {
-		jest.spyOn(TokenModule, 'addPostMessageListener').mockImplementation(() =>
+		jest.spyOn(TokenModule._, 'addPostMessageListener').mockImplementation(() =>
 			Promise.resolve({
 				code: 'code',
 				state: 'state',
@@ -53,7 +54,7 @@ describe('IdentityAuth#Token', () => {
 		);
 
 		jest
-			.spyOn(TokenModule, 'loadFrame')
+			.spyOn(TokenModule._, 'loadFrame')
 			.mockReturnValue(document.createElement('iframe'));
 
 		const result = await TokenModule.performAuthCodeFlowIframe(
@@ -69,7 +70,7 @@ describe('IdentityAuth#Token', () => {
 	});
 
 	it('should perform auth code flow in iframe and return OAuthAuthorizeResponseError', async () => {
-		jest.spyOn(TokenModule, 'addPostMessageListener').mockImplementation(() =>
+		jest.spyOn(TokenModule._, 'addPostMessageListener').mockImplementation(() =>
 			Promise.resolve({
 				state: 'state',
 				error: 'error',
@@ -78,7 +79,7 @@ describe('IdentityAuth#Token', () => {
 		);
 
 		jest
-			.spyOn(TokenModule, 'loadFrame')
+			.spyOn(TokenModule._, 'loadFrame')
 			.mockReturnValue(document.createElement('iframe'));
 
 		const result = await TokenModule.performAuthCodeFlowIframe(

--- a/libs/@guardian/identity-auth/src/__tests__/tokenManager.test.ts
+++ b/libs/@guardian/identity-auth/src/__tests__/tokenManager.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method -- jest mocks */
 import { storage } from '@guardian/libs';
+import { jest } from '@jest/globals';
 import type {
 	AccessToken,
 	AccessTokenStorage,

--- a/libs/@guardian/identity-auth/src/token.ts
+++ b/libs/@guardian/identity-auth/src/token.ts
@@ -751,6 +751,12 @@ export const loadFrame = (url: string) => {
 	return document.body.appendChild(frame);
 };
 
+/** @internal - exported for testing spyOn only */
+export const _ = {
+	addPostMessageListener,
+	loadFrame,
+};
+
 /**
  * @name performAuthCodeFlowIframe
  * @description Performs the authorization code flow with PKCE using an iframe, and returns the AuthorizationResponse
@@ -769,12 +775,12 @@ export const performAuthCodeFlowIframe = async (
 	const searchParams = new URLSearchParams(authorizeParams);
 
 	// create the postMessage listener for the iframe
-	const postMessageListener = addPostMessageListener(
+	const postMessageListener = _.addPostMessageListener(
 		options,
 		authorizeParams.state,
 	);
 	// load the iframe with the authorize url
-	const iframe = loadFrame(
+	const iframe = _.loadFrame(
 		`${oauthUrls.authorizeUrl}?${searchParams.toString()}`,
 	);
 

--- a/libs/@guardian/libs/jest.dist.setup.js
+++ b/libs/@guardian/libs/jest.dist.setup.js
@@ -1,6 +1,6 @@
 // Mock `./src/index` with whatever `package.json` points at in dist.
 // This means we can run the unit tests against `dist` instead.
-
+import { jest } from '@jest/globals';
 import * as dist from '.';
 
 jest.mock('./src/index', () => dist);

--- a/libs/@guardian/libs/package.json
+++ b/libs/@guardian/libs/package.json
@@ -36,6 +36,7 @@
 	},
 	"devDependencies": {
 		"@guardian/eslint-config": "workspace:*",
+		"@jest/globals": "30.4.1",
 		"@playwright/test": "1.60.0",
 		"@types/jest": "30.0.0",
 		"@types/wcag-contrast": "3.0.3",
@@ -45,7 +46,7 @@
 		"jest-fetch-mock": "3.0.3",
 		"mockdate": "3.0.5",
 		"rollup": "4.60.0",
-		"ts-jest": "29.4.0",
+		"ts-jest": "29.4.10",
 		"tslib": "2.8.1",
 		"tsx": "4.22.1",
 		"typescript": "5.9.3",
@@ -133,7 +134,7 @@
 			]
 		},
 		"test": {
-			"command": "jest",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
 			"files": [
 				"**",
 				"../../../configs/jest.*",
@@ -159,7 +160,7 @@
 			"output": []
 		},
 		"verify-dist": {
-			"command": "jest -c=./jest.dist.config.js --setupFilesAfterEnv ./jest.dist.setup.js",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest -c=./jest.dist.config.js --setupFilesAfterEnv ./jest.dist.setup.js",
 			"dependencies": [
 				"build"
 			],

--- a/libs/@guardian/libs/src/cookies/cookies.test.ts
+++ b/libs/@guardian/libs/src/cookies/cookies.test.ts
@@ -1,9 +1,16 @@
+import { jest } from '@jest/globals';
 import MockDate from 'mockdate';
-import { getCookie } from './getCookie';
-import * as getCookieValues from './getCookieValues';
-import { removeCookie } from './removeCookie';
-import { setCookie } from './setCookie';
-import { setSessionCookie } from './setSessionCookie';
+import { getCookieValues as realGetCookieValues } from './getCookieValues';
+
+jest.unstable_mockModule('./getCookieValues', () => ({
+	getCookieValues: jest.fn(realGetCookieValues),
+}));
+
+const { getCookie } = await import('./getCookie');
+const { setCookie } = await import('./setCookie');
+const { setSessionCookie } = await import('./setSessionCookie');
+const { removeCookie } = await import('./removeCookie');
+const { getCookieValues } = await import('./getCookieValues');
 
 describe('cookies', () => {
 	let cookieValue = '';
@@ -160,7 +167,8 @@ describe('cookies', () => {
 			daysToLive: 1,
 			isCrossSubdomain: true,
 		});
-		const spy = jest.spyOn(getCookieValues, 'getCookieValues');
+		const getCookieValuesSpy = jest.mocked(getCookieValues);
+
 		expect(
 			getCookie({
 				name: 'GU_geo_country',
@@ -173,7 +181,7 @@ describe('cookies', () => {
 				shouldMemoize: true,
 			}),
 		).toEqual('GB');
-		expect(spy).toHaveBeenCalledTimes(1);
+		expect(getCookieValuesSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it('gets a memoized cookie with days to live', () => {
@@ -182,7 +190,9 @@ describe('cookies', () => {
 			value: 'IT',
 			daysToLive: 1,
 		});
-		const spy = jest.spyOn(getCookieValues, 'getCookieValues');
+
+		const getCookieValuesSpy = jest.mocked(getCookieValues);
+
 		expect(
 			getCookie({
 				name: 'GU_geo_country',
@@ -201,8 +211,7 @@ describe('cookies', () => {
 				shouldMemoize: true,
 			}),
 		).toEqual('IT');
-		// for some reason the spy is been called 1 additional time although that's not happening in reality
-		expect(spy).not.toHaveBeenCalledTimes(2);
+		expect(getCookieValuesSpy).not.toHaveBeenCalledTimes(2);
 	});
 
 	it('re-sets a memoized cookie', () => {

--- a/libs/@guardian/libs/src/locale/getLocale.test.ts
+++ b/libs/@guardian/libs/src/locale/getLocale.test.ts
@@ -1,10 +1,17 @@
+import { jest } from '@jest/globals';
 import fetchMock from 'jest-fetch-mock';
-import * as getCookieForSpy from '../cookies/getCookie';
-import { getCookie } from '../cookies/getCookie';
+import { getCookie as realGetCookie } from '../cookies/getCookie';
 import { removeCookie } from '../cookies/removeCookie';
 import { setSessionCookie } from '../cookies/setSessionCookie';
 import { storage } from '../storage/storage';
-import { __resetCachedValue, getLocale } from './getLocale';
+
+jest.unstable_mockModule('../cookies/getCookie', () => ({
+	getCookie: jest.fn(realGetCookie),
+}));
+
+const { getCookie } = await import('../cookies/getCookie');
+const getCookieSpy = jest.mocked(getCookie);
+const { __resetCachedValue, getLocale } = await import('./getLocale');
 
 const KEY = 'GU_geo_country';
 const KEY_OVERRIDE = 'gu.geo.override';
@@ -61,14 +68,12 @@ describe('getLocale', () => {
 	});
 
 	it('uses the cached value if available', async () => {
-		const spy = jest.spyOn(getCookieForSpy, 'getCookie');
-
 		setSessionCookie({ name: KEY, value: 'CY' });
 		const locale = await getLocale();
 		const locale2 = await getLocale();
 
 		expect(locale).toBe(locale2);
-		expect(spy).toHaveBeenCalledTimes(1);
+		expect(getCookieSpy).toHaveBeenCalledTimes(1);
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/libs/@guardian/libs/src/logger/logger.test.ts
+++ b/libs/@guardian/libs/src/logger/logger.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { hex } from 'wcag-contrast';
 import { storage } from '../storage/storage';
 import type { Subscription } from './@types/logger';

--- a/libs/@guardian/libs/src/storage/storage.test.ts
+++ b/libs/@guardian/libs/src/storage/storage.test.ts
@@ -1,6 +1,7 @@
+import { jest } from '@jest/globals';
 import { storage } from './storage';
 
-function functionThatThrowsAnError() {
+function functionThatThrowsAnError(): never {
 	throw new Error('bang');
 }
 
@@ -12,12 +13,12 @@ describe.each([
 	[LOCAL, storage[LOCAL], globalThis.localStorage],
 	[SESSION, storage[SESSION], globalThis.sessionStorage],
 ])('storage.%s', (name, implementation, native) => {
-	let getSpy: jest.SpyInstance;
-	let setSpy: jest.SpyInstance;
+	let getSpy: jest.SpiedFunction<Storage['getItem']>;
+	let setSpy: jest.SpiedFunction<Storage['setItem']>;
 
 	beforeEach(() => {
-		getSpy = jest.spyOn(native.__proto__, 'getItem');
-		setSpy = jest.spyOn(native.__proto__, 'setItem');
+		getSpy = jest.spyOn(Object.getPrototypeOf(native) as Storage, 'getItem');
+		setSpy = jest.spyOn(Object.getPrototypeOf(native) as Storage, 'setItem');
 		jest.resetModules();
 		native.clear();
 	});

--- a/libs/@guardian/react-crossword/jest.dist.setup.js
+++ b/libs/@guardian/react-crossword/jest.dist.setup.js
@@ -1,5 +1,6 @@
 // Mock `src/index` with whatever the dist `package.json` points at.
 // This means we can run `src/index.test.ts` against `dist` instead.
+import { jest } from '@jest/globals';
 
 // @ts-ignore
 import * as reactCrossword from '.';

--- a/libs/@guardian/react-crossword/package.json
+++ b/libs/@guardian/react-crossword/package.json
@@ -38,6 +38,7 @@
 		"@guardian/eslint-config": "workspace:*",
 		"@guardian/libs": "32.0.0",
 		"@guardian/source": "12.2.1",
+		"@jest/globals": "30.4.1",
 		"@storybook/addon-a11y": "10.4.0",
 		"@storybook/addon-docs": "10.4.0",
 		"@storybook/addon-links": "10.4.0",
@@ -54,7 +55,7 @@
 		"react-dom": "18.2.0",
 		"rollup": "4.60.0",
 		"storybook": "10.4.0",
-		"ts-jest": "29.4.0",
+		"ts-jest": "29.4.10",
 		"tslib": "2.8.1",
 		"typescript": "5.9.3",
 		"wireit": "0.14.12"
@@ -136,7 +137,7 @@
 			"output": []
 		},
 		"test": {
-			"command": "jest",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
 			"dependencies": [
 				"build"
 			],
@@ -165,7 +166,7 @@
 			"output": []
 		},
 		"verify-dist": {
-			"command": "jest --setupFilesAfterEnv ./jest.dist.setup.js",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --setupFilesAfterEnv ./jest.dist.setup.js",
 			"dependencies": [
 				"build"
 			],

--- a/libs/@guardian/source-development-kitchen/jest.dist.setup.js
+++ b/libs/@guardian/source-development-kitchen/jest.dist.setup.js
@@ -1,5 +1,6 @@
 // Mock `src/index` with whatever the dist `package.json` points at.
 // This means we can run `src/index.test.ts` against `dist` instead.
+import { jest } from '@jest/globals';
 
 // @ts-ignore
 import * as reactComponents from './react-components';

--- a/libs/@guardian/source-development-kitchen/package.json
+++ b/libs/@guardian/source-development-kitchen/package.json
@@ -34,6 +34,7 @@
 		"@guardian/eslint-config": "workspace:*",
 		"@guardian/libs": "32.0.0",
 		"@guardian/source": "12.2.1",
+		"@jest/globals": "30.4.1",
 		"@storybook/addon-a11y": "10.4.0",
 		"@storybook/addon-docs": "10.4.0",
 		"@storybook/addon-links": "10.4.0",
@@ -47,7 +48,7 @@
 		"react-dom": "18.2.0",
 		"rollup": "4.60.0",
 		"storybook": "10.4.0",
-		"ts-jest": "29.4.0",
+		"ts-jest": "29.4.10",
 		"tslib": "2.8.1",
 		"typescript": "5.9.3",
 		"wireit": "0.14.12"
@@ -140,7 +141,7 @@
 			"output": []
 		},
 		"test": {
-			"command": "jest",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
 			"dependencies": [
 				"__deps__"
 			],
@@ -169,7 +170,7 @@
 			"output": []
 		},
 		"verify-dist": {
-			"command": "jest --setupFilesAfterEnv ./jest.dist.setup.js",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --setupFilesAfterEnv ./jest.dist.setup.js",
 			"dependencies": [
 				"build"
 			],

--- a/libs/@guardian/source/jest.dist.setup.js
+++ b/libs/@guardian/source/jest.dist.setup.js
@@ -1,5 +1,6 @@
 // Mock `src/index` with whatever the dist `package.json` points at.
 // This means we can run `src/index.test.ts` against `dist` instead.
+import { jest } from '@jest/globals';
 
 // Register our custom Jest matcher.
 import './lib/jest-matchers/toBeValidCSS';

--- a/libs/@guardian/source/package.json
+++ b/libs/@guardian/source/package.json
@@ -51,6 +51,7 @@
 		"@emotion/react": "11.11.4",
 		"@guardian/eslint-config": "workspace:*",
 		"@guardian/libs": "workspace:*",
+		"@jest/globals": "30.4.1",
 		"@storybook/addon-a11y": "10.4.0",
 		"@storybook/addon-docs": "10.4.0",
 		"@storybook/addon-links": "10.4.0",
@@ -73,7 +74,7 @@
 		"react-dom": "18.2.0",
 		"rollup": "4.60.0",
 		"storybook": "10.4.0",
-		"ts-jest": "29.4.0",
+		"ts-jest": "29.4.10",
 		"tslib": "2.8.1",
 		"tsx": "4.22.1",
 		"typescript": "5.9.3",
@@ -170,7 +171,7 @@
 			"output": []
 		},
 		"test": {
-			"command": "jest",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest",
 			"dependencies": [
 				"build"
 			],
@@ -199,7 +200,7 @@
 			"output": []
 		},
 		"verify-dist": {
-			"command": "jest --setupFilesAfterEnv ./jest.dist.setup.js",
+			"command": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --setupFilesAfterEnv ./jest.dist.setup.js",
 			"dependencies": [
 				"build"
 			],

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"prettier": "3.8.0",
 		"sort-package-json": "3.6.0",
 		"syncpack": "13.0.0",
+		"ts-jest": "29.4.10",
 		"typescript": "5.9.3",
 		"wireit": "0.14.12"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       syncpack:
         specifier: 13.0.0
         version: 13.0.0(typescript@5.9.3)
+      ts-jest:
+        specifier: 29.4.10
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.11.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -146,13 +149,16 @@ importers:
     dependencies:
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@24.11.0)(babel-plugin-macros@3.1.0)
+        version: 30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0)
 
   libs/@guardian/ab-core:
     devDependencies:
       '@guardian/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -161,7 +167,7 @@ importers:
         version: 9.39.1
       jest:
         specifier: 30.4.2
-        version: 30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0)
+        version: 30.4.2(@types/node@24.11.0)(babel-plugin-macros@3.1.0)
       jest-environment-jsdom:
         specifier: 30.4.1
         version: 30.4.1
@@ -169,8 +175,8 @@ importers:
         specifier: 4.60.0
         version: 4.60.0
       ts-jest:
-        specifier: 29.4.0
-        version: 29.4.0(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        specifier: 29.4.10
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.11.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -189,6 +195,9 @@ importers:
       '@guardian/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
       '@testing-library/react':
         specifier: 16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -220,8 +229,8 @@ importers:
         specifier: 4.60.0
         version: 4.60.0
       ts-jest:
-        specifier: 29.4.0
-        version: 29.4.0(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        specifier: 29.4.10
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -265,6 +274,9 @@ importers:
       '@guardian/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
@@ -293,8 +305,8 @@ importers:
         specifier: 4.60.0
         version: 4.60.0
       ts-jest:
-        specifier: 29.4.0
-        version: 29.4.0(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        specifier: 29.4.10
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -319,6 +331,9 @@ importers:
       '@guardian/libs':
         specifier: 32.0.0
         version: link:../libs
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -335,8 +350,8 @@ importers:
         specifier: 4.60.0
         version: 4.60.0
       ts-jest:
-        specifier: 29.4.0
-        version: 29.4.0(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        specifier: 29.4.10
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -407,6 +422,9 @@ importers:
       '@guardian/libs':
         specifier: 32.0.0
         version: link:../libs
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -426,8 +444,8 @@ importers:
         specifier: 4.60.0
         version: 4.60.0
       ts-jest:
-        specifier: 29.4.0
-        version: 29.4.0(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        specifier: 29.4.10
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -449,6 +467,9 @@ importers:
       '@guardian/libs':
         specifier: 32.0.0
         version: link:../libs
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -468,8 +489,8 @@ importers:
         specifier: 4.60.0
         version: 4.60.0
       ts-jest:
-        specifier: 29.4.0
-        version: 29.4.0(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        specifier: 29.4.10
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -489,6 +510,9 @@ importers:
       '@guardian/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
@@ -517,8 +541,8 @@ importers:
         specifier: 4.60.0
         version: 4.60.0
       ts-jest:
-        specifier: 29.4.0
-        version: 29.4.0(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        specifier: 29.4.10
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -595,6 +619,9 @@ importers:
       '@guardian/source':
         specifier: 12.2.1
         version: link:../source
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
       '@storybook/addon-a11y':
         specifier: 10.4.0
         version: 10.4.0(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@18.2.79)(prettier@3.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -644,8 +671,8 @@ importers:
         specifier: 10.4.0
         version: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@18.2.79)(prettier@3.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       ts-jest:
-        specifier: 29.4.0
-        version: 29.4.0(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        specifier: 29.4.10
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -686,6 +713,9 @@ importers:
       '@guardian/libs':
         specifier: workspace:*
         version: link:../libs
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
       '@storybook/addon-a11y':
         specifier: 10.4.0
         version: 10.4.0(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@18.2.79)(prettier@3.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -753,8 +783,8 @@ importers:
         specifier: 10.4.0
         version: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@18.2.79)(prettier@3.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       ts-jest:
-        specifier: 29.4.0
-        version: 29.4.0(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        specifier: 29.4.10
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -782,6 +812,9 @@ importers:
       '@guardian/source':
         specifier: 12.2.1
         version: link:../source
+      '@jest/globals':
+        specifier: 30.4.1
+        version: 30.4.1
       '@storybook/addon-a11y':
         specifier: 10.4.0
         version: 10.4.0(storybook@10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@18.2.79)(prettier@3.8.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -822,8 +855,8 @@ importers:
         specifier: 10.4.0
         version: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@18.2.79)(prettier@3.8.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       ts-jest:
-        specifier: 29.4.0
-        version: 29.4.0(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        specifier: 29.4.10
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -3375,9 +3408,6 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
-  async@3.2.6:
-    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -3917,11 +3947,6 @@ packages:
   effect@3.20.1:
     resolution: {integrity: sha512-Jl4IbaJQqerCRA2k1bAuz6k1IkCjeGTUyIq5zgCza+QN1v7/8EIKpR49MRhjI+7Ye96WjclsOQyYYdiLySViMA==}
 
-  ejs@3.1.10:
-    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-
   electron-to-chromium@1.5.249:
     resolution: {integrity: sha512-5vcfL3BBe++qZ5kuFhD/p8WOM1N9m3nwvJPULJx+4xf2usSlZFJ0qoNYO2fOX4hi3ocuDcmDobtA+5SFr4OmBg==}
 
@@ -4256,9 +4281,6 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  filelist@1.0.4:
-    resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -4441,6 +4463,11 @@ packages:
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -4832,11 +4859,6 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
-  jake@10.9.4:
-    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   jest-changed-files@30.4.1:
     resolution: {integrity: sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==}
@@ -5473,6 +5495,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
@@ -6137,11 +6162,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
@@ -6526,8 +6546,8 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
-  ts-jest@29.4.0:
-    resolution: {integrity: sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==}
+  ts-jest@29.4.10:
+    resolution: {integrity: sha512-vMTlTTtvz5aKZgzOoc7DQ5TzAL2fCzl8JnG1+ZpwjQa/g0xLlwE44yQ+1Cao9ZP1xVv9y5g34IFXEiqGOGFBUA==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -6538,7 +6558,7 @@ packages:
       esbuild: '*'
       jest: ^29.0.0 || ^30.0.0
       jest-util: ^29.0.0 || ^30.0.0
-      typescript: '>=4.3 <6'
+      typescript: '>=4.3 <7'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -6624,6 +6644,11 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
 
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
@@ -7024,6 +7049,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   wrap-ansi@10.0.0:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
@@ -7691,7 +7719,7 @@ snapshots:
   '@effect/schema@0.71.1(effect@3.20.1)':
     dependencies:
       effect: 3.20.1
-      fast-check: 3.21.0
+      fast-check: 3.23.2
 
   '@emmetio/abbreviation@2.3.3':
     dependencies:
@@ -9955,8 +9983,6 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  async@3.2.6: {}
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -10490,10 +10516,6 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
-  ejs@3.1.10:
-    dependencies:
-      jake: 10.9.4
-
   electron-to-chromium@1.5.249: {}
 
   electron-to-chromium@1.5.286: {}
@@ -11005,10 +11027,6 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  filelist@1.0.4:
-    dependencies:
-      minimatch: 10.2.5
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -11212,6 +11230,15 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.4
       uncrypto: 0.1.3
+
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
 
   has-bigints@1.1.0: {}
 
@@ -11645,12 +11672,6 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-
-  jake@10.9.4:
-    dependencies:
-      async: 3.2.6
-      filelist: 1.0.4
-      picocolors: 1.1.1
 
   jest-changed-files@30.4.1:
     dependencies:
@@ -12693,6 +12714,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  neo-async@2.6.2: {}
+
   neotraverse@0.6.18: {}
 
   nlcst-to-string@4.0.0:
@@ -12838,7 +12861,7 @@ snapshots:
       log-symbols: 6.0.0
       stdin-discarder: 0.2.2
       string-width: 7.2.0
-      strip-ansi: 7.1.2
+      strip-ansi: 7.2.0
 
   outdent@0.5.0: {}
 
@@ -13521,8 +13544,6 @@ snapshots:
 
   semver@7.7.3: {}
 
-  semver@7.7.4: {}
-
   semver@7.8.0: {}
 
   set-function-length@1.2.2:
@@ -13961,7 +13982,7 @@ snapshots:
       fast-check: 3.21.0
       globby: 14.0.2
       jsonc-parser: 3.3.1
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       npm-package-arg: 11.0.3
       ora: 8.0.1
       prompts: 2.4.2
@@ -14038,16 +14059,16 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.4.0(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  ts-jest@29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
-      ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
       jest: 30.4.2(@types/node@25.8.0)(babel-plugin-macros@3.1.0)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.7.4
+      semver: 7.8.0
       type-fest: 4.41.0
       typescript: 5.9.3
       yargs-parser: 21.1.1
@@ -14057,6 +14078,26 @@ snapshots:
       '@jest/types': 30.4.1
       babel-jest: 30.4.1(@babel/core@7.29.0)
       esbuild: 0.28.0
+      jest-util: 30.4.1
+
+  ts-jest@29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.11.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 30.4.2(@types/node@24.11.0)(babel-plugin-macros@3.1.0)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.8.0
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.0)
       jest-util: 30.4.1
 
   ts-toolbelt@9.6.0: {}
@@ -14142,6 +14183,9 @@ snapshots:
   typescript@5.9.3: {}
 
   ufo@1.6.4: {}
+
+  uglify-js@3.19.3:
+    optional: true
 
   ultrahtml@1.6.0: {}
 
@@ -14535,6 +14579,8 @@ snapshots:
       proper-lockfile: 4.1.2
 
   word-wrap@1.2.5: {}
+
+  wordwrap@1.0.0: {}
 
   wrap-ansi@10.0.0:
     dependencies:


### PR DESCRIPTION
## What are you changing?

- Enable [Jest ESM](https://jestjs.io/docs/ecmascript-modules) and [ts-jest ESM](https://kulshekhar.github.io/ts-jest/docs/guides/esm-support) support
- Update base jest configuration to use ESM preset
- Install `@jest/globals` for `jest` variable support
- Go through each package one-by-one and fix tests/types/linting as required to enable new support e.g. by using dymanic imports in order to support mocking

## Why?

- Typescript 6 has deprecated `moduleResolution=node10`, but ts-jest in it's default state applies this regardless of what is in your tsconfig.json
- In [ts-jest 29.4.10](https://github.com/kulshekhar/ts-jest/blob/main/CHANGELOG.md#29410-2026-05-18) a bug was fixed that "respect tsconfig moduleResolution instead of forcing Node10 ([1bffffc](https://github.com/kulshekhar/ts-jest/commit/1bffffc667557c173ae0c1f93dd436920775dac4))"
- However jest by default runs in commonjs mode, and ts-jest will continue to run in `moduleResolution=node10` mode as long as jest is doing this, despire CSNX setup to output ESM by default, with a comment in the mentioned commit confirming this
- So we need to first enable ESM support in Jest, so that ts-jest respects `moduleResolution` in our tsconfig file, and then that means we can upgrade to Typescript 6+
- We also now respect modern standards

## Notes

Maybe Jest isn't the best long term tool for JS/TS testing? Could we look into alternatives, such as [vitest](https://vitest.dev/)?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214972512316724