### PR TITLE
Rollout AB Test only to South Carolina intially

### DIFF
--- a/.changeset/thirty-trams-raise.md
+++ b/.changeset/thirty-trams-raise.md
@@ -1,0 +1,5 @@
+---
+'@guardian/consent-manager': patch
+---
+
+Roll out US AB test to South Carolina

--- a/libs/@guardian/consent-manager/src/usAbtest.test.js
+++ b/libs/@guardian/consent-manager/src/usAbtest.test.js
@@ -18,26 +18,27 @@ describe('usAbtest', () => {
 	const identityAndTrustConsentAbTestCookieName =
 		'identity-and-trust-consent-rr-banner-us';
 	const abTestCookieName = 'gu_client_ab_tests';
+	const usStateInSupportedList = 'SC';
 	const guCountryRegionCookieName = 'GU_geo_country_region';
 
 	describe('isInUsStateForAbTest', () => {
 		it('returns true when the geo region cookie contains a supported US state', () => {
-			mockGetCookie.mockReturnValue('US-WA');
+			mockGetCookie.mockReturnValue(`US-${usStateInSupportedList}`);
 			expect(isInUsStateForAbTest()).toBe(true);
 		});
 
 		it('returns false when the geo region cookie contains an unsupported US state', () => {
-			mockGetCookie.mockReturnValue('US-NY');
+			mockGetCookie.mockReturnValue('US-NY'); // NY is not in the supported list
 			expect(isInUsStateForAbTest()).toBe(false);
 		});
 
 		it('returns false when the geo region cookie is for a non-US region', () => {
-			mockGetCookie.mockReturnValue('GB-PNM');
+			mockGetCookie.mockReturnValue('GB-PNM'); // Non-US region
 			expect(isInUsStateForAbTest()).toBe(false);
 		});
 
 		it('returns false when the geo region cookie is for a non-US region but with a state code that matches', () => {
-			mockGetCookie.mockReturnValue('GB-WA');
+			mockGetCookie.mockReturnValue('GB-WA'); // Non-US region with a state code that matches
 			expect(isInUsStateForAbTest()).toBe(false);
 		});
 
@@ -77,7 +78,7 @@ describe('usAbtest', () => {
 		it('returns true when the user is in a supported US state and is in the control ab test group', () => {
 			mockGetCookie.mockImplementation(({ name }) => {
 				if (name === guCountryRegionCookieName) {
-					return 'US-WA';
+					return `US-${usStateInSupportedList}`;
 				}
 				if (name === abTestCookieName) {
 					return `${identityAndTrustConsentAbTestCookieName}:control`;
@@ -90,7 +91,7 @@ describe('usAbtest', () => {
 		it('returns true when the user is in a supported US state and is in the variant-1 ab test group', () => {
 			mockGetCookie.mockImplementation(({ name }) => {
 				if (name === guCountryRegionCookieName) {
-					return 'US-WA';
+					return `US-${usStateInSupportedList}`;
 				}
 				if (name === abTestCookieName) {
 					return `${identityAndTrustConsentAbTestCookieName}:variant-1`;
@@ -103,7 +104,7 @@ describe('usAbtest', () => {
 		it('returns true when the user is in a supported US state and is in the variant-2 ab test group', () => {
 			mockGetCookie.mockImplementation(({ name }) => {
 				if (name === guCountryRegionCookieName) {
-					return 'US-WA';
+					return `US-${usStateInSupportedList}`;
 				}
 				if (name === abTestCookieName) {
 					return `${identityAndTrustConsentAbTestCookieName}:variant-2`;
@@ -116,7 +117,7 @@ describe('usAbtest', () => {
 		it('returns false when the user is in a supported US state but has no ab test group', () => {
 			mockGetCookie.mockImplementation(({ name }) => {
 				if (name === guCountryRegionCookieName) {
-					return 'US-WA';
+					return `US-${usStateInSupportedList}`;
 				}
 				if (name === abTestCookieName) {
 					return 'some-other-test:control';

--- a/libs/@guardian/consent-manager/src/usAbtest.test.js
+++ b/libs/@guardian/consent-manager/src/usAbtest.test.js
@@ -1,4 +1,5 @@
 import {
+	AB_TEST_US_STATES,
 	getUsAbTestGroup,
 	isInUsStateForAbTest,
 	isUserInAbTest,
@@ -18,7 +19,7 @@ describe('usAbtest', () => {
 	const identityAndTrustConsentAbTestCookieName =
 		'identity-and-trust-consent-rr-banner-us';
 	const abTestCookieName = 'gu_client_ab_tests';
-	const usStateInSupportedList = 'SC';
+	const usStateInSupportedList = AB_TEST_US_STATES[0];
 	const guCountryRegionCookieName = 'GU_geo_country_region';
 
 	describe('isInUsStateForAbTest', () => {

--- a/libs/@guardian/consent-manager/src/usAbtest.ts
+++ b/libs/@guardian/consent-manager/src/usAbtest.ts
@@ -3,7 +3,7 @@ import { getCookie } from '@guardian/libs';
 const AB_TEST_COOKIE_NAME = 'gu_client_ab_tests';
 const AB_TEST_GROUP_PREFIX = 'identity-and-trust-consent-rr-banner-us:';
 const AB_TEST_GEO_REGION_COOKIE = 'GU_geo_country_region';
-const AB_TEST_US_STATES = [
+export const AB_TEST_US_STATES: string[] = [
 	// 'WA', // Washington
 	// 'NC', // North Carolina
 	// 'OH', // Ohio

--- a/libs/@guardian/consent-manager/src/usAbtest.ts
+++ b/libs/@guardian/consent-manager/src/usAbtest.ts
@@ -4,19 +4,19 @@ const AB_TEST_COOKIE_NAME = 'gu_client_ab_tests';
 const AB_TEST_GROUP_PREFIX = 'identity-and-trust-consent-rr-banner-us:';
 const AB_TEST_GEO_REGION_COOKIE = 'GU_geo_country_region';
 const AB_TEST_US_STATES = [
-	'WA', // Washington
-	'NC', // North Carolina
-	'OH', // Ohio
+	// 'WA', // Washington
+	// 'NC', // North Carolina
+	// 'OH', // Ohio
 	'SC', // South Carolina
-	'MI', // Michigan
-	'AZ', // Arizona
-	'MO', // Missouri
-	'WI', // Wisconsin
-	'DC', // District of Columbia
-	'KS', // Kansas
-	'NM', // New Mexico
-	'ME', // Maine
-];
+	// 'MI', // Michigan
+	// 'AZ', // Arizona
+	// 'MO', // Missouri
+	// 'WI', // Wisconsin
+	// 'DC', // District of Columbia
+	// 'KS', // Kansas
+	// 'NM', // New Mexico
+	// 'ME', // Maine
+]; // Temporarily only rolling out to South Carolina
 
 export const isInUsStateForAbTest = (): boolean => {
 	const usStateCookie = getCookie({


### PR DESCRIPTION
## What are you changing?

- This PR comments out other US states for the US AB banner test.

## Why?

- This will be rolled out the one state for testing before rolling out to other 11 states.
