### PR TITLE
Add newsletter highlight card title

### DIFF
--- a/.changeset/lovely-ears-hang.md
+++ b/.changeset/lovely-ears-hang.md
@@ -1,0 +1,5 @@
+---
+'@guardian/newsletter-types': minor
+---
+
+Add highlight card title

--- a/libs/@guardian/newsletter-types/src/@types/newsletters-api.ts
+++ b/libs/@guardian/newsletter-types/src/@types/newsletters-api.ts
@@ -96,6 +96,8 @@ export type NewsletterApiData = {
 	signUpDescription: string;
 	/** the description text used in embedded in-article sign-up forms for this newsletter */
 	signUpEmbedDescription: string;
+	/** the title used in the fronts signup highlight card */
+	highlightCardTitle: string;
 	/** a custom message to display when comfirming to a user that their subscription request was received */
 	mailSuccessDescription?: string;
 


### PR DESCRIPTION
## What are you changing?

- Add highlight card title field for newsletters

## Why?

- To enable a short title for newsletter signup cards in the highlights section of fronts to be added
