### PR TITLE
Improve Storybook accessibility

### DIFF
--- a/libs/@guardian/source/src/foundations/palette/storybookColorPalette.tsx
+++ b/libs/@guardian/source/src/foundations/palette/storybookColorPalette.tsx
@@ -24,7 +24,7 @@ const SwatchLabelStyles = css`
 	font-size: 12px;
 	line-height: 1;
 	overflow: hidden;
-	color: #33333399;
+	color: #333333;
 
 	div {
 		display: inline-block;
@@ -110,7 +110,7 @@ const ListHeadingStyles = css`
 	align-items: center;
 	padding-bottom: 20px;
 	font-weight: 700;
-	color: #33333399;
+	color: #333333;
 	font-size: 14px;
 `;
 

--- a/libs/@guardian/source/src/react-components/radio/Radio.stories.tsx
+++ b/libs/@guardian/source/src/react-components/radio/Radio.stories.tsx
@@ -85,6 +85,7 @@ export const UnlabelledDefaultTheme: Story = {
 	args: {
 		...DefaultDefaultTheme.args,
 		label: undefined,
+		'aria-label': 'Radio',
 	},
 };
 


### PR DESCRIPTION
## What are you changing?

- Improve colour contrast in colour palette stories
- Add aria-label to unlabelled Radio button

## Why?

This fixes all 104 critical and serious [accessibility issues identified in Source by Chromatic](https://www.chromatic.com/dash?appId=5e933197d94d9c002275a15e&view=a11y). Note that none of these issues were present in the Source library itself, only in the Storybooks. Fixing them improves the accessibility of the Source documentation, and reduces noise in Chromatic's accessibility reporting.

<img width="1355" height="310" alt="Screenshot 2026-07-30 at 21 34 03" src="https://github.com/user-attachments/assets/79e5c5db-ed56-4771-b12e-85899431fc64" />

