### PR TITLE
chore: add missing license metadata to @guardian/prettier

### DIFF
--- a/libs/@guardian/prettier/package.json
+++ b/libs/@guardian/prettier/package.json
@@ -2,6 +2,7 @@
 	"name": "@guardian/prettier",
 	"version": "11.0.0",
 	"description": "Prettier config for Guardian JavaScript & TypeScript projects",
+	"license": "Apache-2.0",
 	"repository": {
 		"url": "https://github.com/guardian/csnx",
 		"directory": "libs/@guardian/prettier"


### PR DESCRIPTION
This PR adds the missing  field to the package.json of @guardian/prettier.

Added:
- license: Apache-2.0 (as verified by the root LICENSE file)

Wallet (TON): UQAVD5f6XBxXDlK4SDbvRpq_btbnmniWroIXv55bvgFnceaz