### PR TITLE
Fix `label` accessibility violation

### DIFF
--- a/.changeset/neat-ends-battle.md
+++ b/.changeset/neat-ends-battle.md
@@ -1,0 +1,5 @@
+---
+'@guardian/react-crossword': patch
+---
+
+Added an aria-label to the cell component to remove the accessibilty violation

--- a/libs/@guardian/react-crossword/src/components/Cell.tsx
+++ b/libs/@guardian/react-crossword/src/components/Cell.tsx
@@ -139,6 +139,9 @@ const CellComponent = ({
 							autoComplete="off"
 							spellCheck="false"
 							autoCorrect="off"
+							aria-label={`
+								${data.description ?? 'Cell'} at row ${data.y + 1}, column ${data.x + 1}
+							`}
 						/>
 					</foreignObject>
 				</>


### PR DESCRIPTION
## What are you changing?

- Added an `aria-label` attribute to `CellComponent` which provides detail of the word a user is located on

## Why?

- Accessibility testing registered the missing `aria-label` as a critical violation


**Before**
<img width="1373" height="986" alt="image" src="https://github.com/user-attachments/assets/a38e0f75-325c-403d-ad0d-d121c0f863b9" />

**After**
<img width="735" height="1005" alt="image" src="https://github.com/user-attachments/assets/a412cec5-9f04-42f5-a8e3-df6737788588" />


