### PR TITLE
CI |  Set up publishing for `@guardian/pulse`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,13 +8,7 @@
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
 	"bumpVersionsWithWorkspaceProtocolOnly": false,
-	"ignore": [
-		"github-pages",
-		"@configs/*",
-		"coverage",
-		"storybooks",
-		"@guardian/pulse"
-	],
+	"ignore": ["github-pages", "@configs/*", "coverage", "storybooks"],
 	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
 		"onlyUpdatePeerDependentsWhenOutOfRange": true
 	}

--- a/.changeset/huge-doodles-smell.md
+++ b/.changeset/huge-doodles-smell.md
@@ -1,0 +1,5 @@
+---
+'@guardian/pulse': patch
+---
+
+Set up publishing pipeline for @guardian/pulse


### PR DESCRIPTION
## What are you changing?

- Set up publishing for `@guardian/pulse`
- Most of the changes have happened within npm, specifically for trusted publishing
- This PR is to test that pipeline works and so do changesets

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217369629582005