### PR TITLE
Add license metadata to @guardian/prettier

### DIFF
--- a/.changeset/prettier-license-metadata.md
+++ b/.changeset/prettier-license-metadata.md
@@ -1,0 +1,5 @@
+---
+'@guardian/prettier': patch
+---
+
+Add license metadata to the published package manifest.

--- a/libs/@guardian/prettier/package.json
+++ b/libs/@guardian/prettier/package.json
@@ -2,6 +2,7 @@
 	"name": "@guardian/prettier",
 	"version": "11.0.0",
 	"description": "Prettier config for Guardian JavaScript & TypeScript projects",
+	"license": "Apache-2.0",
 	"repository": {
 		"url": "https://github.com/guardian/csnx",
 		"directory": "libs/@guardian/prettier"


### PR DESCRIPTION
Adds the missing `license` field to `libs/@guardian/prettier/package.json`, matching the repository and other published Guardian packages (`Apache-2.0`).

Verification:
- `python3 -m json.tool libs/@guardian/prettier/package.json`
- `npm pkg get license --workspaces=false` in `libs/@guardian/prettier` returned `"Apache-2.0"`

Bounty: charles-openclaw/charles-microbounties#1430