### PR TITLE
Sync Pulse tokens

### DIFF
--- a/.github/workflows/sync-pulse-tokens.yml
+++ b/.github/workflows/sync-pulse-tokens.yml
@@ -21,13 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Enable Corepack
-        run: corepack enable
+      - uses: ./.github/actions/setup-node-env
 
       - name: Create config file
         run: |
@@ -52,6 +46,9 @@ jobs:
 
       - name: Pull tokens from Studio
         run: pnpm dlx @tokens-studio/studio-cli pull --ci
+
+      - name: Format token files
+        run: pnpm prettier src/tokens --write
 
       - name: Commit changes
         run: |

--- a/.github/workflows/sync-pulse-tokens.yml
+++ b/.github/workflows/sync-pulse-tokens.yml
@@ -21,7 +21,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - uses: ./.github/actions/setup-node-env
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Create config file
         run: |
@@ -47,15 +53,12 @@ jobs:
       - name: Pull tokens from Studio
         run: pnpm dlx @tokens-studio/studio-cli pull --ci
 
-      - name: Build tokens with Terrazzo
-        run: pnpm run build
-
       - name: Commit changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add src/tokens/ dist/
+          git add src/tokens/
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else

--- a/.github/workflows/sync-pulse-tokens.yml
+++ b/.github/workflows/sync-pulse-tokens.yml
@@ -1,0 +1,54 @@
+name: Sync Design Tokens
+
+on:
+  repository_dispatch:
+    types: [tokens-release]
+  workflow_dispatch:
+
+permissions:
+  contents: write # Required to commit token files
+
+defaults:
+  run:
+    working-directory: ./libs/@guardian/pulse
+
+jobs:
+  sync-tokens:
+    runs-on: ubuntu-latest
+    env:
+      STUDIO_SERVICE_TOKEN: ${{ secrets.STUDIO_SERVICE_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Create config file
+        run: |
+          cat > .studio.json << "EOF"
+          {
+            "version": 2,
+            "source": {
+              "project": "${{ vars.TOKENS_PROJECT }}",
+              "ref": { "type": "branch", "name": "main" }
+            },
+            "outputs": {
+              "tokens": {
+                "format": "dtcg",
+                "dir": "src/tokens"
+              }
+            }
+          }
+          EOF
+
+      - name: Clean token output folder
+        run: rm -rf ./src/tokens
+
+      - name: Pull tokens from Studio
+        run: pnpm dlx @tokens-studio/studio-cli pull --ci

--- a/.github/workflows/sync-pulse-tokens.yml
+++ b/.github/workflows/sync-pulse-tokens.yml
@@ -21,13 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '24'
-
-      - name: Enable Corepack
-        run: corepack enable
+      - uses: ./.github/actions/setup-node-env
 
       - name: Create config file
         run: |

--- a/.github/workflows/sync-pulse-tokens.yml
+++ b/.github/workflows/sync-pulse-tokens.yml
@@ -46,3 +46,19 @@ jobs:
 
       - name: Pull tokens from Studio
         run: pnpm dlx @tokens-studio/studio-cli pull --ci
+
+      - name: Build tokens with Terrazzo
+        run: pnpm run build
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add src/tokens/ dist/
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: sync design tokens from Studio"
+            git push
+          fi

--- a/.github/workflows/sync-pulse-tokens.yml
+++ b/.github/workflows/sync-pulse-tokens.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write # Required for OIDC authentication
   contents: write # Required to commit token files
 
 defaults:
@@ -15,8 +16,6 @@ defaults:
 jobs:
   sync-tokens:
     runs-on: ubuntu-latest
-    env:
-      STUDIO_SERVICE_TOKEN: ${{ secrets.STUDIO_SERVICE_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## What are you changing?

Adds workflow to fetch latest Pulse tokens from Tokens Studio and commit back to the repo.

> [!note]
> This workflow only syncs the raw DTCG tokens with the repo. Tokens are not built with Terrazzo as we do not commit the `/dist` folder
