### PR TITLE
Temporarily prevent publishing of Pulse package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,13 @@
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
 	"bumpVersionsWithWorkspaceProtocolOnly": false,
-	"ignore": ["github-pages", "@configs/*", "coverage", "storybooks"],
+	"ignore": [
+		"github-pages",
+		"@configs/*",
+		"coverage",
+		"storybooks",
+		"@guardian/pulse"
+	],
 	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
 		"onlyUpdatePeerDependentsWhenOutOfRange": true
 	}


### PR DESCRIPTION
## What are you changing?

Add Pulse package to Changesets ignore list to temporarily prevent publishing[^1]

## Why?

We haven't yet set up trusted publishing for this package so the publishing workflow fails with an error. This package is also empty at the moment so there is nothing of value to publish.

[^1]: https://changesets.dev/guide/config#ignore
